### PR TITLE
436 Provision s3 bucket for database backups

### DIFF
--- a/Infrastructure/README.md
+++ b/Infrastructure/README.md
@@ -14,6 +14,36 @@ Uses Terraform Cloud to store state and get temporary credentials based on "lice
 If you need to rollback please note that Terraform willnot destroy s# bucket if it has any objects.
 If you need to destroy anyway - please empty s3 bucket via AWS console first, then run 'terraform destroy -auto-approve'
 
+## How to provision another bucket 
+- !DO NOT MODIFY EXISTING VARIABLE `bucket_name`
+- create new variable in `variable.tf` file - i.e.
+```
+variable "foobar_bucket_name" {
+    default = "fapi7b-dev-ccbc-foobar"
+}
+``` 
+- in `main.tf` create new module referencing new variable
+```
+module "foobar_s3" {
+  source  = "./modules/s3_bucket"
+  vpc_id = data.aws_vpc.selected.id
+  bucket_name = var.foobar_bucket_name 
+}
+```
+- run 'terraform init'
+- run 'terraform plan'
+- confirm that plan does not contain any `destroy` actions, only 5 resources to be added
+- run 'terraform apply -auto-approve'
+- confirm that new s3 bucket is created as expected
+
+Please note that variables use `dev` as target environment. If the same bucket need to be created in another environment, please follow the next steps:
+- find `dev` and replace it with `test` in `variable.tf` file
+- find `dev` and replace it with `test` in `main.tf` file (line 7 only)
+- run 'terraform init -reconfigure'
+- run 'terraform plan'
+- confirm that plan does not contain any `destroy` actions, only 5 resources to be added
+- run 'terraform apply -auto-approve'
+- confirm that new s3 bucket is created as expected
 
 
 

--- a/Infrastructure/main.tf
+++ b/Infrastructure/main.tf
@@ -24,3 +24,9 @@ module "s3" {
   vpc_id = data.aws_vpc.selected.id
   bucket_name = var.bucket_name 
 }
+
+module "db_backup" {
+  source  = "./modules/s3_bucket"
+  vpc_id = data.aws_vpc.selected.id
+  bucket_name = var.backup_bucket_name 
+}

--- a/Infrastructure/variable.tf
+++ b/Infrastructure/variable.tf
@@ -10,3 +10,7 @@ variable "license_plate" {
 variable "bucket_name" {
     default = "fapi7b-dev-ccbc-data"
 }
+
+variable "backup_bucket_name" {
+    default = "fapi7b-dev-ccbc-dbbackup"
+}


### PR DESCRIPTION
- updated terraform scripts to provision new s3 bucket;
- updated README with steps how to provision new s3 buckets if needed;