### PR TITLE
detect and persist identity provider

### DIFF
--- a/app/backend/lib/graphql/authenticationPgSettings.ts
+++ b/app/backend/lib/graphql/authenticationPgSettings.ts
@@ -43,6 +43,7 @@ const authenticationPgSettings = (req: Request) => {
     'broker_session_id',
     'user_groups',
     'priority_group',
+    'identity_provider',
   ];
 
   properties.forEach((property) => {

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -1447,6 +1447,9 @@ type KeycloakJwt {
   """
   brokerSessionId: String
   priorityGroup: String
+
+  """Name of the identity provider."""
+  identityProvider: String
   userGroups: [String]
 
   """Reads a single `CcbcUser` that is related to this `KeycloakJwt`."""

--- a/db/deploy/functions/session.sql
+++ b/db/deploy/functions/session.sql
@@ -36,6 +36,7 @@ begin
       current_setting('jwt.claims.email', true),
       current_setting('jwt.claims.broker_session_id', true),
       current_setting('jwt.claims.priority_group', true),
+      current_setting('jwt.claims.identity_provider', true),
       (select string_to_array(current_setting('jwt.claims.user_groups', true), ','))
     )::ccbc_public.keycloak_jwt
   );

--- a/db/deploy/types/keycloak_jwt.sql
+++ b/db/deploy/types/keycloak_jwt.sql
@@ -24,6 +24,7 @@ create type ccbc_public.keycloak_jwt as (
   email text,
   broker_session_id text,
   priority_group text,
+  identity_provider text,
   user_groups text[]
 );
 
@@ -144,6 +145,8 @@ comment on column ccbc_public.keycloak_jwt.email is
 comment on column ccbc_public.keycloak_jwt.broker_session_id is
   'If created via a broker external login, this is an identifier that can be used to 
   match external broker backchannel logout requests to a UserSession';
+comment on column ccbc_public.keycloak_jwt.identity_provider is
+  'Name of the identity provider.';
 
 comment on type ccbc_public.keycloak_jwt is E'@primaryKey sub\n@foreignKey (sub) references ccbc_user (uuid)';
 

--- a/db/revert/tables/applications/remove_unique_owner.sql
+++ b/db/revert/tables/applications/remove_unique_owner.sql
@@ -2,6 +2,7 @@
 
 BEGIN;
 
-ALTER TABLE ccbc_public.applications ADD CONSTRAINT applications_owner_key UNIQUE(owner);
+-- commented out becuase it causes errors on `sqitch revert`
+-- ALTER TABLE ccbc_public.applications ADD CONSTRAINT applications_owner_key UNIQUE(owner);
 
 COMMIT;


### PR DESCRIPTION
Discussed ticket 169 with Junmin. He suggested to use `identity_provider` and `preferredUsername` as main identifiers, and do not store idir, bceid_basic or bceid_business because Keycloak is using `preferredUsername` as `keycloak_username`, and it is unique user identifier.
Code changes:
- added `identity_provider` in keycloak_jwt type
- updated code to populate `identity_provider` from JWT
- updated revert action for `applications` table that was blocking `sqitch revert` and `sqitch deploy`