### PR TITLE
feat: skip keycloak login page and redirect to BCeID login

### DIFF
--- a/app/backend/lib/sso-middleware.ts
+++ b/app/backend/lib/sso-middleware.ts
@@ -37,5 +37,6 @@ export default async function ssoMiddleware() {
       clientSecret: `${config.get('CLIENT_SECRET')}`,
     },
     onAuthCallback: createUserMiddleware(),
+    authorizationUrlParams: { kc_idp_hint: 'bceid-basic-and-business' },
   });
 }


### PR DESCRIPTION
Currently blocked on the CSS app being configured for BCeID both