### PR TITLE
fix(helm): metabase NetworkPolicy selector uses postgres-operator label

### DIFF
--- a/helm/app/templates/networkPolicies/metabase-ingress.yaml
+++ b/helm/app/templates/networkPolicies/metabase-ingress.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/instance: {{ .Release.Name }}-hippo-ha
+      postgres-operator.crunchydata.com/instance-set: {{ .Release.Name }}-hippo-ha
   ingress:
   - from:
     - namespaceSelector:


### PR DESCRIPTION
### Description: 

The Metabase NetworkPolicy selector uses a label that is not created by the crunchydata postgres operator. This fixes it.

References #270 

### Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### Checklist for DoD:
- [ ] Code produced (all ‘to do’ items in code completed) 
- [ ]  Acceptance Criteria were executed without fail. 
- [ ]  Code commented, checked in and ran against current version in source control 
- [ ]  Obey “Conventional commits” (https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Code review (https://google.github.io/eng-practices/review/)
- [ ]  Peer reviewed (or produced with pair programming) and meeting development standards ([Google](https://google.github.io/eng-practices/review/reviewer/)) 
- [ ]  Defects = 0% (?). (How to measure this?) 
- [ ]  Unit tests are written and passing 
- [ ]  Test coverage > 80%(?) 
- [ ]  Deployed to the system test(?) environment and passed system tests 
- [ ]  Any build / deployment / configuration changes are implemented / documented / communicated 
- [ ]  Relevant documentation / diagrams produced and / or updated 
- [ ]  Don’t introduce breaking changes. 
- [ ]  Don’t (avoid) introducing more tech debt. 
- [ ]  Automatic Tests implemented and running 
- [ ]  Exploratory Test executed if it applies 
- [ ]  Week-notes (~5 bullets of accomplished this sprint + ~5 bullets of what's coming) 
- [ ]  Written discoveries and recommendations 
- [ ]  Presentation to Stakeholders 
- [ ]  User Manual/FAQ updated 
- [ ]  GitHub DOCs updated 

