### PR TITLE
fix: filewidget delete empty array validation bug

### DIFF
--- a/app/components/Review/Review.tsx
+++ b/app/components/Review/Review.tsx
@@ -45,21 +45,6 @@ const StyledAlert = styled(Alert)`
   margin-bottom: 32px;
 `;
 
-// Todo: expand/collapse all functionality
-// const StyledExpandDiv = styled('div')`
-//   display: flex;
-//   justify-content: flex-end;
-//   min-width: 100%;
-//   margin: 16px 0;
-// `;
-
-// const StyledExpandButton = styled('button')`
-//   border: none;
-//   background: none;
-//   cursor: pointer;
-//   color: ${(props) => props.theme.color.links};
-// `;
-
 const Review = ({
   formData,
   formErrorSchema,
@@ -68,7 +53,6 @@ const Review = ({
   onReviewConfirm,
   reviewConfirm,
 }: Props) => {
-  // const [expand, setExpand] = useState(false);
   const reviewSchema = [
     'projectInformation',
     'projectArea',
@@ -92,16 +76,6 @@ const Review = ({
 
   return (
     <div>
-      {/* <StyledExpandDiv>
-        <StyledExpandButton
-          onClick={(e) => {
-            e.preventDefault();
-            setExpand(!expand);
-          }}
-        >
-          {!expand ? 'Expand all' : 'Collapse all'}
-        </StyledExpandButton>
-      </StyledExpandDiv> */}
       <StyledAlert
         id="review-alert"
         size="small"

--- a/app/components/Review/Table.tsx
+++ b/app/components/Review/Table.tsx
@@ -85,7 +85,7 @@ const Table = ({ errorSchema, formData, subschema }: any) => {
             if (!value || value.length <= 2) return;
             const uploadArray = JSON.parse(value);
             const string =
-              uploadArray.length > 0 &&
+              uploadArray?.length > 0 &&
               uploadArray.map((file) => file.name).join(',\n');
 
             return string;

--- a/app/lib/theme/widgets/FileWidget.tsx
+++ b/app/lib/theme/widgets/FileWidget.tsx
@@ -95,7 +95,7 @@ const FileWidget: React.FC<WidgetProps> = ({
   const hiddenFileInput = useRef() as MutableRefObject<HTMLInputElement>;
   const allowMultipleFiles = uiSchema['ui:options']?.allowMultipleFiles;
   const acceptedFileTypes = uiSchema['ui:options']?.fileTypes;
-  const isFiles = fileList.length > 0;
+  const isFiles = fileList?.length > 0;
   const loading = isCreatingAttachment || isDeletingAttachment;
 
   // 104857600 bytes = 100mb
@@ -109,8 +109,8 @@ const FileWidget: React.FC<WidgetProps> = ({
 
   useEffect(() => {
     // Update value in RJSF with useEffect instead of handleChange due to async setState delay
-    onChange(JSON.stringify(fileList) || undefined);
-  }, [fileList, onChange]);
+    onChange(isFiles ? JSON.stringify(fileList) : undefined);
+  }, [fileList, isFiles, onChange]);
 
   const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     setError('');
@@ -162,7 +162,9 @@ const FileWidget: React.FC<WidgetProps> = ({
           };
 
           if (allowMultipleFiles) {
-            setFileList((prev) => [...prev, fileDetails]);
+            setFileList((prev) =>
+              prev ? [...prev, fileDetails] : [fileDetails]
+            );
           } else {
             setFileList([fileDetails]);
           }
@@ -194,7 +196,8 @@ const FileWidget: React.FC<WidgetProps> = ({
         });
         const newFileList = [...fileList];
         newFileList.splice(indexOfFile, 1);
-        setFileList(newFileList);
+        const isFileListEmpty = newFileList.length <= 0;
+        setFileList(isFileListEmpty ? null : newFileList);
       },
     });
   };
@@ -226,7 +229,7 @@ const FileWidget: React.FC<WidgetProps> = ({
     <StyledContainer style={{ border: error && '1px solid #E71F1F' }}>
       <StyledDetails>
         <StyledH4>{description}</StyledH4>
-        {fileList.length > 0 &&
+        {isFiles &&
           fileList.map((file: File) => {
             return (
               <StyledFileDiv key={file.uuid}>


### PR DESCRIPTION
Fixes a bug where if a user deletes a file it would still store an empty array in the field, causing required fields to incorrectly validate as filled. This is what caused the missing required field Mars flagged on the review page in this ticket: 

https://app.zenhub.com/workspaces/ccbc---delivery-board-61c0c1204c8bcb001491c5f3/issues/bcgov/conn-ccbc-portal/277