### PR TITLE
314 dynamic intakes on pages

### DIFF
--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -9,10 +9,6 @@ import { schemaToSubschemasArray } from '../../utils/schemaUtils';
 import { Review } from '../Review';
 import { acknowledgements } from '../../formSchema/pages';
 
-const NUM_ACKNOWLEDGEMENTS =
-  acknowledgements.acknowledgements.properties.acknowledgementsList.items.enum
-    .length;
-
 // https://github.com/rjsf-team/react-jsonschema-form/issues/2131
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -31,12 +27,21 @@ import { updateApplicationMutation } from '__generated__/updateApplicationMutati
 import ApplicationFormStatus from './ApplicationFormStatus';
 import styled from 'styled-components';
 import { ApplicationForm_query$key } from '__generated__/ApplicationForm_query.graphql';
+import { SubmissionDescriptionField } from 'lib/theme/fields';
+
+const NUM_ACKNOWLEDGEMENTS =
+  acknowledgements.acknowledgements.properties.acknowledgementsList.items.enum
+    .length;
 
 const customPages = [
   'estimatedProjectEmployment',
   'acknowledgements',
   'submission',
 ];
+
+const CUSTOM_SUBMISSION_FIELD = {
+  SubmissionField: SubmissionDescriptionField
+}
 
 const formatErrorSchema = (formData, schema) => {
   const errorSchema = validateFormData(formData, schema)?.errorSchema;
@@ -381,7 +386,9 @@ const ApplicationForm: React.FC<Props> = ({
         onCalculate={updateAreAllSubmissionFieldsSet}
         formData={formData[sectionName]}
         schema={sectionSchema}
-        uiSchema={uiSchema}
+        uiSchema={uiSchema[sectionName]}
+        fields={CUSTOM_SUBMISSION_FIELD}
+        formContext={formContext}
         noValidate={true}
         disabled={status === 'withdrawn'}
       >

--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -354,6 +354,7 @@ const ApplicationForm: React.FC<Props> = ({
         // Facing rendering issues, key here to allow react to identify a new component
         key="estimatedProjectEmployment"
         onSubmit={handleSubmit}
+        onChange={handleChange}
         onCalculate={(formData: CalculatedFieldJSON) => calculate(formData)}
         formData={formData[sectionName]}
         schema={sectionSchema}
@@ -369,6 +370,7 @@ const ApplicationForm: React.FC<Props> = ({
       <CalculationForm
         key="acknowledgements"
         onSubmit={handleSubmit}
+        onChange={handleChange}
         onCalculate={updateAreAllAcknowledgementFieldsSet}
         formData={formData[sectionName]}
         schema={sectionSchema}
@@ -383,6 +385,7 @@ const ApplicationForm: React.FC<Props> = ({
       <CalculationForm
         key="submission"
         onSubmit={handleSubmit}
+        onChange={handleChange}
         onCalculate={updateAreAllSubmissionFieldsSet}
         formData={formData[sectionName]}
         schema={sectionSchema}

--- a/app/components/Review/ReviewField.tsx
+++ b/app/components/Review/ReviewField.tsx
@@ -1,0 +1,25 @@
+import { FieldProps } from '@rjsf/core';
+import { DateTime } from 'luxon';
+
+const ReviewField: React.FC<FieldProps> = (props) => {
+  const {
+    formContext: { intakeCloseTimestamp },
+  } = props;
+
+  return (
+    <>
+      <p>
+        Please ensure your responses are accurate. You may continue to edit your
+        application after marking it as Ready for Assessment until the intake
+        closes on{' '}
+        {DateTime.fromISO(intakeCloseTimestamp, {
+          locale: 'en-CA',
+          zone: 'America/Vancouver',
+        }).toLocaleString(DateTime.DATETIME_FULL)}
+        .
+      </p>
+    </>
+  );
+};
+
+export default ReviewField;

--- a/app/components/Review/index.ts
+++ b/app/components/Review/index.ts
@@ -7,3 +7,4 @@ export { default as ProjectFundingTable } from './ProjectFundingTable';
 export { default as ProjectAreaTable } from './ProjectAreaTable';
 export { default as Review } from './Review';
 export { default as Table } from './Table';
+export { default as ReviewField } from './ReviewField'

--- a/app/formSchema/pages/review.ts
+++ b/app/formSchema/pages/review.ts
@@ -1,9 +1,7 @@
 const review = {
   review: {
-    title: 'Review',
     type: 'object',
-    description:
-      'Please ensure your responses are accurate. You may continue to edit your application after marking it as Ready for Assessment until the intake closes on [YYYY/MM/DD].',
+    title: 'Review'
   },
 };
 

--- a/app/formSchema/pages/submission.ts
+++ b/app/formSchema/pages/submission.ts
@@ -1,8 +1,7 @@
 const submission = {
   submission: {
     title: 'Submission',
-    description:
-      'Certify that you have the authority to submit this information on behalf of the Applicant. After submission, you can continue to edit this application until the intake closes on November 6, 2022 at 9:00AM Pacific Time (PT)',
+    // description is rendered and stored in the SubmissionField.tsx
     type: 'object',
     required: [
       'submissionCompletedFor',

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -424,9 +424,7 @@ const uiSchema = {
     'ui:title': ` `,
     'ui:widget': 'CheckboxesWidget',
   },
-  submissionDate: {
-    'ui:widget': 'DatePickerWidget',
-  },
+
   backboneTechnology: {
     'ui:widget': 'CheckboxesWidget',
     'ui:options': {
@@ -887,10 +885,13 @@ const uiSchema = {
     },
   },
   review: {
-    'ui:field': 'ReviewField'
+    'ui:field': 'ReviewField',
   },
   submission: {
-    "ui:field": 'SubmissionField'
+    'ui:field': 'SubmissionField',
+    submissionDate: {
+      'ui:widget': 'DatePickerWidget',
+    },
   },
   'ui:inline': [
     // Each object is a row for inline grid elements. Set the number of columns with column key

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -886,6 +886,9 @@ const uiSchema = {
       ignoreOptional: true,
     },
   },
+  review: {
+    'ui:field': 'ReviewField'
+  },
   'ui:inline': [
     // Each object is a row for inline grid elements. Set the number of columns with column key
     // and the field key value is the gridColumn value

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -889,6 +889,9 @@ const uiSchema = {
   review: {
     'ui:field': 'ReviewField'
   },
+  submission: {
+    "ui:field": 'SubmissionField'
+  },
   'ui:inline': [
     // Each object is a row for inline grid elements. Set the number of columns with column key
     // and the field key value is the gridColumn value

--- a/app/lib/theme/FormWithTheme.tsx
+++ b/app/lib/theme/FormWithTheme.tsx
@@ -12,6 +12,7 @@ import {
   TextWidget,
   SelectWidget,
 } from './widgets';
+import { ReviewField } from 'components/Review';
 
 const { fields, widgets } = utils.getDefaultRegistry();
 
@@ -19,6 +20,7 @@ const formTheme: ThemeProps = {
   fields: {
     ...fields,
     DescriptionField: DescriptionField,
+    ReviewField: ReviewField
   },
   widgets: {
     ...widgets,

--- a/app/lib/theme/fields/SubmissionDescriptionField.tsx
+++ b/app/lib/theme/fields/SubmissionDescriptionField.tsx
@@ -1,0 +1,44 @@
+import { FieldProps } from '@rjsf/core';
+import { DateTime } from 'luxon';
+
+/*
+ In a perfect world, the old spec that was passed the formContext to the 
+ to the DescriptionField would've been used, but that was removed at one point.
+ 
+ Now, as far as I can tell, this is probably the easier way to do this without
+ having to refactor with relay like in the ciip project. 
+*/
+const SubmissionField: React.FC<FieldProps> = (props) => {
+  const {
+    formContext: { intakeCloseTimestamp },
+    schema,
+    registry,
+  } = props;
+
+  //Remove the title so it isn't rendered twice.
+  const submissionSchemaWithoutTitle = {...schema}
+  delete submissionSchemaWithoutTitle.title
+  const ObjectField = registry.fields.ObjectField;
+  const DescriptionField = registry.fields.DescriptionField;
+
+  const submissionDescriptionText = `Certify that you have the authority to submit this information on behalf of the Applicant. After submission, you can continue to edit this application until the intake closes on ${DateTime.fromISO(
+    intakeCloseTimestamp,
+    {
+      locale: 'en-CA',
+      zone: 'America/Vancouver',
+    }
+  ).toLocaleString(DateTime.DATETIME_FULL)}`;
+
+  return (
+    <>
+    {/* wrapping in an h3 to mimic behaviour in the current object renderer */}
+    <h3>
+      <DescriptionField {...props} description={submissionDescriptionText} />
+    </h3>
+
+      <ObjectField {...props} schema={submissionSchemaWithoutTitle} />
+    </>
+  );
+};
+
+export default SubmissionField;

--- a/app/lib/theme/fields/index.ts
+++ b/app/lib/theme/fields/index.ts
@@ -1,2 +1,3 @@
 export { default as ArrayFieldTemplate } from './ArrayFieldTemplate';
 export { default as DescriptionField } from './DescriptionField';
+export { default as SubmissionDescriptionField } from './SubmissionDescriptionField';

--- a/app/pages/dashboard.tsx
+++ b/app/pages/dashboard.tsx
@@ -9,6 +9,7 @@ import { useCreateApplicationMutation } from '../schema/mutations/application/cr
 import { Layout } from '../components';
 import { DashboardTable } from '../components/Dashboard';
 import { dashboardQuery } from '../__generated__/dashboardQuery.graphql';
+import { DateTime } from 'luxon';
 
 const getDashboardQuery = graphql`
   query dashboardQuery($formOwner: ApplicationCondition!) {
@@ -32,12 +33,19 @@ const getDashboardQuery = graphql`
     session {
       sub
     }
+    openIntake {
+      closeTimestamp
+    }
   }
 `;
 // eslint-disable-next-line @typescript-eslint/ban-types
 const Dashboard = ({ preloadedQuery }: RelayProps<{}, dashboardQuery>) => {
   const query = usePreloadedQuery(getDashboardQuery, preloadedQuery);
-  const { allApplications, session } = query;
+  const {
+    allApplications,
+    session,
+    openIntake: { closeTimestamp },
+  } = query;
 
   const trimmedSub: string = session?.sub.replace(/-/g, '');
 
@@ -75,7 +83,11 @@ const Dashboard = ({ preloadedQuery }: RelayProps<{}, dashboardQuery>) => {
         <h1>Dashboard</h1>
         <p>
           Start a new application; applications can be saved and edited until
-          the intake closes on YYYY/MM/DD
+          the intake closes on{' '}
+          {DateTime.fromISO(closeTimestamp, {
+            locale: 'en-CA',
+            zone: 'America/Vancouver',
+          }).toLocaleString(DateTime.DATETIME_FULL)}
         </p>
         <StyledGovButton onClick={handleCreateApplication}>
           New application

--- a/app/pages/dashboard.tsx
+++ b/app/pages/dashboard.tsx
@@ -41,11 +41,9 @@ const getDashboardQuery = graphql`
 // eslint-disable-next-line @typescript-eslint/ban-types
 const Dashboard = ({ preloadedQuery }: RelayProps<{}, dashboardQuery>) => {
   const query = usePreloadedQuery(getDashboardQuery, preloadedQuery);
-  const {
-    allApplications,
-    session,
-    openIntake: { closeTimestamp },
-  } = query;
+  const { allApplications, session, openIntake } = query;
+
+  const closeTimestamp = openIntake?.closeTimestamp;
 
   const trimmedSub: string = session?.sub.replace(/-/g, '');
 
@@ -81,14 +79,18 @@ const Dashboard = ({ preloadedQuery }: RelayProps<{}, dashboardQuery>) => {
     <Layout session={session} title="Connecting Communities BC">
       <div>
         <h1>Dashboard</h1>
-        <p>
-          Start a new application; applications can be saved and edited until
-          the intake closes on{' '}
-          {DateTime.fromISO(closeTimestamp, {
-            locale: 'en-CA',
-            zone: 'America/Vancouver',
-          }).toLocaleString(DateTime.DATETIME_FULL)}
-        </p>
+        {closeTimestamp ? (
+          <p>
+            Start a new application; applications can be saved and edited until
+            the intake closes on{' '}
+            {DateTime.fromISO(closeTimestamp, {
+              locale: 'en-CA',
+              zone: 'America/Vancouver',
+            }).toLocaleString(DateTime.DATETIME_FULL)}
+          </p>
+        ) : (
+          <p>There are no currently open intakes.</p>
+        )}
         <StyledGovButton onClick={handleCreateApplication}>
           New application
         </StyledGovButton>

--- a/app/pages/form/[id]/[page].tsx
+++ b/app/pages/form/[id]/[page].tsx
@@ -27,6 +27,7 @@ const getPageQuery = graphql`
     session {
       sub
     }
+    ...ApplicationForm_query
   }
 `;
 
@@ -54,6 +55,7 @@ const FormPage = ({ preloadedQuery }: RelayProps<{}, PageQuery>) => {
         <ApplicationForm
           pageNumber={pageNumber}
           application={applicationByRowId}
+          query={query}
         />
       </FormDiv>
     </Layout>

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -39,7 +39,6 @@ const Home = ({ preloadedQuery }: RelayProps<{}, pagesQuery>) => {
     getPagesQuery,
     preloadedQuery
   );
-  console.log(openIntake)
 
   return (
     <Layout session={session} title="Connecting Communities BC">
@@ -124,9 +123,9 @@ const Home = ({ preloadedQuery }: RelayProps<{}, pagesQuery>) => {
                   locale: 'en-CA',
                   zone: 'America/Vancouver',
                 }).toLocaleString(DateTime.DATETIME_FULL)
-              : 'November 6 at 9:00 AM Pacific Time (PT)'}.
-            The CCBC anticipates opening additional future intakes for receiving
-            applications and will update this date accordingly.
+              : 'November 6 at 9:00 AM Pacific Time (PT)'}
+            . The CCBC anticipates opening additional future intakes for
+            receiving applications and will update this date accordingly.
           </li>
         </ul>
         <h3>Get started</h3>

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -6,6 +6,7 @@ import defaultRelayOptions from '../lib/relay/withRelayOptions';
 import { ButtonLink, Layout } from '../components';
 import styled from 'styled-components';
 import { pagesQuery } from '../__generated__/pagesQuery.graphql';
+import { dateTimeFormat } from 'lib/theme/functions/formatDates';
 
 const StyledOl = styled('ol')`
   max-width: 300px;
@@ -25,12 +26,19 @@ const getPagesQuery = graphql`
     session {
       sub
     }
+    openIntake {
+      openTimestamp
+      closeTimestamp
+    }
   }
 `;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 const Home = ({ preloadedQuery }: RelayProps<{}, pagesQuery>) => {
-  const { session } = usePreloadedQuery(getPagesQuery, preloadedQuery);
+  const { session, openIntake } = usePreloadedQuery(
+    getPagesQuery,
+    preloadedQuery
+  );
 
   return (
     <Layout session={session} title="Connecting Communities BC">
@@ -102,9 +110,13 @@ const Home = ({ preloadedQuery }: RelayProps<{}, pagesQuery>) => {
           </li>
           <li>All questions are mandatory unless indicated otherwise.</li>
           <li>
-            The application intake opens on MM/DD/YYYY at 12:00 AM Pacific Time
-            (PT) and closes on MM/DD/YYYY at midnight Pacific Time (PT). The
-            CCBC anticipates opening additional future intakes for receiving
+            The application intake opens on{' '}
+            {dateTimeFormat(openIntake.openTimestamp, 'date_year_first')} at{' '}
+            {dateTimeFormat(openIntake.openTimestamp, 'minutes_time_only')} and
+            closes on{' '}
+            {dateTimeFormat(openIntake.closeTimestamp, 'date_year_first')} at{' '}
+            {dateTimeFormat(openIntake.closeTimestamp, 'minutes_time_only')}.
+            The CCBC anticipates opening additional future intakes for receiving
             applications and will update this date accordingly.
           </li>
         </ul>

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -6,7 +6,7 @@ import defaultRelayOptions from '../lib/relay/withRelayOptions';
 import { ButtonLink, Layout } from '../components';
 import styled from 'styled-components';
 import { pagesQuery } from '../__generated__/pagesQuery.graphql';
-import { dateTimeFormat } from 'lib/theme/functions/formatDates';
+import { DateTime } from 'luxon';
 
 const StyledOl = styled('ol')`
   max-width: 300px;
@@ -39,6 +39,7 @@ const Home = ({ preloadedQuery }: RelayProps<{}, pagesQuery>) => {
     getPagesQuery,
     preloadedQuery
   );
+  console.log(openIntake)
 
   return (
     <Layout session={session} title="Connecting Communities BC">
@@ -111,11 +112,19 @@ const Home = ({ preloadedQuery }: RelayProps<{}, pagesQuery>) => {
           <li>All questions are mandatory unless indicated otherwise.</li>
           <li>
             The application intake opens on{' '}
-            {dateTimeFormat(openIntake.openTimestamp, 'date_year_first')} at{' '}
-            {dateTimeFormat(openIntake.openTimestamp, 'minutes_time_only')} and
-            closes on{' '}
-            {dateTimeFormat(openIntake.closeTimestamp, 'date_year_first')} at{' '}
-            {dateTimeFormat(openIntake.closeTimestamp, 'minutes_time_only')}.
+            {openIntake
+              ? DateTime.fromISO(openIntake.openTimestamp, {
+                  locale: 'en-CA',
+                  zone: 'America/Vancouver',
+                }).toLocaleString(DateTime.DATETIME_FULL)
+              : 'September 7 at 9:00 AM Pacific Time (PT)'}{' '}
+            and closes on{' '}
+            {openIntake
+              ? DateTime.fromISO(openIntake.closeTimestamp, {
+                  locale: 'en-CA',
+                  zone: 'America/Vancouver',
+                }).toLocaleString(DateTime.DATETIME_FULL)
+              : 'November 6 at 9:00 AM Pacific Time (PT)'}.
             The CCBC anticipates opening additional future intakes for receiving
             applications and will update this date accordingly.
           </li>

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -196,6 +196,9 @@ type Query implements Node {
   attachmentByRowId(rowId: Int!): Attachment
   ccbcUserByRowId(rowId: Int!): CcbcUser
   intakeByRowId(rowId: Int!): Intake
+
+  """Returns the current open intake"""
+  openIntake: Intake
   session: KeycloakJwt
 
   """Reads a single `ApplicationStatus` using its globally unique `ID`."""

--- a/app/tests/components/Form/ApplicationForm.test.tsx
+++ b/app/tests/components/Form/ApplicationForm.test.tsx
@@ -14,6 +14,10 @@ const testQuery = graphql`
     application(id: "TestApplicationID") {
       ...ApplicationForm_application
     }
+
+    query {
+      ...ApplicationForm_query
+    }
   }
 `;
 
@@ -22,6 +26,13 @@ const mockQueryPayload = {
     return {
       id: 'TestApplicationID',
       formData: {},
+    };
+  },
+  Query() {
+    return {
+      openIntake: {
+        closeTimestamp: '2022-08-27T12:51:26.69172-04:00',
+      },
     };
   },
 };
@@ -35,6 +46,7 @@ const componentTestingHelper =
     getPropsFromTestQuery: (data) => ({
       application: data.application,
       pageNumber: 1,
+      query: data.query,
     }),
   });
 
@@ -92,6 +104,7 @@ describe('The application form', () => {
     componentTestingHelper.renderComponent((data) => ({
       application: data.application,
       pageNumber: 20,
+      query: data.query,
     }));
 
     const continueButton = screen.getByRole('button', {
@@ -106,6 +119,7 @@ describe('The application form', () => {
     componentTestingHelper.renderComponent((data) => ({
       application: data.application,
       pageNumber: 20,
+      query: data.query,
     }));
 
     const checkBoxes = screen.getAllByRole('checkbox');
@@ -132,6 +146,7 @@ describe('The application form', () => {
     componentTestingHelper.renderComponent((data) => ({
       application: data.application,
       pageNumber: 21,
+      query: data.query,
     }));
 
     const completedFor = screen.getByLabelText(/Completed for/i);
@@ -170,6 +185,7 @@ describe('The application form', () => {
     componentTestingHelper.renderComponent((data) => ({
       application: data.application,
       pageNumber: 21,
+      query: data.query,
     }));
 
     expect(
@@ -198,6 +214,7 @@ describe('The application form', () => {
     componentTestingHelper.renderComponent((data) => ({
       application: data.application,
       pageNumber: 21,
+      query: data.query,
     }));
 
     await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
@@ -242,5 +259,32 @@ describe('The application form', () => {
     expect(componentTestingHelper.router.push).toHaveBeenCalledWith(
       '/form/42/success'
     );
+  });
+
+  it('Review page contains submission date from DB', async () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent((data) => ({
+      application: data.application,
+      pageNumber: 19,
+      query: data.query,
+    }));
+
+    expect(
+      screen.getByText(/August 27, 2022, 9:51 a.m. PDT/)
+    ).toBeInTheDocument();
+  });
+
+  it('Submission page contains submission date from DB', async () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent((data) => ({
+      application: data.application,
+      pageNumber: 21,
+      query: data.query,
+    }));
+
+    // luxon renders this differently in test?
+    expect(
+      screen.getByText(/August 27, 2022, 9:51 a.m. PDT/)
+    ).toBeInTheDocument();
   });
 });

--- a/app/tests/pages/dashboard.test.tsx
+++ b/app/tests/pages/dashboard.test.tsx
@@ -31,6 +31,9 @@ const mockQueryPayload = {
       session: {
         sub: '4e0ac88c-bf05-49ac-948f-7fd53c7a9fd6',
       },
+      openIntake: {
+        closeTimestamp: '2022-08-27T12:51:26.69172-04:00',
+      },
     };
   },
 };
@@ -65,5 +68,13 @@ describe('The index page', () => {
         destination: '/',
       },
     });
+  });
+
+  
+  it('Renders the close date', () => {
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    expect(screen.getByText(/August 27, 2022, 9:51 a.m. PDT/)).toBeInTheDocument();
   });
 });

--- a/app/tests/pages/index.test.tsx
+++ b/app/tests/pages/index.test.tsx
@@ -38,8 +38,8 @@ describe('The index page', () => {
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
     
-    expect(screen.getByText(/2022-08-17 at 09:51 AM \(PDT\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/August 17, 2022, 9:51 a\.m\. PDT/i)).toBeInTheDocument();
 
-    expect(screen.getByText(/2022-08-27 at 09:51 AM \(PDT\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/August 27, 2022, 9:51 a\.m\. PDT/i)).toBeInTheDocument();
   })
 });

--- a/app/tests/pages/index.test.tsx
+++ b/app/tests/pages/index.test.tsx
@@ -1,4 +1,28 @@
 import { withRelayOptions } from '../../pages';
+import {screen} from '@testing-library/react'
+import PageTestingHelper from '../utils/pageTestingHelper';
+import Home from '../../pages/index';
+import compiledPagesQuery,{ pagesQuery } from '__generated__/pagesQuery.graphql';
+
+const mockQueryPayload = {
+  Query() {
+    return {
+      session: {
+        sub: '4e0ac88c-bf05-49ac-948f-7fd53c7a9fd6',
+      },
+      openIntake: {
+        openTimestamp: '2022-08-17T12:51:26.69172-04:00',
+        closeTimestamp: '2022-08-27T12:51:26.69172-04:00',
+      },
+    };
+  },
+};
+
+const pageTestingHelper = new PageTestingHelper<pagesQuery>({
+  pageComponent: Home,
+  compiledQuery: compiledPagesQuery,
+  defaultQueryResolver: mockQueryPayload
+})
 
 describe('The index page', () => {
   it('does not redirect an unauthorized user', async () => {
@@ -9,4 +33,13 @@ describe('The index page', () => {
     } as any;
     expect(await withRelayOptions.serverSideProps(ctx)).toEqual({});
   });
+
+  it('Displays open and close intake days', async () => {
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+    
+    expect(screen.getByText(/2022-08-17 at 09:51 AM \(PDT\)/i)).toBeInTheDocument();
+
+    expect(screen.getByText(/2022-08-27 at 09:51 AM \(PDT\)/i)).toBeInTheDocument();
+  })
 });

--- a/db/deploy/functions/add_ccbc_id.sql
+++ b/db/deploy/functions/add_ccbc_id.sql
@@ -23,18 +23,18 @@ BEGIN
     select id, ccbc_intake_number into current_intake_fk,  _ccbc_intake_number from ccbc_public.intake where current_timestamp >= open_timestamp  AND current_timestamp <= close_timestamp;
 
 
-    IF current_intake_fk is null THEN
-        -- [VB] use hardcoded intake number for now and backfill intake table
-        -- development intake - need it to unblock development
-        INSERT INTO ccbc_public.intake(open_timestamp, close_timestamp, ccbc_intake_number) 
-        VALUES ('2022-07-25 00:00:00','2022-09-06 23:59:59', 1);
+    -- IF current_intake_fk is null THEN
+    --     -- [VB] use hardcoded intake number for now and backfill intake table
+    --     -- development intake - need it to unblock development
+    --     -- INSERT INTO ccbc_public.intake(open_timestamp, close_timestamp, ccbc_intake_number) 
+    --     -- VALUES ('2022-07-25 09:00:00 America/Vancouver','2022-11-06 09:00:00 America/Vancouver', 1);
 
-        -- real intake
-        INSERT INTO ccbc_public.intake(open_timestamp, close_timestamp, ccbc_intake_number) 
-        VALUES ('2022-09-07 00:00:00','2022-11-06 23:59:59', 2);
-        current_intake_fk := 1;
-        _ccbc_intake_number := 1;
-    END IF;
+    --     -- real intake
+    --     -- INSERT INTO ccbc_public.intake(open_timestamp, close_timestamp, ccbc_intake_number) 
+    --     -- VALUES ('2022-09-07 09:00:00 America/Vancouver','2022-11-06 09:00:00 America/Vancouver', 2);
+    --     current_intake_fk := 1;
+    --     _ccbc_intake_number := 1;
+    -- END IF;
 
     IF current_intake_fk is null THEN
         RAISE 'There are no available intakes';

--- a/db/deploy/functions/open_intake.sql
+++ b/db/deploy/functions/open_intake.sql
@@ -1,0 +1,14 @@
+-- Deploy ccbc:functions/open_intake to pg
+
+BEGIN;
+
+create or replace function ccbc_public.open_intake() returns ccbc_public.intake as 
+$function$
+ select * from ccbc_public.intake where now() >= open_timestamp and now() <= close_timestamp;
+$function$ language sql stable;
+
+grant execute on function ccbc_public.open_intake to ccbc_guest, ccbc_auth_user;
+
+comment on function ccbc_public.open_intake is 'Returns the current open intake';
+
+COMMIT;

--- a/db/deploy/tables/add_intake_table.sql
+++ b/db/deploy/tables/add_intake_table.sql
@@ -19,6 +19,7 @@ begin
 perform ccbc_private.grant_permissions('select', 'intake', 'ccbc_auth_user');
 perform ccbc_private.grant_permissions('insert', 'intake', 'ccbc_auth_user');
 perform ccbc_private.grant_permissions('update', 'intake', 'ccbc_auth_user');
+perform ccbc_private.grant_permissions('select', 'intake', 'ccbc_guest');
 
 end
 $grant$;

--- a/db/deploy/tables/add_intake_table.sql
+++ b/db/deploy/tables/add_intake_table.sql
@@ -12,6 +12,9 @@ CREATE TABLE ccbc_public.intake(
 select ccbc_private.upsert_timestamp_columns('ccbc_public', 'intake');
 create unique index ccbc_intake_number on ccbc_public.intake(ccbc_intake_number);
 
+INSERT INTO ccbc_public.intake(open_timestamp, close_timestamp, ccbc_intake_number) 
+VALUES ('2022-08-19 09:00:00 America/Vancouver','2022-11-06 09:00:00 America/Vancouver', 1);
+
 do
 $grant$
 begin

--- a/db/revert/functions/open_intake.sql
+++ b/db/revert/functions/open_intake.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:functions/open_intake from pg
+
+BEGIN;
+
+drop function ccbc_public.open_intake;
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -28,3 +28,4 @@ functions/ccbc_id_computed_column 2022-07-28T14:18:09Z Anthony Bushara <anthony@
 functions/add_ccbc_id 2022-07-27T14:05:20Z Anthony Bushara <anthony@button.is> # Creates function to add a ccbc id to an application as well as expose it as a computed column
 tables/applications_001 2022-08-03T19:33:26Z Marcel Mueller,,, <marcel@Thinkpad> # add column to applications
 views/applications_view 2022-08-17T20:50:30Z ,,, <vb@vbpro> # Adding view
+functions/open_intake 2022-08-16T13:48:54Z Anthony Bushara <anthony@button.is> # Function to display the current open intake

--- a/db/test/unit/functions/open_intake_test.sql
+++ b/db/test/unit/functions/open_intake_test.sql
@@ -1,0 +1,62 @@
+BEGIN;
+
+SELECT plan(4);
+
+SELECT has_function('ccbc_public', 'open_intake',
+ 'function ccbc_public.open_intake exists');
+
+-- setup intake table, since there is no guarantee that an intake will be available when running the test
+
+DELETE FROM ccbc_public.intake;
+
+INSERT INTO ccbc_public.intake 
+    (open_timestamp, close_timestamp, ccbc_intake_number) 
+    VALUES (now(), now() + interval '10 days', 10);
+
+-- ccbc_auth_user
+SET ROLE ccbc_auth_user;
+SELECT concat('current user is: ', (SELECT current_user));
+
+SELECT results_eq(
+    $$
+        SELECT ccbc_intake_number FROM ccbc_public.open_intake();
+    $$
+    , ARRAY[10::int], 
+    'Current intake number is displayed for ccbc_auth_user'
+    );
+
+-- ccbc_guest
+SET ROLE ccbc_guest;
+SELECT concat('current user is: ', (SELECT current_user));
+
+SELECT results_eq(
+    $$
+        SELECT ccbc_intake_number FROM ccbc_public.open_intake();
+    $$
+    , ARRAY[10::int], 
+    'Current intake number is displayed for guest'
+    );
+
+-- no open intakes should return null
+-- set role with enough permissions to delete from intake table
+SET ROLE postgres;
+DELETE FROM ccbc_public.intake;
+
+INSERT INTO ccbc_public.intake 
+    (open_timestamp, close_timestamp, ccbc_intake_number) 
+    VALUES (now() - interval '11 days', now() - interval '2 days', 10);
+
+-- set role back to guest user
+SET ROLE ccbc_guest;
+
+SELECT is(
+    (SELECT ccbc_intake_number FROM ccbc_public.open_intake())
+    ,
+    null
+    ,
+    'Open intake should return null when no intakes are available'
+);
+
+
+SELECT finish();
+ROLLBACK;

--- a/db/verify/functions/open_intake.sql
+++ b/db/verify/functions/open_intake.sql
@@ -1,0 +1,7 @@
+-- Verify ccbc:functions/open_intake on pg
+
+BEGIN;
+
+select pg_get_functiondef('ccbc_public.open_intake()'::regprocedure);
+
+ROLLBACK;


### PR DESCRIPTION
### Description: 

PR to add intake dates that match the real intake dates in the DB.

References 314

### Type of change:

- [X] New feature (non-breaking change which adds functionality)

### Acceptance Criteria: 


## Acceptance criteria

- [ ] Show the intake starting date: September 7, 2022 9:00AM PT
- [x] Show the intake end date: November 6, 2022 9:00AM PT

## Pages affected
- [x] Landing page 
- Current Intake
- [x] Dashboard page 
- Current Intake
- [x] Submission page 
- Draft Status = Current Intake
- Submit Status = My intake
- [x] Submission success page 
- Submit Status = My intake

### Checklist for DoD:
- [x]  Code commented, checked in and ran against current version in source control 
- [x]  Obey “Conventional commits” (https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Code review (https://google.github.io/eng-practices/review/)
- [x]  Peer reviewed (or produced with pair programming) and meeting development standards ([Google](https://google.github.io/eng-practices/review/reviewer/)) 
- [x]  Unit tests are written and passing 
- [x]  Don’t introduce breaking changes. 
- [x]  Don’t (avoid) introducing more tech debt. 
- [x]  Automatic Tests implemented and running 

### Additional Notes:

_(Include any notes you have about this pull request)_
