### PR TITLE
feat: trivy sensitivy to critical

### DIFF
--- a/.github/workflows/publish_deploy_image.yaml
+++ b/.github/workflows/publish_deploy_image.yaml
@@ -34,8 +34,8 @@ jobs:
         format: sarif
         output: trivy-results.sarif
         exit-code: '0'
-        ignore-unfixed: false
-        severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+        ignore-unfixed: true
+        severity: CRITICAL
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v2
       with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,9 +33,9 @@ jobs:
         format: sarif
         output: trivy-results.sarif
         exit-code: '0'
-        ignore-unfixed: false
+        ignore-unfixed: true
         vuln-type: os,library
-        severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+        severity: CRITICAL
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v2
       with:
@@ -54,9 +54,9 @@ jobs:
         format: sarif
         output: trivy-results.sarif
         exit-code: '0'
-        ignore-unfixed: false
+        ignore-unfixed: true
         vuln-type: os,library
-        severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+        severity: CRITICAL
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v2
       with:


### PR DESCRIPTION
Now that the main branch has a comprehensive baseline, let's set PRs so they error out if they introduce new critical vulnerabilities where there is a known fix.

continues #524
ref #366