### PR TITLE
fix: logged in user should be redirected to '/applicantportal/dashboard'

### DIFF
--- a/app/backend/lib/sso-middleware.ts
+++ b/app/backend/lib/sso-middleware.ts
@@ -24,7 +24,7 @@ export default async function ssoMiddleware() {
   return ssoExpress({
     applicationDomain: '.gov.bc.ca',
     getLandingRoute: () => {
-      return '/dashboard';
+      return '/applicantportal/dashboard';
     },
     bypassAuthentication: {
       login: mockAuth,


### PR DESCRIPTION
One thing we forgot to update in #532 