### PR TITLE
415 - Switch up some requireds, optionals, & if applicables

### DIFF
--- a/app/formSchema/pages/authorizedContact.ts
+++ b/app/formSchema/pages/authorizedContact.ts
@@ -9,6 +9,7 @@ const authorizedContact = {
       'authPositionTitle',
       'authEmail',
       'authTelephone',
+      'isAuthContactSigningOfficer',
     ],
     properties: {
       authFamilyName: {

--- a/app/formSchema/pages/organizationLocation.ts
+++ b/app/formSchema/pages/organizationLocation.ts
@@ -3,7 +3,14 @@ const organizationLocation = {
     title: 'Organization location',
     description: 'Provide an address for your organization',
     type: 'object',
-    required: ['streetNumber', 'streetName', 'city', 'province', 'postalCode'],
+    required: [
+      'streetNumber',
+      'streetName',
+      'city',
+      'province',
+      'postalCode',
+      'isMailingAddress',
+    ],
     properties: {
       unitNumber: {
         title: 'Unit number',

--- a/app/formSchema/pages/otherFundingSources.ts
+++ b/app/formSchema/pages/otherFundingSources.ts
@@ -75,7 +75,7 @@ const otherFundingSources = {
                       ],
                     },
                     nameOfFundingProgram: {
-                      title: 'Name of program (if applicable)',
+                      title: 'Name of program',
                       type: 'string',
                     },
                     requestedFundingPartner2223: {

--- a/app/formSchema/pages/techSolution.ts
+++ b/app/formSchema/pages/techSolution.ts
@@ -3,12 +3,7 @@ const techSolution = {
     title: 'Technological solution',
     type: 'object',
     description: 'Describe your technological solution',
-    required: [
-      'systemDesign',
-      'scalability',
-      'backboneTechnology',
-      'lastMileTechnology',
-    ],
+    required: ['systemDesign', 'scalability', 'lastMileTechnology'],
     properties: {
       systemDesign: {
         title:

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -758,7 +758,7 @@ const uiSchema = {
         'ui:description': 'maximum 150 characters',
         'ui:options': {
           maxLength: 150,
-          hideOptional: true,
+          altOptionalText: 'if applicable',
         },
       },
       requestedFundingPartner2223: {

--- a/app/formSchema/uiSchema.ts
+++ b/app/formSchema/uiSchema.ts
@@ -282,6 +282,7 @@ const uiSchema = {
   authFamilyName: {
     'ui:options': {
       maxLength: MAX_CONTACT_INPUT_LENGTH,
+      altOptionalText: 'if applicable',
     },
   },
   authGivenName: {
@@ -316,6 +317,7 @@ const uiSchema = {
   altFamilyName: {
     'ui:options': {
       maxLength: MAX_CONTACT_INPUT_LENGTH,
+      altOptionalText: 'if applicable',
     },
   },
   altGivenName: {
@@ -655,11 +657,11 @@ const uiSchema = {
   },
   otherSupportingMaterials: {
     'ui:widget': 'FileWidget',
-    'ui:description': 'Other supporting materials (if applicable)',
+    'ui:description': 'Other supporting materials',
     'ui:options': {
       maxLength: MAX_LONG_INPUT_LENGTH,
       allowMultipleFiles: true,
-      hideOptional: true,
+      altOptionalText: 'if applicable',
     },
   },
   wirelessAddendum: {

--- a/app/lib/theme/FieldTemplate.tsx
+++ b/app/lib/theme/FieldTemplate.tsx
@@ -19,12 +19,14 @@ const FieldTemplate: React.FC<FieldTemplateProps> = ({
   id,
 }) => {
   const hideOptional = uiSchema['ui:options']?.hideOptional;
+  const altOptionalText = uiSchema['ui:options']?.altOptionalText;
 
   return (
     <div>
       {displayLabel && (
         <FieldLabel
           label={label}
+          altOptionalText={altOptionalText && String(altOptionalText)}
           hideOptional={hideOptional && true}
           required={required}
           htmlFor={id}

--- a/app/lib/theme/widgets/FieldLabel.tsx
+++ b/app/lib/theme/widgets/FieldLabel.tsx
@@ -1,23 +1,26 @@
 interface Props {
+  altOptionalText: string;
+  htmlFor: string;
+  hideOptional: boolean;
   label: string;
   required: boolean;
-  htmlFor: string;
   tagName?: 'label' | 'dt';
-  hideOptional: boolean;
 }
 
 const FieldLabel: React.FC<Props> = ({
+  altOptionalText,
+  hideOptional,
+  htmlFor,
   label,
   required,
-  htmlFor,
   tagName = 'label',
-  hideOptional,
 }) => {
   if (!label) {
     return null;
   }
+  const optionalText = ` (${altOptionalText ? altOptionalText : 'optional'})`;
   const displayedLabel =
-    label + (required || hideOptional ? '' : ` (optional)`) + ' ';
+    label + (required || hideOptional ? '' : optionalText) + ' ';
 
   if (tagName === 'label')
     return <label htmlFor={htmlFor}>{displayedLabel}</label>;


### PR DESCRIPTION
https://app.zenhub.com/workspaces/ccbc---delivery-board-61c0c1204c8bcb001491c5f3/issues/bcgov/conn-ccbc-portal/415

@wenzowski I added `altOptionalText` to `ui:options` so we can override the optional text as you asked. I decided to keep the `hideOptional` flag to hide the label on non required fields but I'm open to other suggestions. 