### PR TITLE
fix: form text formatting

### DIFF
--- a/.github/actions/app/action.yaml
+++ b/.github/actions/app/action.yaml
@@ -29,7 +29,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Authenticate, set context, and run deploy script
+    - name: Authenticate, set context and run deploy script
       uses: redhat-actions/oc-login@v1
       with:
         openshift_server_url: ${{ inputs.openshift_server_url }}

--- a/.github/actions/dev-env-setup/action.yml
+++ b/.github/actions/dev-env-setup/action.yml
@@ -1,5 +1,5 @@
 name: 'Set up CCBC dev environment'
-description: 'Sets up asdf, perl, and configures the cache'
+description: 'Sets up asdf, perl and configures the cache'
 runs:
   using: composite
   steps:

--- a/app/formSchema/pages/benefits.ts
+++ b/app/formSchema/pages/benefits.ts
@@ -12,7 +12,7 @@ const benefits = {
         
         Sustainability. Description of the social and economic benefits as a result of the proposed project, such as improvements to community connectivity, facilitation of commercial or industrial development, improvement of public services or social programs delivery, improvement of small businesses, enhancement of entrepreneurship capacity, applicant’s corporate social responsibility policy and its philanthropic practices, etc. 
         
-        In the case of internal corporate policies, social responsibility, and philanthropic practices, describe how your organization promotes gender equality and diversity or how your organization gives back to the community.`,
+        In the case of internal corporate policies, social responsibility and philanthropic practices, describe how your organization promotes gender equality and diversity or how your organization gives back to the community.`,
         type: 'string',
       },
       numberOfHouseholds: {

--- a/app/formSchema/pages/budgetDetails.ts
+++ b/app/formSchema/pages/budgetDetails.ts
@@ -7,7 +7,7 @@ const budgetDetails = {
     required: ['totalEligibleCosts', 'totalProjectCost'],
     properties: {
       totalEligibleCosts: {
-        title: `The applicant must complete and upload the appropriate templates related to the project budget details in Section 3. Template Uploads of the application submission. Values here must match Template 2 - Detailed Budget in Section 2. Template Uploads.
+        title: `The applicant must complete and upload the appropriate templates related to the project budget details in the Template Uploads section. Values here must match values in Template 2 - Detailed Budget.
 
           Total eligible costs`,
         type: 'number',

--- a/app/formSchema/pages/declarations.ts
+++ b/app/formSchema/pages/declarations.ts
@@ -17,9 +17,9 @@ const declarations = {
           agencies/departments and non-profit organizations, to collect and share with them, as the Program deems necessary in order to reach a decision
           on this proposed project.`,
             `The applicant confirms that any person, who is required to be registered pursuant to the Lobbying Act including consultant and in-house lobbyists,
-            is registered pursuant to that Act, and is in compliance with the provisions of the Act.`,
+            is registered pursuant to that Act and is in compliance with the provisions of the Act.`,
             `The applicant confirms that any person, who is required to be registered pursuant to the Lobbying Act including consultant and in-house lobbyists,
-            is registered pursuant to that Act, and is in compliance with the provisions of the Act.`,
+            is registered pursuant to that Act and is in compliance with the provisions of the Act.`,
             `The applicant recognizes that the project may require an impact assessment under the Impact Assessment Act 2019.`,
             `The applicant recognizes that there is a duty to consult Indigenous groups if a federally funded project will undertake infrastructure in, or affecting,
             an Indigenous community.`,
@@ -27,7 +27,7 @@ const declarations = {
             Values and Ethics Code for the Public Service, the Policy on Conflict of Interest and Post-Employment and the Conflict of Interest Act.`,
             `The applicant understands that all costs incurred in the preparation and submission of the proposal shall be wholly absorbed by the applicant.`,
             `The applicant understands that the Program reserves the right to make partial awards and to negotiate project scope changes with applicants.`,
-            `The applicant understands that the Program is a discretionary program subject to available funding, and that submission of a complete application,
+            `The applicant understands that the Program is a discretionary program subject to available funding and that submission of a complete application,
             meeting any or all of the assessment criteria, does not mean that funding will be granted. All applicants whose projects are approved for funding
             will be notified in writing.`,
             `The applicant confirms that it is and will remain in compliance with any applicable Canadian national security requirements as defined and/or

--- a/app/formSchema/pages/declarations.ts
+++ b/app/formSchema/pages/declarations.ts
@@ -2,7 +2,7 @@ const declarations = {
   declarations: {
     title: 'Declarations',
     description:
-      'By checking the boxes below the Applicant certifies and acknowledges, that:',
+      'By checking the boxes below the applicant certifies and acknowledges, that:',
     type: 'object',
     required: ['declarationsList'],
     properties: {
@@ -11,33 +11,33 @@ const declarations = {
         items: {
           type: 'boolean',
           enum: [
-            `The Applicant confirms that it is under no obligation or prohibition, nor is it subject to, or threatened by any actions, suits or proceedings, which
+            `The applicant confirms that it is under no obligation or prohibition, nor is it subject to, or threatened by any actions, suits or proceedings, which
           could or would affect its ability to implement this proposed project.`,
-            `The Applicant confirms that it authorizes the Program to make enquiries of such persons, firms, corporations, federal and provincial government
+            `The applicant confirms that it authorizes the Program to make enquiries of such persons, firms, corporations, federal and provincial government
           agencies/departments and non-profit organizations, to collect and share with them, as the Program deems necessary in order to reach a decision
           on this proposed project.`,
-            `The Applicant confirms that any person, who is required to be registered pursuant to the Lobbying Act including consultant and in-house lobbyists,
+            `The applicant confirms that any person, who is required to be registered pursuant to the Lobbying Act including consultant and in-house lobbyists,
             is registered pursuant to that Act, and is in compliance with the provisions of the Act.`,
-            `The Applicant confirms that any person, who is required to be registered pursuant to the Lobbying Act including consultant and in-house lobbyists,
+            `The applicant confirms that any person, who is required to be registered pursuant to the Lobbying Act including consultant and in-house lobbyists,
             is registered pursuant to that Act, and is in compliance with the provisions of the Act.`,
-            `The Applicant recognizes that the project may require an impact assessment under the Impact Assessment Act 2019.`,
-            `The Applicant recognizes that there is a duty to consult Indigenous groups if a federally funded project will undertake infrastructure in, or affecting,
+            `The applicant recognizes that the project may require an impact assessment under the Impact Assessment Act 2019.`,
+            `The applicant recognizes that there is a duty to consult Indigenous groups if a federally funded project will undertake infrastructure in, or affecting,
             an Indigenous community.`,
-            `The Applicant confirms that any former public officer holder or public servant employed by the Applicant is in compliance with the provisions of the
+            `The applicant confirms that any former public officer holder or public servant employed by the applicant is in compliance with the provisions of the
             Values and Ethics Code for the Public Service, the Policy on Conflict of Interest and Post-Employment and the Conflict of Interest Act.`,
-            `The Applicant understands that all costs incurred in the preparation and submission of the proposal shall be wholly absorbed by the Applicant.`,
-            `The Applicant understands that the Program reserves the right to make partial awards and to negotiate project scope changes with applicants.`,
-            `The Applicant understands that the Program is a discretionary program subject to available funding, and that submission of a complete application,
+            `The applicant understands that all costs incurred in the preparation and submission of the proposal shall be wholly absorbed by the applicant.`,
+            `The applicant understands that the Program reserves the right to make partial awards and to negotiate project scope changes with applicants.`,
+            `The applicant understands that the Program is a discretionary program subject to available funding, and that submission of a complete application,
             meeting any or all of the assessment criteria, does not mean that funding will be granted. All applicants whose projects are approved for funding
             will be notified in writing.`,
-            `The Applicant confirms that it is and will remain in compliance with any applicable Canadian national security requirements as defined and/or
+            `The applicant confirms that it is and will remain in compliance with any applicable Canadian national security requirements as defined and/or
             administered by the Canadian security authorities.`,
-            `The Applicant confirms that it has the managing capability to deliver the project on time and on budget.`,
-            `The Applicant confirms that it is requesting the lowest possible contribution amount required to make this project financially viable.`,
-            `The Applicant acknowledges that knowingly making any false statements or misrepresentations, including by omission, in an application may
+            `The applicant confirms that it has the managing capability to deliver the project on time and on budget.`,
+            `The applicant confirms that it is requesting the lowest possible contribution amount required to make this project financially viable.`,
+            `The applicant acknowledges that knowingly making any false statements or misrepresentations, including by omission, in an application may
             affect its eligibility and funding approval may be revoked.`,
-            `The Applicant confirms that, to the best of its knowledge, the information submitted in this application is true and correct.`,
-            `The Applicant agrees that information provided in this application form (including attachments) may be shared with the Government of Canada and other levels of government to promote the program and maximize the benefits to citizens.`,
+            `The applicant confirms that, to the best of its knowledge, the information submitted in this application is true and correct.`,
+            `The applicant agrees that information provided in this application form (including attachments) may be shared with the Government of Canada and other levels of government to promote the program and maximize the benefits to citizens.`,
           ],
         },
         uniqueItems: true,

--- a/app/formSchema/pages/declarationsSign.ts
+++ b/app/formSchema/pages/declarationsSign.ts
@@ -2,7 +2,7 @@ const declarationsSign = {
   declarationsSign: {
     title: 'Declarations',
     description:
-      'You certify that you have the authority to submit this information on behalf of the Applicant.',
+      'You certify that you have the authority to submit this information on behalf of the applicant.',
     type: 'object',
     required: [
       'declarationsCompletedFor',
@@ -12,7 +12,7 @@ const declarationsSign = {
     ],
     properties: {
       declarationsCompletedFor: {
-        title: 'Completed for (Applicant Name)',
+        title: 'Completed for (applicant Name)',
         type: 'string',
       },
       declarationsDate: {

--- a/app/formSchema/pages/existingNetworkCoverage.ts
+++ b/app/formSchema/pages/existingNetworkCoverage.ts
@@ -28,15 +28,13 @@ const existingNetworkCoverage = {
         enumNames: ['Yes', 'No'],
       },
       isInfrastuctureAvailable: {
-        title: `The applicant intends to make reasonable efforts to make its passive infrastructure available for use by other broadband operators to expand and
-          improve coverage in Canada?`,
+        title: `The applicant intends to make reasonable efforts to make its passive infrastructure available for use by other broadband operators to expand and improve coverage in Canada?`,
         type: 'boolean',
         enum: [true, false],
         enumNames: ['Yes', 'No'],
       },
       requiresThirdPartyInfrastructureAccess: {
-        title: `Does the applicant’s project require access to third party passive infrastructure (including for example, towers, poles, rights of way or other similar
-            assets and infrastructure)?`,
+        title: `Does the applicant’s project require access to third party passive infrastructure (including for example, towers, poles, rights of way or other similar assets and infrastructure)?`,
         type: 'boolean',
         enum: [true, false],
         enumNames: ['Yes', 'No'],

--- a/app/formSchema/pages/mapping.ts
+++ b/app/formSchema/pages/mapping.ts
@@ -12,12 +12,12 @@ const mapping = {
       },
       currentNetworkInfastructure: {
         title:
-          'Please include layers for your organization’s (1) fibre lines, (2) PoPs, COs, towers, and microwave links, (3) current coverage for the proposed project (with speeds), (4) location of project specific backhaul/backbone access points, and (5) PTP microwave paths (if applicable).',
+          'Please include layers for your organization’s (1) fibre lines, (2) PoPs, COs, towers and microwave links, (3) current coverage for the proposed project (with speeds), (4) location of project specific backhaul/backbone access points and (5) PTP microwave paths (if applicable).',
         type: 'string',
       },
       upgradedNetworkInfrastructure: {
         title:
-          'Please include layers for your organization’s (1) proposed coverage for the communities proposed in the project, (2) locations (colour differentiated) of new and upgraded towers, PoPs, fibre, PTP microwave links, and COs, and (3) new PTP microwave paths (colour differentiated) between towers (required for fixed wireless projects.',
+          'Please include layers for your organization’s (1) proposed coverage for the communities proposed in the project, (2) locations (colour differentiated) of new and upgraded towers, PoPs, fibre, PTP microwave links, COs and (3) new PTP microwave paths (colour differentiated) between towers (required for fixed wireless projects.',
         type: 'string',
       },
     },

--- a/app/formSchema/pages/organizationProfile.ts
+++ b/app/formSchema/pages/organizationProfile.ts
@@ -62,7 +62,7 @@ const organizationProfile = {
       },
       isSubsidiary: {
         title:
-          'Is this Applicant organization a subsidiary of a parent organization?',
+          'Is this applicant organization a subsidiary of a parent organization?',
         type: 'boolean',
         enum: ['Yes', 'No'],
       },

--- a/app/formSchema/pages/projectPlan.ts
+++ b/app/formSchema/pages/projectPlan.ts
@@ -21,12 +21,12 @@ const projectPlan = {
       },
       relationshipManagerApplicant: {
         title:
-          'Please describe the relationship between the project manager and the Applicant.',
+          'Please describe the relationship between the project manager and the applicant.',
         type: 'string',
       },
       overviewOfProjectParticipants: {
         title:
-          'Overview of project participants – Please identify the Applicant’s project participants including builder(s), owner(s), and operator(s) if different. Please indicate the names, titles, operating name (if applicable), legal type, contact information, and relevant portion of the network. Applicant and collaborators must have strong project management, financial control, and technical development skills.',
+          'Overview of project participants – Please identify the applicant’s project participants including builder(s), owner(s), and operator(s) if different. Please indicate the names, titles, operating name (if applicable), legal type, contact information, and relevant portion of the network. Applicant and collaborators must have strong project management, financial control, and technical development skills.',
         type: 'string',
       },
       operationalPlan: {

--- a/app/formSchema/pages/projectPlan.ts
+++ b/app/formSchema/pages/projectPlan.ts
@@ -25,14 +25,13 @@ const projectPlan = {
         type: 'string',
       },
       overviewOfProjectParticipants: {
-        title: `Overview of project participants – Please identify the Applicant’s project participants including builder(s), owner(s), and operator(s) if different. Please
-        indicate the names, titles, operating name (if applicable), legal type, contact information, and relevant portion of the network. Applicant and collaborators must have strong project management, financial control, and technical development skills.`,
+        title:
+          'Overview of project participants – Please identify the Applicant’s project participants including builder(s), owner(s), and operator(s) if different. Please indicate the names, titles, operating name (if applicable), legal type, contact information, and relevant portion of the network. Applicant and collaborators must have strong project management, financial control, and technical development skills.',
         type: 'string',
       },
       operationalPlan: {
-        title: `Operational Plan – Describe key factors to indicate how the applicant will be prepared to operate, manage, and maintain the proposed broadband
-        network including any external managed services which will support network management or operations functions. Address how the applicant will
-        ensure that the necessary sales, operational, technical, and billing support systems are or will be in place to supply the proposed services.`,
+        title:
+          'Operational Plan – Describe key factors to indicate how the applicant will be prepared to operate, manage, and maintain the proposed broadband network including any external managed services which will support network management or operations functions. Address how the applicant will ensure that the necessary sales, operational, technical, and billing support systems are or will be in place to supply the proposed services.',
         type: 'string',
       },
     },

--- a/app/formSchema/pages/projectPlan.ts
+++ b/app/formSchema/pages/projectPlan.ts
@@ -26,12 +26,12 @@ const projectPlan = {
       },
       overviewOfProjectParticipants: {
         title:
-          'Overview of project participants – Please identify the applicant’s project participants including builder(s), owner(s), and operator(s) if different. Please indicate the names, titles, operating name (if applicable), legal type, contact information, and relevant portion of the network. Applicant and collaborators must have strong project management, financial control, and technical development skills.',
+          'Overview of project participants – Please identify the applicant’s project participants including builder(s), owner(s) and operator(s) if different. Please indicate the names, titles, operating name (if applicable), legal type, contact information and relevant portion of the network. Applicant and collaborators must have strong project management, financial control and technical development skills.',
         type: 'string',
       },
       operationalPlan: {
         title:
-          'Operational Plan – Describe key factors to indicate how the applicant will be prepared to operate, manage, and maintain the proposed broadband network including any external managed services which will support network management or operations functions. Address how the applicant will ensure that the necessary sales, operational, technical, and billing support systems are or will be in place to supply the proposed services.',
+          'Operational Plan – Describe key factors to indicate how the applicant will be prepared to operate, manage and maintain the proposed broadband network including any external managed services which will support network management or operations functions. Address how the applicant will ensure that the necessary sales, operational, technical and billing support systems are or will be in place to supply the proposed services.',
         type: 'string',
       },
     },

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -168,7 +168,7 @@ const uiSchema = {
     'ui:widget': 'TextAreaWidget',
     'ui:description': 'maximum 3,500 characters',
     'ui:title':
-      'Using non-technical language, provide a description of the project, including its key elements, purpose, objectives, and benefits. Identify the ‘who’, ‘what’, ‘where’, ‘when’, and ‘why’. Please avoid including confidential or proprietary information.',
+      'Using non-technical language, provide a description of the project, including its key elements, purpose, objectives and benefits. Identify the ‘who’, ‘what’, ‘where’, ‘when’ and ‘why’. Please avoid including confidential or proprietary information.',
 
     'ui:options': {
       maxLength: MAX_TEXTAREA_LENGTH,

--- a/db/deploy/functions/session.sql
+++ b/db/deploy/functions/session.sql
@@ -12,7 +12,7 @@ declare
   _idir_userid text := current_setting('jwt.claims.idir_userid', true);
 begin
   if ((coalesce(trim(_sub), '') = '') is not false) then
-    return null; -- ensure null, empty, and whitespace _sub / idir_userid claims are filtered out
+    return null; -- ensure null, empty and whitespace _sub / idir_userid claims are filtered out
   end if;
   return (
     select row (

--- a/db/revert/create_roles.sql
+++ b/db/revert/create_roles.sql
@@ -5,7 +5,7 @@ begin;
 do
 $do$
 begin
-raise NOTICE 'Created roles may be used in other projects, and need to be manually deleted if needed';
+raise NOTICE 'Created roles may be used in other projects and need to be manually deleted if needed';
 end;
 $do$;
 

--- a/db/test/tables/table_applications_test.sql
+++ b/db/test/tables/table_applications_test.sql
@@ -8,7 +8,7 @@ SELECT * FROM no_plan();
 -- Table exists
 select has_table(
   'ccbc_public', 'applications',
-  'ccbc_public.applications should exist, and be a table'
+  'ccbc_public.applications should exist and be a table'
 );
 
 

--- a/db/test/tables/table_connect_session_test.sql
+++ b/db/test/tables/table_connect_session_test.sql
@@ -8,7 +8,7 @@ SELECT * FROM no_plan();
 -- Table exists
 select has_table(
   'ccbc_private', 'connect_session',
-  'ccbc_private.connect_session should exist, and be a table'
+  'ccbc_private.connect_session should exist and be a table'
 );
 
 

--- a/docs/Definition_of_ Ready.md
+++ b/docs/Definition_of_ Ready.md
@@ -3,38 +3,42 @@
 💡 The Definition of Ready is the agreement that the Product Owner has with the Dev Team on what each user story **needs to have to be a candidate to be executed or developed** (next or further sprint)
 
 ### Purpose
+
 ---
+
 The purpose of the DoR is to mitigate REWORK!!!
 
-
 ### For each individual sprint
+
 ---
+
 What we need for each sprint.
 
-- [ ]  **Has the story the INVEST criteria** 
-- “I” ndependent (of all others as practicable) 
-- “N” egotiable (not a specific contract for features) 
-- “V” aluable (or vertical) 
-- “E” stimable (to a good approximation) 
-- “S” mall (so as to fit within an iteration) 
-- “T” estable (in principle, even if there isn’t a test for it yet) 
-- [ ]  **It has Acceptance Criteria.**
-- [ ]  **If it has a Prototype, a screenshot should be added to the story.**
-- [ ]  **The Acceptance Criteria was evaluated by the Dev Team (Feasible or not, or there is a better way to do this).**
-- [ ]  **Another person can execute it without further questions (clarity).**
+- [ ] **Has the story the INVEST criteria**
+- “I” ndependent (of all others as practicable)
+- “N” egotiable (not a specific contract for features)
+- “V” aluable (or vertical)
+- “E” stimable (to a good approximation)
+- “S” mall (so as to fit within an iteration)
+- “T” estable (in principle, even if there isn’t a test for it yet)
+- [ ] **It has Acceptance Criteria.**
+- [ ] **If it has a Prototype, a screenshot should be added to the story.**
+- [ ] **The Acceptance Criteria was evaluated by the Dev Team (Feasible or not, or there is a better way to do this).**
+- [ ] **Another person can execute it without further questions (clarity).**
 
 ---
 
-- A user story is clear if all Scrum team members have a shared understanding of what it means. Collaboratively writing user stories, and adding acceptance criteria to the high-priority ones facilitates clarity.  
-- An item is testable if there is an effective way to determine if the functionality works as expected. Acceptance criteria ensure that each story can be tested.  
-- A user story is feasible if it can be completed in one sprint, according to the Definition of Done. If this is not achievable, it needs to be broken down further. 
+- A user story is clear if all Scrum team members have a shared understanding of what it means. Collaboratively writing user stories and adding acceptance criteria to the high-priority ones facilitates clarity.
+- An item is testable if there is an effective way to determine if the functionality works as expected. Acceptance criteria ensure that each story can be tested.
+- A user story is feasible if it can be completed in one sprint, according to the Definition of Done. If this is not achievable, it needs to be broken down further.
 
 ---
 
 **User Story Template**
+
 ```
-As a [type of user or profile who performs the action] 
-I want [action - what they are doing?] 
+As a [type of user or profile who performs the action]
+I want [action - what they are doing?]
 so that [because - why this is important? What problem is this solving?]
 
 ## Acceptace Criteria:
@@ -43,13 +47,13 @@ so that [because - why this is important? What problem is this solving?]
     Given
     When
     Then
-    
+
 - [ ] Scenario: ...
     Given
     When
     Then
-    
+
 ## Not included:
-- 
-- 
+-
+-
 ```

--- a/docs/Team_Agreements.md
+++ b/docs/Team_Agreements.md
@@ -1,38 +1,44 @@
 ## Working together
-- Share what you plan to work on to prevent duplication of work 
+
+- Share what you plan to work on to prevent duplication of work
 
 ## Working with the Board
+
 ### Creating cards:
-- Before creating a card, check if the card already exists on the board. 
-- Card Title: Noum + verb/action 
-- Add tags - Use the existing ones. Don't create tags. Talk with the team first! 
-- Add to the proper column/stage 
-- Add the Epic 
-- Add the Sprint, if needed 
+
+- Before creating a card, check if the card already exists on the board.
+- Card Title: Noum + verb/action
+- Add tags - Use the existing ones. Don't create tags. Talk with the team first!
+- Add to the proper column/stage
+- Add the Epic
+- Add the Sprint, if needed
 
 ### Communication
+
 - Update the card the Backlog before the Stand-up meeting
-- Always mention the card in the conversation 
-- Communication takes place in the development channel in the Gov Team. Gov Teams is the main channel of communication between PO, Stakeholders, and the team 
+- Always mention the card in the conversation
+- Communication takes place in the development channel in the Gov Team. Gov Teams is the main channel of communication between PO, Stakeholders and the team
 
 ## Meetings
-- Not invite everyone to all meetings. Be mindful of each meeting one of the team members should be present. (Required vs Optional) 
-- Feel free to leave a meeting if you feel you shouldn’t be there. 
+
+- Not invite everyone to all meetings. Be mindful of each meeting one of the team members should be present. (Required vs Optional)
+- Feel free to leave a meeting if you feel you shouldn’t be there.
 
 ## Development and Version Control
-- Devs can appoint representatives for dev-design syncs 
-- Branch naming policy is as follows: [issue#]-brief-description. In the event that an issue does not already exist for the changes being made in a branch, one should be made. 
-- Make draft pull requests early and often to facilitate a transparent process. 
-- When a PR is ready, post a request for review with a link to the branch in Teams. 
-- Reviews can be done by the first person who gets to it. If the code needs explaining, request the author to walk you through it. 
-- Follow peer review best practices by suggesting opportunities to improve code during peer review, merging as soon as the code is better than the code in the target branch and release ready. 
-- Treat any opportunity for improvement feedback identified during peer review but not implemented in the PR where it was raised as technical debt worthy of a new issue referencing the PR where the comments first came up. 
-- When necessary, use git rebase to sync a feature branch with main. This keeps a tidier history in git, however, can be destructive, so do so cautiously. 
 
-**Guardrails** 
+- Devs can appoint representatives for dev-design syncs
+- Branch naming policy is as follows: [issue#]-brief-description. In the event that an issue does not already exist for the changes being made in a branch, one should be made.
+- Make draft pull requests early and often to facilitate a transparent process.
+- When a PR is ready, post a request for review with a link to the branch in Teams.
+- Reviews can be done by the first person who gets to it. If the code needs explaining, request the author to walk you through it.
+- Follow peer review best practices by suggesting opportunities to improve code during peer review, merging as soon as the code is better than the code in the target branch and release ready.
+- Treat any opportunity for improvement feedback identified during peer review but not implemented in the PR where it was raised as technical debt worthy of a new issue referencing the PR where the comments first came up.
+- When necessary, use git rebase to sync a feature branch with main. This keeps a tidier history in git, however, can be destructive, so do so cautiously.
 
-- The following guardrails are in place to ensure we keep a clean working tree, while avoiding merging breaking changes into our main branch. 
-- The default branch for this repo is main. 
-- All commits must be made to a non-protected branch and submitted via a pull request before they can be merged into main. (There can be no direct commits made to main.) 
-- Branches are automatically deleted on Github when a PR is merged. Each teammate should set git config fetch.prune true to mirror this behaviour to their local workstation. 
+**Guardrails**
+
+- The following guardrails are in place to ensure we keep a clean working tree, while avoiding merging breaking changes into our main branch.
+- The default branch for this repo is main.
+- All commits must be made to a non-protected branch and submitted via a pull request before they can be merged into main. (There can be no direct commits made to main.)
+- Branches are automatically deleted on Github when a PR is merged. Each teammate should set git config fetch.prune true to mirror this behaviour to their local workstation.
 - Squash merge has been disabled to increase the efficiency of git bisect.

--- a/helm/app/.helmignore
+++ b/helm/app/.helmignore
@@ -1,5 +1,5 @@
 # Patterns to ignore when building packages.
-# This supports shell glob matching, relative path matching, and
+# This supports shell glob matching, relative path matching and
 # negation (prefixed with !). Only one pattern per line.
 .DS_Store
 # Common VCS dirs


### PR DESCRIPTION
This fixes some weird text formatting issues due to my use of `white-space: pre line` so we could have multi line titles as required in some form pages. This just removes the line breaks and turns template literals into regular strings. 

Also changed instances of the term `Applicant` to lowercase and removed oxford commas as these aren't used in government/

![Screenshot at 2022-06-28 13-23-14](https://user-images.githubusercontent.com/14259474/176277940-426c86f8-79d9-448c-a91f-0650581a9ed5.png)
