### PR TITLE
chore: bump cpanm dependencies

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,3 @@
-requires 'DBD::Pg', '== 3.15.0';
+requires 'DBD::Pg', '== 3.15.1';
 requires 'App::Sqitch', '== 1.2.1';
 requires 'TAP::Parser::SourceHandler::pgTAP', '== 3.35';

--- a/db/cpanfile
+++ b/db/cpanfile
@@ -1,3 +1,3 @@
-requires 'DBD::Pg', '== 3.15.0';
-requires 'App::Sqitch', '== 1.1.0';
+requires 'DBD::Pg', '== 3.15.1';
+requires 'App::Sqitch', '== 1.2.1';
 requires 'TAP::Parser::SourceHandler::pgTAP', '== 3.35';


### PR DESCRIPTION
Our database schema dockerfile builds started failing due to some random issue, cif had it as well. This should fix it. 