### PR TITLE
Fix migration

### DIFF
--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -590,35 +590,6 @@ type CcbcUser implements Node {
   ): ApplicationStatusesConnection!
 
   """Reads and enables pagination through a set of `Attachment`."""
-  attachmentsByDeletedBy(
-    """Only read the first `n` values of the set."""
-    first: Int
-
-    """Only read the last `n` values of the set."""
-    last: Int
-
-    """
-    Skip the first `n` values from our `after` cursor, an alternative to cursor
-    based pagination. May not be used with `last`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering `Attachment`."""
-    orderBy: [AttachmentsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: AttachmentCondition
-  ): AttachmentsConnection!
-
-  """Reads and enables pagination through a set of `Attachment`."""
   attachmentsByCreatedBy(
     """Only read the first `n` values of the set."""
     first: Int
@@ -678,6 +649,35 @@ type CcbcUser implements Node {
 
   """Reads and enables pagination through a set of `Attachment`."""
   attachmentsByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Attachment`."""
+    orderBy: [AttachmentsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: AttachmentCondition
+  ): AttachmentsConnection!
+
+  """Reads and enables pagination through a set of `Attachment`."""
+  attachmentsByDeletedBy(
     """Only read the first `n` values of the set."""
     first: Int
 
@@ -981,15 +981,6 @@ type Attachment implements Node {
   """
   applicationStatusId: Int
 
-  """Boolean declaring if the file has been soft deleted"""
-  isDeleted: Boolean!
-
-  """The id of the user that deleted the file"""
-  deletedBy: Int
-
-  """The time the file was deleted at"""
-  deletedAt: Datetime
-
   """created by user id"""
   createdBy: Int
 
@@ -1008,6 +999,15 @@ type Attachment implements Node {
   """archived at timestamp"""
   archivedAt: Datetime
 
+  """Boolean declaring if the file has been soft deleted"""
+  isDeleted: Boolean!
+
+  """The id of the user that deleted the file"""
+  deletedBy: Int
+
+  """The time the file was deleted at"""
+  deletedAt: Datetime
+
   """Reads a single `Application` that is related to this `Attachment`."""
   applicationByApplicationId: Application
 
@@ -1017,9 +1017,6 @@ type Attachment implements Node {
   applicationStatusByApplicationStatusId: ApplicationStatus
 
   """Reads a single `CcbcUser` that is related to this `Attachment`."""
-  ccbcUserByDeletedBy: CcbcUser
-
-  """Reads a single `CcbcUser` that is related to this `Attachment`."""
   ccbcUserByCreatedBy: CcbcUser
 
   """Reads a single `CcbcUser` that is related to this `Attachment`."""
@@ -1027,6 +1024,9 @@ type Attachment implements Node {
 
   """Reads a single `CcbcUser` that is related to this `Attachment`."""
   ccbcUserByArchivedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `Attachment`."""
+  ccbcUserByDeletedBy: CcbcUser
 }
 
 """A `Attachment` edge in the connection."""
@@ -1057,12 +1057,6 @@ enum AttachmentsOrderBy {
   APPLICATION_ID_DESC
   APPLICATION_STATUS_ID_ASC
   APPLICATION_STATUS_ID_DESC
-  IS_DELETED_ASC
-  IS_DELETED_DESC
-  DELETED_BY_ASC
-  DELETED_BY_DESC
-  DELETED_AT_ASC
-  DELETED_AT_DESC
   CREATED_BY_ASC
   CREATED_BY_DESC
   CREATED_AT_ASC
@@ -1075,6 +1069,12 @@ enum AttachmentsOrderBy {
   ARCHIVED_BY_DESC
   ARCHIVED_AT_ASC
   ARCHIVED_AT_DESC
+  IS_DELETED_ASC
+  IS_DELETED_DESC
+  DELETED_BY_ASC
+  DELETED_BY_DESC
+  DELETED_AT_ASC
+  DELETED_AT_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -1108,15 +1108,6 @@ input AttachmentCondition {
   """Checks for equality with the object’s `applicationStatusId` field."""
   applicationStatusId: Int
 
-  """Checks for equality with the object’s `isDeleted` field."""
-  isDeleted: Boolean
-
-  """Checks for equality with the object’s `deletedBy` field."""
-  deletedBy: Int
-
-  """Checks for equality with the object’s `deletedAt` field."""
-  deletedAt: Datetime
-
   """Checks for equality with the object’s `createdBy` field."""
   createdBy: Int
 
@@ -1134,6 +1125,15 @@ input AttachmentCondition {
 
   """Checks for equality with the object’s `archivedAt` field."""
   archivedAt: Datetime
+
+  """Checks for equality with the object’s `isDeleted` field."""
+  isDeleted: Boolean
+
+  """Checks for equality with the object’s `deletedBy` field."""
+  deletedBy: Int
+
+  """Checks for equality with the object’s `deletedAt` field."""
+  deletedAt: Datetime
 }
 
 """A `Application` edge in the connection."""
@@ -1803,9 +1803,6 @@ type CreateAttachmentPayload {
   applicationStatusByApplicationStatusId: ApplicationStatus
 
   """Reads a single `CcbcUser` that is related to this `Attachment`."""
-  ccbcUserByDeletedBy: CcbcUser
-
-  """Reads a single `CcbcUser` that is related to this `Attachment`."""
   ccbcUserByCreatedBy: CcbcUser
 
   """Reads a single `CcbcUser` that is related to this `Attachment`."""
@@ -1813,6 +1810,9 @@ type CreateAttachmentPayload {
 
   """Reads a single `CcbcUser` that is related to this `Attachment`."""
   ccbcUserByArchivedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `Attachment`."""
+  ccbcUserByDeletedBy: CcbcUser
 
   """An edge for our `Attachment`. May be used by Relay 1."""
   attachmentEdge(
@@ -1862,15 +1862,6 @@ input AttachmentInput {
   """
   applicationStatusId: Int
 
-  """Boolean declaring if the file has been soft deleted"""
-  isDeleted: Boolean
-
-  """The id of the user that deleted the file"""
-  deletedBy: Int
-
-  """The time the file was deleted at"""
-  deletedAt: Datetime
-
   """created by user id"""
   createdBy: Int
 
@@ -1888,6 +1879,15 @@ input AttachmentInput {
 
   """archived at timestamp"""
   archivedAt: Datetime
+
+  """Boolean declaring if the file has been soft deleted"""
+  isDeleted: Boolean
+
+  """The id of the user that deleted the file"""
+  deletedBy: Int
+
+  """The time the file was deleted at"""
+  deletedAt: Datetime
 }
 
 """The `Upload` scalar type represents a file upload."""
@@ -2197,9 +2197,6 @@ type UpdateAttachmentPayload {
   applicationStatusByApplicationStatusId: ApplicationStatus
 
   """Reads a single `CcbcUser` that is related to this `Attachment`."""
-  ccbcUserByDeletedBy: CcbcUser
-
-  """Reads a single `CcbcUser` that is related to this `Attachment`."""
   ccbcUserByCreatedBy: CcbcUser
 
   """Reads a single `CcbcUser` that is related to this `Attachment`."""
@@ -2207,6 +2204,9 @@ type UpdateAttachmentPayload {
 
   """Reads a single `CcbcUser` that is related to this `Attachment`."""
   ccbcUserByArchivedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `Attachment`."""
+  ccbcUserByDeletedBy: CcbcUser
 
   """An edge for our `Attachment`. May be used by Relay 1."""
   attachmentEdge(
@@ -2265,15 +2265,6 @@ input AttachmentPatch {
   """
   applicationStatusId: Int
 
-  """Boolean declaring if the file has been soft deleted"""
-  isDeleted: Boolean
-
-  """The id of the user that deleted the file"""
-  deletedBy: Int
-
-  """The time the file was deleted at"""
-  deletedAt: Datetime
-
   """created by user id"""
   createdBy: Int
 
@@ -2291,6 +2282,15 @@ input AttachmentPatch {
 
   """archived at timestamp"""
   archivedAt: Datetime
+
+  """Boolean declaring if the file has been soft deleted"""
+  isDeleted: Boolean
+
+  """The id of the user that deleted the file"""
+  deletedBy: Int
+
+  """The time the file was deleted at"""
+  deletedAt: Datetime
 }
 
 """All input for the `updateAttachmentByRowId` mutation."""
@@ -2559,9 +2559,6 @@ type DeleteAttachmentPayload {
   applicationStatusByApplicationStatusId: ApplicationStatus
 
   """Reads a single `CcbcUser` that is related to this `Attachment`."""
-  ccbcUserByDeletedBy: CcbcUser
-
-  """Reads a single `CcbcUser` that is related to this `Attachment`."""
   ccbcUserByCreatedBy: CcbcUser
 
   """Reads a single `CcbcUser` that is related to this `Attachment`."""
@@ -2569,6 +2566,9 @@ type DeleteAttachmentPayload {
 
   """Reads a single `CcbcUser` that is related to this `Attachment`."""
   ccbcUserByArchivedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `Attachment`."""
+  ccbcUserByDeletedBy: CcbcUser
 
   """An edge for our `Attachment`. May be used by Relay 1."""
   attachmentEdge(

--- a/db/deploy/tables/attachment.sql
+++ b/db/deploy/tables/attachment.sql
@@ -13,10 +13,7 @@ create table ccbc_public.attachment
   file_type varchar(100),
   file_size varchar(100),
   application_id integer not null references ccbc_public.applications(id),
-  application_status_id integer references ccbc_public.application_status(id),
-  is_deleted boolean not null default false,
-  deleted_by int references ccbc_public.ccbc_user,
-  deleted_at TIMESTAMP
+  application_status_id integer references ccbc_public.application_status(id)
 );
 
 select ccbc_private.upsert_timestamp_columns('ccbc_public', 'attachment');
@@ -46,8 +43,5 @@ comment on column ccbc_public.attachment.file_type is 'Original uploaded file ty
 comment on column ccbc_public.attachment.file_size is 'Original uploaded file size';
 comment on column ccbc_public.attachment.application_id is 'The id of the project (ccbc_public.application.id) that the attachment was uploaded to';
 comment on column ccbc_public.attachment.application_status_id is 'The id of the application_status (ccbc_public.application_status.id) that the attachment references';
-comment on column ccbc_public.attachment.is_deleted is 'Boolean declaring if the file has been soft deleted';
-comment on column ccbc_public.attachment.deleted_by is 'The id of the user that deleted the file';
-comment on column ccbc_public.attachment.deleted_at is 'The time the file was deleted at';
 
 commit;

--- a/db/deploy/tables/attachment_001.sql
+++ b/db/deploy/tables/attachment_001.sql
@@ -1,0 +1,14 @@
+-- Deploy ggircs-portal:tables/application_002 to pg
+-- requires: tables/application
+
+begin;
+
+alter table ccbc_public.attachment add column is_deleted boolean not null default false;
+alter table ccbc_public.attachment add column deleted_by int references ccbc_public.ccbc_user;
+alter table ccbc_public.attachment add column deleted_at TIMESTAMP;
+
+comment on column ccbc_public.attachment.is_deleted is 'Boolean declaring if the file has been soft deleted';
+comment on column ccbc_public.attachment.deleted_by is 'The id of the user that deleted the file';
+comment on column ccbc_public.attachment.deleted_at is 'The time the file was deleted at';
+
+commit;

--- a/db/revert/tables/attachment_001.sql
+++ b/db/revert/tables/attachment_001.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:tables/attachment_001 from pg
+
+BEGIN;
+
+-- XXX Add DDLs here.
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -21,3 +21,4 @@ tables/attachment 2022-07-07T23:19:04Z Marcel Mueller,,, <marcel@Thinkpad> # add
 functions/expose_application_name 2022-07-15T16:39:24Z Anthony Bushara <anthony@button.is> # Exposes Application Name as Computed Column
 tables/applications/remove_unique_owner 2022-07-19T14:44:25Z Anthony Bushara <anthony@button.is> # Removes unique constraint for owner
 tables/applications/owner_not_null 2022-07-20T15:51:46Z Anthony Bushara <anthony@button.is> # Owner of the application cannot be null
+tables/attachment_001 2022-07-26T22:32:51Z Marcel Mueller,,, <marcel@Thinkpad> # add columns to attachment

--- a/db/verify/tables/attachment_001.sql
+++ b/db/verify/tables/attachment_001.sql
@@ -1,0 +1,7 @@
+-- Verify ccbc:tables/attachment_001 on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;


### PR DESCRIPTION
Added some new columns to `attachment` table and sqitch didn't know about them. Instead of rebasing I am trying a way that Dylan suggested that will be good if we have to add columns when in prod. Basically make a numbered file in sqitch `attachment_001` `with alter table add column` and add to sqitch plan.

I tested pushing this to dev so it works, will need to merge in so we can deploy db to dev again (sorry I didn't know a better way).