### PR TITLE
feat: set max width for nav/footer items

### DIFF
--- a/app/components/FooterLinks.tsx
+++ b/app/components/FooterLinks.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import styled from 'styled-components';
+import GlobalTheme from '../styles/GlobalTheme';
 
 const StyledUl = styled.ul`
   padding-left: 20px;
@@ -7,32 +8,34 @@ const StyledUl = styled.ul`
 
 export default function FooterLinks() {
   return (
-    <StyledUl>
-      <li key="0">
-        <Link href="https://www2.gov.bc.ca/gov/content/governments/connectivity-in-bc">
-          <a style={{ paddingLeft: 0 }}>Home</a>
-        </Link>
-      </li>
-      <li key="1">
-        <Link href="https://www2.gov.bc.ca/gov/content/home/disclaimer">
-          <a>Disclaimer</a>
-        </Link>
-      </li>
-      <li key="2">
-        <Link href="https://www2.gov.bc.ca/gov/content/home/privacy">
-          <a>Privacy</a>
-        </Link>
-      </li>
-      <li key="3">
-        <Link href="https://www2.gov.bc.ca/gov/content/home/accessible-government">
-          <a>Accessibility</a>
-        </Link>
-      </li>
-      <li key="4">
-        <Link href="https://www2.gov.bc.ca/gov/content/home/copyright">
-          <a>Copyright</a>
-        </Link>
-      </li>
-    </StyledUl>
+    <GlobalTheme>
+      <StyledUl>
+        <li key="0">
+          <Link href="https://www2.gov.bc.ca/gov/content/governments/connectivity-in-bc">
+            <a style={{ paddingLeft: 0 }}>Home</a>
+          </Link>
+        </li>
+        <li key="1">
+          <Link href="https://www2.gov.bc.ca/gov/content/home/disclaimer">
+            <a>Disclaimer</a>
+          </Link>
+        </li>
+        <li key="2">
+          <Link href="https://www2.gov.bc.ca/gov/content/home/privacy">
+            <a>Privacy</a>
+          </Link>
+        </li>
+        <li key="3">
+          <Link href="https://www2.gov.bc.ca/gov/content/home/accessible-government">
+            <a>Accessibility</a>
+          </Link>
+        </li>
+        <li key="4">
+          <Link href="https://www2.gov.bc.ca/gov/content/home/copyright">
+            <a>Copyright</a>
+          </Link>
+        </li>
+      </StyledUl>
+    </GlobalTheme>
   );
 }

--- a/app/components/FooterLinks.tsx
+++ b/app/components/FooterLinks.tsx
@@ -1,11 +1,16 @@
 import Link from 'next/link';
