### PR TITLE
show Dashboard link only for logged in

### DIFF
--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -63,10 +63,14 @@ const Navigation: React.FC<Props> = ({ isLoggedIn = false, title = '' }) => {
             <h1>{title}</h1>
           </StyledMainTitle>
           <StyledRightSideLinks>
+            {isLoggedIn &&
+            <>
             <Link passHref href="/dashboard">
               <StyledAnchor>Dashboard</StyledAnchor>
             </Link>
             |
+            </>
+            }            
             <NavLoginForm
               action={isLoggedIn ? '/logout' : '/login'}
               linkText={isLoggedIn ? 'Logout' : 'Login'}

--- a/app/cypress/integration/index.spec.js
+++ b/app/cypress/integration/index.spec.js
@@ -53,7 +53,6 @@ context('Homepage', () => {
   it('should render the header', () => {
     cy.get('header').contains('Help');
     cy.get('header').get('.banner').find('img');
-    cy.get('.pg-menu-group').find('a').contains('Dashboard');
     cy.get('.pg-menu-group').find('form').get('button').contains('Login');
   });
 


### PR DESCRIPTION
Hide `Dashboard` link in the header for un-authenticated users