### PR TITLE
feat: add ignoreoptional option

### DIFF
--- a/app/formSchema/pages/organizationLocation.ts
+++ b/app/formSchema/pages/organizationLocation.ts
@@ -45,7 +45,7 @@ const organizationLocation = {
         ],
       },
       postalCode: {
-        title: 'Postal code (H0H 0H0)',
+        title: 'Postal code (H0H0H0)',
         type: 'string',
       },
       isMailingAddress: {
@@ -123,7 +123,7 @@ const organizationLocation = {
                     ],
                   },
                   postalCodeMailing: {
-                    title: 'Postal code (H0H 0H0)',
+                    title: 'Postal code (H0H0H0)',
                     type: 'string',
                   },
                 },

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -688,6 +688,7 @@ const uiSchema = {
         'ui:description': 'maximum 150 characters',
         'ui:options': {
           maxLength: 150,
+          ignoreOptional: true,
         },
       },
       requestedFundingPartner2223: {

--- a/app/lib/theme/FieldTemplate.tsx
+++ b/app/lib/theme/FieldTemplate.tsx
@@ -4,6 +4,7 @@ import {
   IndigenousEntity,
   ProjectBenefits,
 } from '../../components/Form/CustomTitles';
+
 const FieldTemplate: React.FC<FieldTemplateProps> = ({
   children,
   errors,
@@ -12,12 +13,20 @@ const FieldTemplate: React.FC<FieldTemplateProps> = ({
   label,
   displayLabel,
   required,
+  uiSchema,
   id,
 }) => {
+  const ignoreOptional = uiSchema['ui:options']?.ignoreOptional;
+
   return (
     <div>
       {displayLabel && (
-        <FieldLabel label={label} required={required} htmlFor={id} />
+        <FieldLabel
+          label={label}
+          ignoreOptional={ignoreOptional && true}
+          required={required}
+          htmlFor={id}
+        />
       )}
       {label === 'isIndigenousEntity' && <IndigenousEntity />}
       {label === 'projectBenefits' && <ProjectBenefits />}

--- a/app/lib/theme/widgets/FieldLabel.tsx
+++ b/app/lib/theme/widgets/FieldLabel.tsx
@@ -3,6 +3,7 @@ interface Props {
   required: boolean;
   htmlFor: string;
   tagName?: 'label' | 'dt';
+  ignoreOptional: boolean;
 }
 
 const FieldLabel: React.FC<Props> = ({
@@ -10,11 +11,13 @@ const FieldLabel: React.FC<Props> = ({
   required,
   htmlFor,
   tagName = 'label',
+  ignoreOptional,
 }) => {
   if (!label) {
     return null;
   }
-  const displayedLabel = label + (required ? '' : ' (optional)') + ' ';
+  const displayedLabel =
+    label + (required || ignoreOptional ? '' : ` (optional)`) + ' ';
 
   if (tagName === 'label')
     return <label htmlFor={htmlFor}>{displayedLabel}</label>;


### PR DESCRIPTION
Updated the postal code example formatting and added a new `ui:options` attribute `ignoreOptional` which removes the `(optional)` to the end of non required fields if desired.