+import styled from 'styled-components';
+
+const StyledUl = styled.ul`
+  padding-left: 20px;
+`;
 
 export default function FooterLinks() {
   return (
-    <ul>
+    <StyledUl>
       <li key="0">
         <Link href="https://www2.gov.bc.ca/gov/content/governments/connectivity-in-bc">
-          <a>Home</a>
+          <a style={{ paddingLeft: 0 }}>Home</a>
         </Link>
       </li>
       <li key="1">
@@ -28,6 +33,6 @@ export default function FooterLinks() {
           <a>Copyright</a>
         </Link>
       </li>
-    </ul>
+    </StyledUl>
   );
 }

--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -16,6 +16,12 @@ const StyledMain = styled.main`
   padding: 5em 3.5em;
 `;
 
+const StyledDiv = styled('div')`
+  width: 100%;
+  max-width: ${(props) => props.theme.width.pageMaxWidth};
+  margin: auto;
+`;
+
 type Props = {
   title: string;
   children: JSX.Element | JSX.Element[] | string | string[];
@@ -57,7 +63,9 @@ const Layout: React.FC<Props> = ({ children, session, title }) => {
       <Navigation isLoggedIn={isLoggedIn} />
       <StyledMain>{children}</StyledMain>
       <StyledFooter>
-        <FooterLinks />
+        <StyledDiv>
+          <FooterLinks />
+        </StyledDiv>
       </StyledFooter>
     </>
   );

--- a/app/components/NavbarLinks.tsx
+++ b/app/components/NavbarLinks.tsx
@@ -6,18 +6,18 @@ const StyledLi = styled.li`
   align-self: center;
 `;
 
-const StlyedUl = styled.ul`
-  padding-left: 15px;
+const StyledUl = styled.ul`
+  padding-left: ${(props) => props.theme.padding.page};
 `;
 
 export const SubHeaderNavbarLinks: React.FC = () => {
   return (
-    <StlyedUl>
+    <StyledUl>
       <StyledLi>
         <Link href="mailto:connectingcommunitiesbc@gov.bc.ca">
-          <a>Help</a>
+          <a style={{ paddingLeft: 0 }}>Help</a>
         </Link>
       </StyledLi>
-    </StlyedUl>
+    </StyledUl>
   );
 };

--- a/app/components/NavbarLinks.tsx
+++ b/app/components/NavbarLinks.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import styled from 'styled-components';
+import GlobalTheme from '../styles/GlobalTheme';
 
 const StyledLi = styled.li`
   display: flex;
@@ -12,12 +13,14 @@ const StyledUl = styled.ul`
 
 export const SubHeaderNavbarLinks: React.FC = () => {
   return (
-    <StyledUl>
-      <StyledLi>
-        <Link href="mailto:connectingcommunitiesbc@gov.bc.ca">
-          <a style={{ paddingLeft: 0 }}>Help</a>
-        </Link>
-      </StyledLi>
-    </StyledUl>
+    <GlobalTheme>
+      <StyledUl>
+        <StyledLi>
+          <Link href="mailto:connectingcommunitiesbc@gov.bc.ca">
+            <a style={{ paddingLeft: 0 }}>Help</a>
+          </Link>
+        </StyledLi>
+      </StyledUl>
+    </GlobalTheme>
   );
 };

--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -23,6 +23,19 @@ const StyledAnchor = styled.a`
   align-self: center;
 `;
 
+const StyledDiv = styled('div')`
+  width: 100%;
+  max-width: ${(props) => props.theme.width.pageMaxWidth};
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  justify-content: space-apart;
+  margin: auto;
+`;
+
+const StyledBaseHeader = styled(BaseHeader)`
+  padding-right: ${(props) => props.theme.padding.page};
+`;
 interface Props {
   isLoggedIn?: boolean;
   title?: string;
@@ -31,34 +44,36 @@ interface Props {
 const Navigation: React.FC<Props> = ({ isLoggedIn = false, title = '' }) => {
   return (
     <BaseNavigation>
-      <BaseHeader>
-        <BaseHeader.Group className="banner">
-          <Link passHref href="/">
-            <a>
-              <Image
-                priority
-                src="/icons/BCID_CC_RGB_rev.svg"
-                alt="Logo for Province of British Columbia Connected Communities"
-                height={100}
-                width={300}
-              />
-            </a>
-          </Link>
-        </BaseHeader.Group>
-        <StyledMainTitle>
-          <h1>{title}</h1>
-        </StyledMainTitle>
-        <StyledRightSideLinks>
-          <Link passHref href="/dashboard">
-            <StyledAnchor>Dashboard</StyledAnchor>
-          </Link>
-          |
-          <NavLoginForm
-            action={isLoggedIn ? '/logout' : '/login'}
-            linkText={isLoggedIn ? 'Logout' : 'Login'}
-          />
-        </StyledRightSideLinks>
-      </BaseHeader>
+      <StyledBaseHeader>
+        <StyledDiv>
+          <BaseHeader.Group className="banner">
+            <Link passHref href="/">
+              <a>
+                <Image
+                  priority
+                  src="/icons/BCID_CC_RGB_rev.svg"
+                  alt="Logo for Province of British Columbia Connected Communities"
+                  height={100}
+                  width={300}
+                />
+              </a>
+            </Link>
+          </BaseHeader.Group>
+          <StyledMainTitle>
+            <h1>{title}</h1>
+          </StyledMainTitle>
+          <StyledRightSideLinks>
+            <Link passHref href="/dashboard">
+              <StyledAnchor>Dashboard</StyledAnchor>
+            </Link>
+            |
+            <NavLoginForm
+              action={isLoggedIn ? '/logout' : '/login'}
+              linkText={isLoggedIn ? 'Logout' : 'Login'}
+            />
+          </StyledRightSideLinks>
+        </StyledDiv>
+      </StyledBaseHeader>
       <SubHeader />
     </BaseNavigation>
   );

--- a/app/components/SubHeader.tsx
+++ b/app/components/SubHeader.tsx
@@ -1,5 +1,6 @@
 import { BaseHeader } from '@button-inc/bcgov-theme/Header';
 import { SubHeaderNavbarLinks } from '.';
+
 import styled from 'styled-components';
 
 const StyledDiv = styled('div')`

--- a/app/components/SubHeader.tsx
+++ b/app/components/SubHeader.tsx
@@ -1,10 +1,19 @@
 import { BaseHeader } from '@button-inc/bcgov-theme/Header';
 import { SubHeaderNavbarLinks } from '.';
+import styled from 'styled-components';
+
+const StyledDiv = styled('div')`
+  width: 100%;
+  max-width: ${(props) => props.theme.width.pageMaxWidth};
+  margin: auto;
+`;
 
 const SubHeader: React.FC = () => {
   return (
     <BaseHeader header="sub">
-      <SubHeaderNavbarLinks />
+      <StyledDiv>
+        <SubHeaderNavbarLinks />
+      </StyledDiv>
     </BaseHeader>
   );
 };

--- a/app/styles/GlobalTheme.tsx
+++ b/app/styles/GlobalTheme.tsx
@@ -21,6 +21,9 @@ const theme = {
     success: '#2E8540',
     text: '#313132',
   },
+  padding: {
+    page: '20px',
+  },
 };
 
 type Props = {


### PR DESCRIPTION
This has been bugging me for awhile, in the spirit of this sprint goal of making the page and form more polished I decided to make the header/footer items only take up the page max width.

![Screenshot at 2022-06-10 08-11-20](https://user-images.githubusercontent.com/14259474/173097418-d6231369-e933-4d1f-9931-505238c5b16e.png)
