### PR TITLE
463 reroute

### DIFF
--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -51,7 +51,7 @@ const Navigation: React.FC<Props> = ({ isLoggedIn = false, title = '' }) => {
               <a>
                 <Image
                   priority
-                  src="/icons/BCID_CC_RGB_rev.svg"
+                  src="/applicantportal/icons/BCID_CC_RGB_rev.svg"
                   alt="Logo for Province of British Columbia Connected Communities"
                   height={100}
                   width={300}

--- a/app/cypress.json
+++ b/app/cypress.json
@@ -1,6 +1,6 @@
 {
   "video": false,
   "screenshot": false,
-  "baseUrl": "http://localhost:3000/",
+  "baseUrl": "http://localhost:3000/applicantportal",
   "pageLoadTimeout": 100000
 }

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -11,7 +11,7 @@ module.exports = {
         source: '/',
         destination: '/applicantportal',
         basePath: false,
-        permanent: false,
+        permanent: true,
       },
     ];
   },

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -3,6 +3,18 @@
 // module.exports = nextConfig
 
 module.exports = {
+  basePath: '/applicantportal',
+
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/applicantportal',
+        basePath: false,
+        permanent: false,
+      },
+    ];
+  },
   reactStrictMode: true,
   webpack: (config, { isServer }) => {
     if (!isServer) {


### PR DESCRIPTION
https://app.zenhub.com/workspaces/ccbc---delivery-board-61c0c1204c8bcb001491c5f3/board

Sets the nextjs basepath to `/applicantportal` and a redirect from `/` to `applicantportal` as well as the cypress base path.

