### PR TITLE
421 - error saving

### DIFF
--- a/app/formSchema/pages/alternateContact.ts
+++ b/app/formSchema/pages/alternateContact.ts
@@ -6,7 +6,7 @@ const alternateContact = {
     type: 'object',
     required: [
       'altGivenName',
-      'altPostionTitle',
+      'altPositionTitle',
       'altEmail',
       'altTelephone',
       'isAltContactSigningOfficer',
@@ -20,7 +20,7 @@ const alternateContact = {
         title: 'Given name',
         type: 'string',
       },
-      altPostionTitle: {
+      altPositionTitle: {
         title: 'Position/title',
         type: 'string',
       },

--- a/app/formSchema/pages/authorizedContact.ts
+++ b/app/formSchema/pages/authorizedContact.ts
@@ -6,7 +6,7 @@ const authorizedContact = {
     type: 'object',
     required: [
       'authGivenName',
-      'authPostionTitle',
+      'authPositionTitle',
       'authEmail',
       'authTelephone',
     ],
@@ -19,7 +19,7 @@ const authorizedContact = {
         title: 'Given name',
         type: 'string',
       },
-      authPostionTitle: {
+      authPositionTitle: {
         title: 'Position/title',
         type: 'string',
       },

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -38,14 +38,14 @@ const uiSchema = {
     'contactWebsite',
     'authFamilyName',
     'authGivenName',
-    'authPostionTitle',
+    'authPositionTitle',
     'authEmail',
     'authTelephone',
     'authExtension',
     'isAuthContactSigningOfficer',
     'altFamilyName',
     'altGivenName',
-    'altPostionTitle',
+    'altPositionTitle',
     'altEmail',
     'altTelephone',
     'altExtension',
@@ -282,15 +282,25 @@ const uiSchema = {
       inputType: 'phone',
     },
   },
+  authEmail: {
+    'ui:options': {
+      inputType: 'email',
+    },
+  },
+  authPositionTitle: {
+    'ui:options': {
+      maxLength: 128,
+    },
+  },
   altTelephone: {
     'ui:widget': NumberWidget,
     'ui:options': {
       inputType: 'phone',
     },
   },
-  authEmail: {
+  altPositionTitle: {
     'ui:options': {
-      inputType: 'email',
+      maxLength: 128,
     },
   },
   altEmail: {
@@ -622,7 +632,8 @@ const uiSchema = {
   },
   supportingConnectivityEvidence: {
     'ui:widget': 'FileWidget',
-    'ui:description': 'Template 8 - Supporting Connectivity Evidence (if applicable)',
+    'ui:description':
+      'Template 8 - Supporting Connectivity Evidence (if applicable)',
     'ui:options': {
       maxLength: MAX_LONG_INPUT_LENGTH,
       label: false,
@@ -851,7 +862,6 @@ const uiSchema = {
     'ui:options': {
       ignoreOptional: true,
     },
-    
   },
   'ui:inline': [
     // Each object is a row for inline grid elements. Set the number of columns with column key

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -6,6 +6,7 @@ import {
 
 const MAX_TEXTAREA_LENGTH = 3500;
 const MAX_LONG_INPUT_LENGTH = 200;
+const MAX_CONTACT_INPUT_LENGTH = 128;
 const MAX_MED_INPUT_LENGTH = 75;
 const MAX_SHORT_INPUT_LENGTH = 9;
 const MIN_INPUT_LENGTH = 1;
@@ -276,20 +277,57 @@ const uiSchema = {
   isAuthContactSigningOfficer: {
     'ui:widget': 'RadioWidget',
   },
+  authFamilyName: {
+    'ui:options': {
+      maxLength: MAX_CONTACT_INPUT_LENGTH,
+    },
+  },
+  authGivenName: {
+    'ui:options': {
+      maxLength: MAX_CONTACT_INPUT_LENGTH,
+    },
+  },
+  authPositionTitle: {
+    'ui:options': {
+      maxLength: MAX_CONTACT_INPUT_LENGTH,
+    },
+  },
+  authEmail: {
+    'ui:options': {
+      inputType: 'email',
+      maxLength: MAX_CONTACT_INPUT_LENGTH,
+    },
+  },
   authTelephone: {
     'ui:widget': NumberWidget,
     'ui:options': {
       inputType: 'phone',
     },
   },
-  authEmail: {
+  authExtension: {
     'ui:options': {
-      inputType: 'email',
+      maxLength: MAX_CONTACT_INPUT_LENGTH,
     },
   },
-  authPositionTitle: {
+  altFamilyName: {
     'ui:options': {
-      maxLength: 128,
+      maxLength: MAX_CONTACT_INPUT_LENGTH,
+    },
+  },
+  altGivenName: {
+    'ui:options': {
+      maxLength: MAX_CONTACT_INPUT_LENGTH,
+    },
+  },
+  altPositionTitle: {
+    'ui:options': {
+      maxLength: MAX_CONTACT_INPUT_LENGTH,
+    },
+  },
+  altEmail: {
+    'ui:options': {
+      inputType: 'email',
+      maxLength: MAX_CONTACT_INPUT_LENGTH,
     },
   },
   altTelephone: {
@@ -298,14 +336,9 @@ const uiSchema = {
       inputType: 'phone',
     },
   },
-  altPositionTitle: {
+  altExtension: {
     'ui:options': {
-      maxLength: 128,
-    },
-  },
-  altEmail: {
-    'ui:options': {
-      inputType: 'email',
+      maxLength: MAX_CONTACT_INPUT_LENGTH,
     },
   },
   contactTelephoneNumber: {

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -305,8 +305,10 @@ const uiSchema = {
     },
   },
   authExtension: {
+    'ui:widget': NumberWidget,
     'ui:options': {
-      maxLength: MAX_CONTACT_INPUT_LENGTH,
+      maxLength: 9,
+      inputType: 'wholeNumber',
     },
   },
   altFamilyName: {
@@ -337,8 +339,10 @@ const uiSchema = {
     },
   },
   altExtension: {
+    'ui:widget': NumberWidget,
     'ui:options': {
-      maxLength: MAX_CONTACT_INPUT_LENGTH,
+      maxLength: 9,
+      inputType: 'wholeNumber',
     },
   },
   contactTelephoneNumber: {
@@ -710,20 +714,6 @@ const uiSchema = {
     },
   },
   contactExtension: {
-    'ui:widget': NumberWidget,
-    'ui:options': {
-      maxLength: 9,
-      inputType: 'wholeNumber',
-    },
-  },
-  authExtension: {
-    'ui:widget': NumberWidget,
-    'ui:options': {
-      maxLength: 9,
-      inputType: 'wholeNumber',
-    },
-  },
-  altExtension: {
     'ui:widget': NumberWidget,
     'ui:options': {
       maxLength: 9,

--- a/app/lib/theme/widgets/TextAreaWidget.tsx
+++ b/app/lib/theme/widgets/TextAreaWidget.tsx
@@ -3,6 +3,8 @@ import { Label } from '../../../components/Form';
 import Textarea from '@button-inc/bcgov-theme/Textarea';
 import styled from 'styled-components';
 
+const INPUT_MAX_LENGTH = 32000;
+
 const StyledTextArea = styled(Textarea)`
   & textarea {
     margin-top: 12px;
@@ -47,7 +49,7 @@ const TextAreaWidget: React.FC<WidgetProps> = ({
         resize="vertical"
         required={required}
         aria-label={label}
-        maxLength={maxLength}
+        maxLength={maxLength || INPUT_MAX_LENGTH}
       />
       {description && <Label>{description}</Label>}
     </StyledDiv>

--- a/app/lib/theme/widgets/TextWidget.tsx
+++ b/app/lib/theme/widgets/TextWidget.tsx
@@ -4,6 +4,8 @@ import { Label } from '../../../components/Form';
 import Input from '@button-inc/bcgov-theme/Input';
 import styled from 'styled-components';
 
+const INPUT_MAX_LENGTH = 32000;
+
 const StyledInput = styled(Input)`
   & input {
     margin-top: 12px;
@@ -97,7 +99,7 @@ const TextWidget: React.FC<WidgetProps> = ({
         size={'medium'}
         required={required}
         aria-label={label}
-        maxLength={maxLength}
+        maxLength={maxLength || INPUT_MAX_LENGTH}
         minLength={minLength}
       />
       <StyledMessage>


### PR DESCRIPTION
https://app.zenhub.com/workspaces/ccbc---delivery-board-61c0c1204c8bcb001491c5f3/issues/bcgov/conn-ccbc-portal/421

Adds max lengths to all fields in authorized and alternate contact pages, as well as a max length of 32000 for any text fields that don't have one set. 