### PR TITLE
chore: increase netapp file backup volume size

### DIFF
--- a/helm/app/values.yaml
+++ b/helm/app/values.yaml
@@ -112,7 +112,7 @@ pgbackrest:
     cpu: 100m
     memory: 128Mi
   volume:
-    storage: 64Mi
+    storage: 2Gi
     storageClassName: netapp-file-backup
   repoHost:
     requests:


### PR DESCRIPTION
Increases the netapp file backup size from 64Mi to 2Gi