### PR TITLE
feat: add mock login config

### DIFF
--- a/app/backend/lib/graphql/authenticationPgSettings.ts
+++ b/app/backend/lib/graphql/authenticationPgSettings.ts
@@ -1,7 +1,15 @@
 import { isAuthenticated } from '@bcgov-cas/sso-express';
 import type { Request } from 'express';
+import config from '../../../config';
 
 const authenticationPgSettings = (req: Request) => {
+  if (config.get('ENABLE_MOCK_AUTH')) {
+    return {
+      'jwt.claims.sub': '00000000-0000-0000-0000-000000000000',
+      role: 'ccbc_auth_user',
+    };
+  }
+
   const claimsSettings: any = {
     role: 'ccbc_guest',
   };

--- a/app/backend/lib/sso-middleware.ts
+++ b/app/backend/lib/sso-middleware.ts
@@ -8,6 +8,9 @@ const baseUrl =
     : `http://${config.get('HOST')}:${config.get('PORT') || 3000}`;
 
 let oidcIssuer: string;
+
+const mockAuth = config.get('ENABLE_MOCK_AUTH');
+
 if (
   config.get('OPENSHIFT_APP_NAMESPACE').endsWith('-dev') ||
   config.get('OPENSHIFT_APP_NAMESPACE') === ''
@@ -22,6 +25,10 @@ export default async function ssoMiddleware() {
     applicationDomain: '.gov.bc.ca',
     getLandingRoute: () => {
       return '/dashboard';
+    },
+    bypassAuthentication: {
+      login: mockAuth,
+      sessionIdleRemainingTime: mockAuth,
     },
     oidcConfig: {
       baseUrl: baseUrl,

--- a/app/config.js
+++ b/app/config.js
@@ -102,6 +102,12 @@ const config = convict({
     default: '',
     env: 'NEXT_PUBLIC_GROWTHBOOK_API_KEY',
   },
+  ENABLE_MOCK_AUTH: {
+    doc: 'Enable mock auth',
+    format: Boolean,
+    default: false,
+    env: 'ENABLE_MOCK_AUTH',
+  },
 });
 
 // Load environment dependent configuration


### PR DESCRIPTION
This enables a mock login if the env variable `ENABLE_MOCK_AUTH` is set to true. Will be helpful for those end to end tests that have been falling behind since auth was implemented.