### PR TITLE
View withdrawn application continue button fix

### DIFF
--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -295,25 +295,19 @@ const ApplicationForm: React.FC<Props> = ({
   };
 
   const handleDisabled = (page: string, noErrors: boolean) => {
-    let disabled = false;
     switch (true) {
       case isWithdrawn:
-        disabled = false;
-        break;
+        return false;
       case page === 'review' && noErrors:
-        disabled = false;
-        break;
+        return false;
       case page === 'review':
-        disabled = !reviewConfirm;
-        break;
+        return !reviewConfirm;
       case page === 'acknowledgements':
-        disabled = !areAllAcknowledgementsChecked;
-        break;
+        return !areAllAcknowledgementsChecked;
       case page === 'submission':
-        disabled = !areAllSubmissionFieldsSet;
-        break;
+        return !areAllSubmissionFieldsSet;
     }
-    return disabled;
+    return false;
   };
 
   const calculate = (formData) => {

--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -185,6 +185,7 @@ const ApplicationForm: React.FC<Props> = ({
   );
 
   const [sectionName, sectionSchema] = subschemaArray[pageNumber - 1];
+  const isWithdrawn = status === 'withdrawn';
 
   if (subschemaArray.length < pageNumber) {
     // Todo: proper 404
@@ -199,7 +200,12 @@ const ApplicationForm: React.FC<Props> = ({
     >,
     isRedirectingToNextPage = false
   ) => {
-    if (status === 'withdrawn') {
+    if (isWithdrawn) {
+      if (pageNumber < subschemaArray.length) {
+        router.push(`/form/${rowId}/${pageNumber + 1}`);
+      } else {
+        router.push(`/form/${rowId}/success`);
+      }
       return;
     }
 
@@ -291,6 +297,9 @@ const ApplicationForm: React.FC<Props> = ({
   const handleDisabled = (page: string, noErrors: boolean) => {
     let disabled = false;
     switch (true) {
+      case isWithdrawn:
+        disabled = false;
+        break;
       case page === 'review' && noErrors:
         disabled = false;
         break;
@@ -335,6 +344,17 @@ const ApplicationForm: React.FC<Props> = ({
   };
 
   const isCustomPage = customPages.includes(sectionName);
+  const isSubmitPage = pageNumber >= subschemaArray.length;
+
+  const formatSubmitBtn = () => {
+    if (isWithdrawn) {
+      return 'Continue';
+    }
+    if (!isSubmitPage) {
+      return 'Save and continue';
+    }
+    return 'Submit';
+  };
 
   const submitBtns = (
     <>
@@ -342,7 +362,7 @@ const ApplicationForm: React.FC<Props> = ({
         variant="primary"
         disabled={handleDisabled(sectionName, noErrors) || isSubmitting}
       >
-        {pageNumber < subschemaArray.length ? 'Save and continue' : 'Submit'}
+        {formatSubmitBtn()}
       </Button>
     </>
   );
@@ -360,7 +380,7 @@ const ApplicationForm: React.FC<Props> = ({
         uiSchema={uiSchema}
         // Todo: validate entire form on completion
         noValidate={true}
-        disabled={status === 'withdrawn'}
+        disabled={isWithdrawn}
       >
         {submitBtns}
       </CalculationForm>
@@ -375,7 +395,7 @@ const ApplicationForm: React.FC<Props> = ({
         schema={sectionSchema}
         uiSchema={uiSchema}
         noValidate={true}
-        disabled={status === 'withdrawn'}
+        disabled={isWithdrawn}
       >
         {submitBtns}
       </CalculationForm>
@@ -392,7 +412,7 @@ const ApplicationForm: React.FC<Props> = ({
         fields={CUSTOM_SUBMISSION_FIELD}
         formContext={formContext}
         noValidate={true}
-        disabled={status === 'withdrawn'}
+        disabled={isWithdrawn}
       >
         {submitBtns}
       </CalculationForm>
@@ -420,7 +440,7 @@ const ApplicationForm: React.FC<Props> = ({
           uiSchema={review ? uiSchema[sectionName] : uiSchema}
           // Todo: validate entire form on completion
           noValidate={true}
-          disabled={status === 'withdrawn'}
+          disabled={isWithdrawn}
           formContext={formContext}
         >
           {review && (

--- a/app/tests/components/Form/ApplicationForm.test.tsx
+++ b/app/tests/components/Form/ApplicationForm.test.tsx
@@ -141,6 +141,30 @@ describe('The application form', () => {
     });
   });
 
+  it.only('displays the correct button label for withdrawn applications', async () => {
+    const payload = {
+      Application() {
+        return {
+          id: 'TestApplicationID',
+          status: 'withdrawn',
+          formData: {},
+        };
+      },
+      Query() {
+        return {
+          openIntake: {
+            closeTimestamp: '2022-08-27T12:51:26.69172-04:00',
+          },
+        };
+      },
+    };
+
+    componentTestingHelper.loadQuery(payload);
+    componentTestingHelper.renderComponent();
+
+    expect(screen.getByRole('button', { name: 'Continue' }));
+  });
+
   it('submission page submit button is enabled on when all inputs filled', async () => {
     componentTestingHelper.loadQuery();
     componentTestingHelper.renderComponent((data) => ({


### PR DESCRIPTION
This PR changes the `Save and continue` button text to `Continue` if the application status is withdrawn as well as fixes the page routing that was refactored to happen upon completion of the update application mutation. The button text will remain `Continue` even on the final submission page so there isn't any confusion.