### PR TITLE
feat: add basic pages ssr tests

### DIFF
--- a/app/tests/pages/dashboard.test.tsx
+++ b/app/tests/pages/dashboard.test.tsx
@@ -1,0 +1,17 @@
+import { withRelayOptions } from '../../pages/dashboard';
+
+describe('The index page', () => {
+  it('should redirect an unauthorized user', async () => {
+    const ctx = {
+      req: {
+        url: '/dashboard',
+      },
+    } as any;
+
+    expect(await withRelayOptions.serverSideProps(ctx)).toEqual({
+      redirect: {
+        destination: '/',
+      },
+    });
+  });
+});

--- a/app/tests/pages/form/success.test.tsx
+++ b/app/tests/pages/form/success.test.tsx
@@ -1,0 +1,17 @@
+import { withRelayOptions } from '../../../pages/form/success';
+
+describe('The form/success page', () => {
+  it('should redirect an unauthorized user', async () => {
+    const ctx = {
+      req: {
+        url: '/form/success',
+      },
+    } as any;
+
+    expect(await withRelayOptions.serverSideProps(ctx)).toEqual({
+      redirect: {
+        destination: '/',
+      },
+    });
+  });
+});

--- a/app/tests/pages/index.test.tsx
+++ b/app/tests/pages/index.test.tsx
@@ -1,23 +1,12 @@
-import Home from '../../pages/index';
-import { RelayEnvironmentProvider } from 'react-relay/hooks';
-import { createMockEnvironment } from 'relay-test-utils';
-import { RelayProps } from 'relay-nextjs';
-
-import { render, screen } from '@testing-library/react';
-
-const environment = createMockEnvironment();
-
-const renderStaticLayout = ({ preloadedQuery }: RelayProps) => {
-  return render(
-    <RelayEnvironmentProvider environment={environment}>
-      <Home preloadedQuery={preloadedQuery} CSN={false} />
-    </RelayEnvironmentProvider>
-  );
-};
+import { withRelayOptions } from '../../pages';
 
 describe('The index page', () => {
-  it('should render Login button', () => {
-    // renderStaticLayout();
-    // expect(screen.getByText('Login'));
+  it('does not redirect an unauthorized user', async () => {
+    const ctx = {
+      req: {
+        url: '/',
+      },
+    } as any;
+    expect(await withRelayOptions.serverSideProps(ctx)).toEqual({});
   });
 });


### PR DESCRIPTION
These are very basic jest tests since the old ones broke once we implemented Relay SSR. Currently only doing basic unauthenticated tests, I will likely have to do up a mock relay auth at some point.