### PR TITLE
238 other funding sources

### DIFF
--- a/app/formSchema/pages/index.ts
+++ b/app/formSchema/pages/index.ts
@@ -10,6 +10,7 @@ export { default as existingNetworkCoverage } from './existingNetworkCoverage';
 export { default as mapping } from './mapping';
 export { default as organizationLocation } from './organizationLocation';
 export { default as organizationProfile } from './organizationProfile';
+export { default as otherFundingSources } from './otherFundingSources';
 export { default as projectArea } from './projectArea';
 export { default as projectFunding } from './projectFunding';
 export { default as projectInformation } from './projectInformation';

--- a/app/formSchema/pages/otherFundingSources.ts
+++ b/app/formSchema/pages/otherFundingSources.ts
@@ -6,7 +6,7 @@ const otherFundingSources = {
       'Identify sources of funding that you expect to secure to cover all project costs, not including the Province of British Columbia or the Universal Broadband Fund. Please only include loans that you anticipate receiving from a program or granting agency. Any other loans must be included in the applicant funding.',
 
     properties: {
-      testArray: {
+      otherFundingSourcesArray: {
         type: 'array',
         items: {
           type: 'object',

--- a/app/formSchema/pages/otherFundingSources.ts
+++ b/app/formSchema/pages/otherFundingSources.ts
@@ -6,75 +6,96 @@ const otherFundingSources = {
       'Identify sources of funding that you expect to secure to cover all project costs, not including the Province of British Columbia or the Universal Broadband Fund. Please only include loans that you anticipate receiving from a program or granting agency. Any other loans must be included in the applicant funding.',
 
     properties: {
-      otherFundingSourcesArray: {
-        type: 'array',
-        items: {
-          type: 'object',
-          properties: {
-            otherFundingSources: {
-              title: 'Will you have other funding sources?',
-              type: 'boolean',
-              enum: ['Yes', 'No'],
-            },
-            fundingPartnersName: {
-              title: `Funding partner's name`,
-              type: 'string',
-            },
-            fundingSourceContactInfo: {
-              title: `Funding source contact information
-              (Name, Address, Telephone, Email)`,
-              type: 'string',
-            },
-            statusOfFunding: {
-              title: 'Status of funding',
-              type: 'string',
-              enum: [
-                'Submitted',
-                'Received confirmation of eligibility',
-                'Pending',
-                'Approved',
-              ],
-            },
-            funderType: {
-              title: 'Funder type',
-              type: 'string',
-              enum: [
-                'Federal',
-                'Provincial/territorial',
-                'Municipal',
-                'Private',
-              ],
-            },
-            nameOfFundingProgram: {
-              title: 'Name of program (if applicable)',
-              type: 'string',
-            },
-            requestedFundingPartner2223: {
-              title: '2022-23',
-              type: 'string',
-            },
-            requestedFundingPartner2324: {
-              title: '2023-24',
-              type: 'string',
-            },
-            requestedFundingPartner2425: {
-              title: '2024-25',
-              type: 'string',
-            },
-            requestedFundingPartner2526: {
-              title: '2025-26',
-              type: 'string',
-            },
-            requestedFundingPartner2627: {
-              title: '2026-27',
-              type: 'string',
-            },
-            totalRequestedFundingPartner: {
-              title: 'Total amount requested from funding partner',
-              type: 'string',
+      otherFundingSources: {
+        title: 'Will you have other funding sources?',
+        type: 'boolean',
+        enum: ['Yes', 'No'],
+      },
+    },
+    dependencies: {
+      otherFundingSources: {
+        oneOf: [
+          {
+            properties: {
+              otherFundingSources: {
+                enum: ['No'],
+              },
             },
           },
-        },
+          {
+            properties: {
+              otherFundingSources: {
+                enum: ['Yes'],
+              },
+              otherFundingSourcesArray: {
+                type: 'array',
+                default: [{}],
+                items: {
+                  type: 'object',
+                  properties: {
+                    fundingPartnersName: {
+                      title: `Funding partner's name`,
+                      type: 'string',
+                    },
+                    fundingSourceContactInfo: {
+                      title: `Funding source contact information
+                      (Name, Address, Telephone, Email)`,
+                      type: 'string',
+                    },
+                    statusOfFunding: {
+                      title: 'Status of funding',
+                      type: 'string',
+                      enum: [
+                        'Submitted',
+                        'Received confirmation of eligibility',
+                        'Pending',
+                        'Approved',
+                      ],
+                    },
+                    funderType: {
+                      title: 'Funder type',
+                      type: 'string',
+                      enum: [
+                        'Federal',
+                        'Provincial/territorial',
+                        'Municipal',
+                        'Private',
+                      ],
+                    },
+                    nameOfFundingProgram: {
+                      title: 'Name of program (if applicable)',
+                      type: 'string',
+                    },
+                    requestedFundingPartner2223: {
+                      title: '2022-23',
+                      type: 'string',
+                    },
+                    requestedFundingPartner2324: {
+                      title: '2023-24',
+                      type: 'string',
+                    },
+                    requestedFundingPartner2425: {
+                      title: '2024-25',
+                      type: 'string',
+                    },
+                    requestedFundingPartner2526: {
+                      title: '2025-26',
+                      type: 'string',
+                    },
+                    requestedFundingPartner2627: {
+                      title: '2026-27',
+                      type: 'string',
+                    },
+                    totalRequestedFundingPartner: {
+                      title: 'Total amount requested from funding partner',
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
       },
     },
   },

--- a/app/formSchema/pages/otherFundingSources.ts
+++ b/app/formSchema/pages/otherFundingSources.ts
@@ -1,0 +1,74 @@
+const otherFundingSources = {
+  otherFundingSources: {
+    title: 'Other funding sources',
+    type: 'object',
+    description:
+      'Identify sources of funding that you expect to secure to cover all project costs, not including the Province of British Columbia or the Universal Broadband Fund. Please only include loans that you anticipate receiving from a program or granting agency. Any other loans must be included in the applicant funding.',
+    // required: [
+    //   'projectTitle',
+    //   'geographicAreaDescription',
+    //   'projectDescription',
+    // ],
+    properties: {
+      otherFundingSources: {
+        title: 'Will you have other funding sources?',
+        type: 'boolean',
+        enum: ['Yes', 'No'],
+      },
+      fundingPartnersName: {
+        title: `Funding partner's name`,
+        type: 'string',
+      },
+      fundingSourceContactInfo: {
+        title: `Funding source contact information
+        (Name, Address, Telephone, Email)`,
+        type: 'string',
+      },
+      statusOfFunding: {
+        title: 'Status of funding',
+        type: 'string',
+        enum: [
+          'Submitted',
+          'Received confirmation of eligibility',
+          'Pending',
+          'Approved',
+        ],
+      },
+      funderType: {
+        title: 'Funder type',
+        type: 'string',
+        enum: ['Federal', 'Provincial/territorial', 'Municipal', 'Private'],
+      },
+      nameOfFundingProgram: {
+        title: 'Name of program (if applicable)',
+        type: 'string',
+      },
+      requestedFundingPartner2223: {
+        title: '2022-23',
+        type: 'string',
+      },
+      requestedFundingPartner2324: {
+        title: '2023-24',
+        type: 'string',
+      },
+      requestedFundingPartner2425: {
+        title: '2024-25',
+        type: 'string',
+      },
+      requestedFundingPartner2526: {
+        title: '2025-26',
+        type: 'string',
+      },
+      requestedFundingPartner2627: {
+        title: '2026-27',
+        type: 'string',
+      },
+      totalRequestedFundingPartner: {
+        title: 'Total amount requested from funding partner',
+        type: 'string',
+      },
+    },
+  },
+};
+
+export default otherFundingSources;

--- a/app/formSchema/pages/otherFundingSources.ts
+++ b/app/formSchema/pages/otherFundingSources.ts
@@ -4,68 +4,77 @@ const otherFundingSources = {
     type: 'object',
     description:
       'Identify sources of funding that you expect to secure to cover all project costs, not including the Province of British Columbia or the Universal Broadband Fund. Please only include loans that you anticipate receiving from a program or granting agency. Any other loans must be included in the applicant funding.',
-    // required: [
-    //   'projectTitle',
-    //   'geographicAreaDescription',
-    //   'projectDescription',
-    // ],
+
     properties: {
-      otherFundingSources: {
-        title: 'Will you have other funding sources?',
-        type: 'boolean',
-        enum: ['Yes', 'No'],
-      },
-      fundingPartnersName: {
-        title: `Funding partner's name`,
-        type: 'string',
-      },
-      fundingSourceContactInfo: {
-        title: `Funding source contact information
-        (Name, Address, Telephone, Email)`,
-        type: 'string',
-      },
-      statusOfFunding: {
-        title: 'Status of funding',
-        type: 'string',
-        enum: [
-          'Submitted',
-          'Received confirmation of eligibility',
-          'Pending',
-          'Approved',
-        ],
-      },
-      funderType: {
-        title: 'Funder type',
-        type: 'string',
-        enum: ['Federal', 'Provincial/territorial', 'Municipal', 'Private'],
-      },
-      nameOfFundingProgram: {
-        title: 'Name of program (if applicable)',
-        type: 'string',
-      },
-      requestedFundingPartner2223: {
-        title: '2022-23',
-        type: 'string',
-      },
-      requestedFundingPartner2324: {
-        title: '2023-24',
-        type: 'string',
-      },
-      requestedFundingPartner2425: {
-        title: '2024-25',
-        type: 'string',
-      },
-      requestedFundingPartner2526: {
-        title: '2025-26',
-        type: 'string',
-      },
-      requestedFundingPartner2627: {
-        title: '2026-27',
-        type: 'string',
-      },
-      totalRequestedFundingPartner: {
-        title: 'Total amount requested from funding partner',
-        type: 'string',
+      testArray: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            otherFundingSources: {
+              title: 'Will you have other funding sources?',
+              type: 'boolean',
+              enum: ['Yes', 'No'],
+            },
+            fundingPartnersName: {
+              title: `Funding partner's name`,
+              type: 'string',
+            },
+            fundingSourceContactInfo: {
+              title: `Funding source contact information
+              (Name, Address, Telephone, Email)`,
+              type: 'string',
+            },
+            statusOfFunding: {
+              title: 'Status of funding',
+              type: 'string',
+              enum: [
+                'Submitted',
+                'Received confirmation of eligibility',
+                'Pending',
+                'Approved',
+              ],
+            },
+            funderType: {
+              title: 'Funder type',
+              type: 'string',
+              enum: [
+                'Federal',
+                'Provincial/territorial',
+                'Municipal',
+                'Private',
+              ],
+            },
+            nameOfFundingProgram: {
+              title: 'Name of program (if applicable)',
+              type: 'string',
+            },
+            requestedFundingPartner2223: {
+              title: '2022-23',
+              type: 'string',
+            },
+            requestedFundingPartner2324: {
+              title: '2023-24',
+              type: 'string',
+            },
+            requestedFundingPartner2425: {
+              title: '2024-25',
+              type: 'string',
+            },
+            requestedFundingPartner2526: {
+              title: '2025-26',
+              type: 'string',
+            },
+            requestedFundingPartner2627: {
+              title: '2026-27',
+              type: 'string',
+            },
+            totalRequestedFundingPartner: {
+              title: 'Total amount requested from funding partner',
+              type: 'string',
+            },
+          },
+        },
       },
     },
   },

--- a/app/formSchema/schema.ts
+++ b/app/formSchema/schema.ts
@@ -12,6 +12,7 @@ import {
   mapping,
   organizationLocation,
   organizationProfile,
+  otherFundingSources,
   projectArea,
   projectInformation,
   projectFunding,
@@ -40,6 +41,9 @@ const useSchema = () => {
   const formOrganizationLocation = useFeature(
     'form-organization-location'
   ).value;
+  const formOtherFundingSources = useFeature(
+    'form-other-funding-sources'
+  ).value;
   const formOrganizationProfile = useFeature('form-organization-profile').value;
   const formProjectArea = useFeature('form-project-area').value;
   const formProjectInformation = useFeature('form-project-information').value;
@@ -66,6 +70,9 @@ const useSchema = () => {
       }),
       ...(formProjectFunding && {
         ...projectFunding,
+      }),
+      ...(formOtherFundingSources && {
+        ...otherFundingSources,
       }),
       ...(formTechSolution && {
         ...techSolution,

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -56,7 +56,6 @@ const uiSchema = {
     'projectLocations',
     'totalEligibleCosts',
     'totalProjectCost',
-
     'typeOfOrganization',
     'other',
     'bandNumber',
@@ -132,6 +131,18 @@ const uiSchema = {
     'infrastructureBankFunding2526',
     'infrastructureBankFunding2627',
     'totalInfrastructureBankFunding',
+    'otherFundingSources',
+    'fundingPartnersName',
+    'fundingSourceContactInfo',
+    'statusOfFunding',
+    'funderType',
+    'nameOfFundingProgram',
+    'requestedFundingPartner2223',
+    'requestedFundingPartner2324',
+    'requestedFundingPartner2425',
+    'requestedFundingPartner2526',
+    'requestedFundingPartner2627',
+    'totalRequestedFundingPartner',
   ],
   projectTitle: {
     'ui:description': 'maximum 200 characters',
@@ -494,9 +505,39 @@ const uiSchema = {
     'ui:subtitle': 'Estimated direct employees',
   },
   totalProjectCost: {},
+  otherFundingSources: {
+    'ui:widget': 'RadioWidget',
+  },
+  fundingPartnersName: {
+    'ui:description': 'maximum 150 characters',
+    'ui:options': {
+      maxLength: 150,
+    },
+  },
+  fundingSourceContactInfo: {
+    'ui:description': 'maximum 250 characters',
+    'ui:options': {
+      maxLength: 250,
+    },
+    'ui:widget': 'TextAreaWidget',
+  },
+  statusOfFunding: {
+    'ui:widget': 'SelectWidget',
+  },
+  funderType: {
+    'ui:widget': 'SelectWidget',
+  },
+  nameOfFundingProgram: {
+    'ui:description': 'maximum 150 characters',
+    'ui:options': {
+      maxLength: 150,
+    },
+  },
   'ui:inline': [
     // Each object is a row for inline grid elements. Single elements with 'full' value
     // will properly format the input width for a single input.
+
+    // Project funding page grid schema:
     {
       title: 'Amount requested under CCBC',
       fundingRequestedCCBC2223: 'inline',
@@ -530,6 +571,34 @@ const uiSchema = {
     {
       totalInfrastructureBankFunding: 'full',
     },
+    // Other funding sources page grid schema:
+    {
+      otherFundingSources: 'full',
+    },
+    {
+      fundingPartnersName: 'full',
+    },
+    {
+      fundingSourceContactInfo: 'full',
+    },
+    {
+      statusOfFunding: 'full',
+    },
+    {
+      funderType: 'full',
+    },
+    {
+      nameOfFundingProgram: 'full',
+    },
+    {
+      title: 'Amount requested from funding partner',
+      requestedFundingPartner2223: 'inline',
+      requestedFundingPartner2324: 'inline',
+      requestedFundingPartner2425: 'inline',
+      requestedFundingPartner2526: 'inline',
+      requestedFundingPartner2627: 'inline',
+    },
+    { totalRequestedFundingPartner: 'full' },
   ],
 };
 

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -143,6 +143,7 @@ const uiSchema = {
     'requestedFundingPartner2526',
     'requestedFundingPartner2627',
     'totalRequestedFundingPartner',
+    'testArray',
   ],
   projectTitle: {
     'ui:description': 'maximum 200 characters',

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -518,7 +518,6 @@ const uiSchema = {
         },
         'ui:widget': 'TextAreaWidget',
       },
-
       fundingPartnersName: {
         'ui:description': 'maximum 150 characters',
         'ui:options': {
@@ -536,6 +535,11 @@ const uiSchema = {
         'ui:options': {
           maxLength: 150,
         },
+      },
+      // Custom array button prop that is used in ArrayFieldTemplate
+      'ui:array-buttons': {
+        addBtnLabel: 'Add another funding source',
+        removeBtnLabel: 'Remove',
       },
       'ui:inline': [
         // This is nested so it works in this array object

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -506,7 +506,9 @@ const uiSchema = {
     'ui:subtitle': 'Estimated direct employees',
   },
   totalProjectCost: {},
-
+  otherFundingSources: {
+    'ui:widget': 'RadioWidget',
+  },
   otherFundingSourcesArray: {
     items: {
       fundingSourceContactInfo: {
@@ -516,9 +518,7 @@ const uiSchema = {
         },
         'ui:widget': 'TextAreaWidget',
       },
-      otherFundingSources: {
-        'ui:widget': 'RadioWidget',
-      },
+
       fundingPartnersName: {
         'ui:description': 'maximum 150 characters',
         'ui:options': {

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -143,7 +143,7 @@ const uiSchema = {
     'requestedFundingPartner2526',
     'requestedFundingPartner2627',
     'totalRequestedFundingPartner',
-    'testArray',
+    'otherFundingSourcesArray',
   ],
   projectTitle: {
     'ui:description': 'maximum 200 characters',
@@ -506,32 +506,69 @@ const uiSchema = {
     'ui:subtitle': 'Estimated direct employees',
   },
   totalProjectCost: {},
-  otherFundingSources: {
-    'ui:widget': 'RadioWidget',
-  },
-  fundingPartnersName: {
-    'ui:description': 'maximum 150 characters',
-    'ui:options': {
-      maxLength: 150,
-    },
-  },
-  fundingSourceContactInfo: {
-    'ui:description': 'maximum 250 characters',
-    'ui:options': {
-      maxLength: 250,
-    },
-    'ui:widget': 'TextAreaWidget',
-  },
-  statusOfFunding: {
-    'ui:widget': 'SelectWidget',
-  },
-  funderType: {
-    'ui:widget': 'SelectWidget',
-  },
-  nameOfFundingProgram: {
-    'ui:description': 'maximum 150 characters',
-    'ui:options': {
-      maxLength: 150,
+
+  otherFundingSourcesArray: {
+    items: {
+      fundingSourceContactInfo: {
+        'ui:description': 'maximum 250 characters',
+        'ui:options': {
+          maxLength: 250,
+        },
+        'ui:widget': 'TextAreaWidget',
+      },
+      otherFundingSources: {
+        'ui:widget': 'RadioWidget',
+      },
+      fundingPartnersName: {
+        'ui:description': 'maximum 150 characters',
+        'ui:options': {
+          maxLength: 150,
+        },
+      },
+      statusOfFunding: {
+        'ui:widget': 'SelectWidget',
+      },
+      funderType: {
+        'ui:widget': 'SelectWidget',
+      },
+      nameOfFundingProgram: {
+        'ui:description': 'maximum 150 characters',
+        'ui:options': {
+          maxLength: 150,
+        },
+      },
+      'ui:inline': [
+        // This is nested so it works in this array object
+
+        // Other funding sources page grid schema:
+        {
+          otherFundingSources: 'full',
+        },
+        {
+          fundingPartnersName: 'full',
+        },
+        {
+          fundingSourceContactInfo: 'full',
+        },
+        {
+          statusOfFunding: 'full',
+        },
+        {
+          funderType: 'full',
+        },
+        {
+          nameOfFundingProgram: 'full',
+        },
+        {
+          title: 'Amount requested from funding partner',
+          requestedFundingPartner2223: 'inline',
+          requestedFundingPartner2324: 'inline',
+          requestedFundingPartner2425: 'inline',
+          requestedFundingPartner2526: 'inline',
+          requestedFundingPartner2627: 'inline',
+        },
+        { totalRequestedFundingPartner: 'full' },
+      ],
     },
   },
   'ui:inline': [

--- a/app/lib/theme/FormWithTheme.tsx
+++ b/app/lib/theme/FormWithTheme.tsx
@@ -1,7 +1,7 @@
 import { ThemeProps, utils } from '@rjsf/core';
 import FieldTemplate from './FieldTemplate';
 import ObjectFieldTemplate from './ObjectFieldTemplate';
-import { DescriptionField } from './fields';
+import { ArrayFieldTemplate, DescriptionField } from './fields';
 import {
   CheckboxesWidget,
   CheckboxWidget,
@@ -32,6 +32,7 @@ const formTheme: ThemeProps = {
     TextAreaWidget: TextAreaWidget,
   },
   ObjectFieldTemplate: ObjectFieldTemplate,
+  ArrayFieldTemplate: ArrayFieldTemplate,
   FieldTemplate: FieldTemplate,
 };
 

--- a/app/lib/theme/ObjectFieldTemplate.tsx
+++ b/app/lib/theme/ObjectFieldTemplate.tsx
@@ -62,13 +62,6 @@ const ObjectFieldTemplate = (props: ObjectFieldTemplateProps) => {
         </h3>
       )}
 
-      {props.properties.map((prop: any) => {
-        const isInlineItem = inlineKeys.find((key) => key === prop.name);
-        if (!isInlineItem) {
-          return prop.content;
-        }
-      })}
-
       {uiInline &&
         uiInline.map((row: any, i: number) => {
           const rowKeys = Object.keys(row);
@@ -101,6 +94,13 @@ const ObjectFieldTemplate = (props: ObjectFieldTemplateProps) => {
             </div>
           );
         })}
+
+      {props.properties.map((prop: any) => {
+        const isInlineItem = inlineKeys.find((key) => key === prop.name);
+        if (!isInlineItem) {
+          return prop.content;
+        }
+      })}
     </FormBorder>
   );
 };

--- a/app/lib/theme/ObjectFieldTemplate.tsx
+++ b/app/lib/theme/ObjectFieldTemplate.tsx
@@ -9,7 +9,8 @@ const DefaultDescriptionField = (props: {
 
 const StyledInline = styled('div')`
   display: flex;
-  input {
+  input,
+  select {
     min-width: 90%;
   }
 `;

--- a/app/lib/theme/fields/ArrayFieldTemplate.tsx
+++ b/app/lib/theme/fields/ArrayFieldTemplate.tsx
@@ -25,7 +25,7 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
     <div>
       {props.items.map((item: any, i: number) => {
         return (
-          <div key={`array-field-template-${i}`}>
+          <div key={item.key}>
             {i != 0 && (
               <StyledDiv>
                 <StyledButton onClick={item.onDropIndexClick(item.index)}>

--- a/app/lib/theme/fields/ArrayFieldTemplate.tsx
+++ b/app/lib/theme/fields/ArrayFieldTemplate.tsx
@@ -23,7 +23,7 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
   const uiArrayButtons = props.uiSchema?.items?.['ui:array-buttons'];
   return (
     <div>
-      {props.items.map((item: any, i: number) => {
+      {props.items.map((item, i: number) => {
         return (
           <div key={item.key}>
             {i != 0 && (

--- a/app/lib/theme/fields/ArrayFieldTemplate.tsx
+++ b/app/lib/theme/fields/ArrayFieldTemplate.tsx
@@ -19,7 +19,7 @@ const StyledButton = styled('button')`
 const ArrayFieldTemplate = (props: any) => {
   return (
     <div>
-      {props.items.map((element: any, i) => {
+      {props.items.map((element: any, i: number) => {
         return (
           <div key={i}>
             {i != 0 && (

--- a/app/lib/theme/fields/ArrayFieldTemplate.tsx
+++ b/app/lib/theme/fields/ArrayFieldTemplate.tsx
@@ -1,0 +1,45 @@
+import Button from '@button-inc/bcgov-theme/Button';
+
+import styled from 'styled-components';
+const StyledDiv = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  min-width: 100%;
+`;
+
+const StyledButton = styled('button')`
+  border: none;
+  background: none;
+  cursor: pointer;
+  text-decoration: underline;
+
+  color: ${(props) => props.theme.color.links};
+`;
+
+const ArrayFieldTemplate = (props: any) => {
+  return (
+    <div>
+      {props.items.map((element: any, i) => {
+        return (
+          <div key={i}>
+            {i != 0 && (
+              <StyledDiv>
+                <StyledButton onClick={element.onDropIndexClick(element.index)}>
+                  Remove
+                </StyledButton>
+              </StyledDiv>
+            )}
+
+            {element.children}
+            <hr />
+          </div>
+        );
+      })}
+      {props.canAdd && (
+        <Button onClick={props.onAddClick}>Add another funding source</Button>
+      )}
+    </div>
+  );
+};
+
+export default ArrayFieldTemplate;

--- a/app/lib/theme/fields/ArrayFieldTemplate.tsx
+++ b/app/lib/theme/fields/ArrayFieldTemplate.tsx
@@ -1,6 +1,7 @@
 import Button from '@button-inc/bcgov-theme/Button';
-
 import styled from 'styled-components';
+import { ArrayFieldTemplateProps } from '@rjsf/core';
+
 const StyledDiv = styled('div')`
   display: flex;
   justify-content: flex-end;
@@ -12,31 +13,37 @@ const StyledButton = styled('button')`
   background: none;
   cursor: pointer;
   text-decoration: underline;
-
   color: ${(props) => props.theme.color.links};
 `;
 
-const ArrayFieldTemplate = (props: any) => {
+const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
+  // Todo: unlikely needed for this project but we could look at better customization
+  // options if we bring this into the toolkit.
+
+  const uiArrayButtons = props.uiSchema?.items?.['ui:array-buttons'];
   return (
     <div>
-      {props.items.map((element: any, i: number) => {
+      {props.items.map((item: any, i: number) => {
         return (
-          <div key={i}>
+          <div key={`array-field-template-${i}`}>
             {i != 0 && (
               <StyledDiv>
-                <StyledButton onClick={element.onDropIndexClick(element.index)}>
-                  Remove
+                <StyledButton onClick={item.onDropIndexClick(item.index)}>
+                  {uiArrayButtons?.removeBtnLabel || 'Remove'}
                 </StyledButton>
               </StyledDiv>
             )}
 
-            {element.children}
+            {item.children}
             <hr />
           </div>
         );
       })}
+
       {props.canAdd && (
-        <Button onClick={props.onAddClick}>Add another funding source</Button>
+        <Button onClick={props.onAddClick}>
+          {uiArrayButtons?.addBtnLabel || 'Add'}
+        </Button>
       )}
     </div>
   );

--- a/app/lib/theme/fields/index.ts
+++ b/app/lib/theme/fields/index.ts
@@ -1,1 +1,2 @@
+export { default as ArrayFieldTemplate } from './ArrayFieldTemplate';
 export { default as DescriptionField } from './DescriptionField';


### PR DESCRIPTION
https://app.zenhub.com/workspaces/ccbc---delivery-board-61c0c1204c8bcb001491c5f3/issues/bcgov/conn-ccbc-portal/238

This one wasn't as bad as I thought, the friction was mostly figuring out that I had to nest the `uiSchema` stuff similar to how the `otherFundingSources` page schema was nested. This page is more complex than others because it dynamically allows us to add as many new groups of fields as we want with the `Add another funding source` button, as well as remove ones though that button only shows up on the second group onward.

This required me to add the custom `ArrayFieldTemplate` renderer. Even though we are unlikely to use this for another page in this project I added custom button labels using the `ui:array-buttons` prop to make it a little more generic than just for this page.

Also, while dynamically showing the form once you hit yes on the initial radio buttons isn't shown in the card I confirmed with Zoey that is how we are going to show it. 
