### PR TITLE
ci: ignore merge commit formatting

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,1 @@
+ignore_merge_commits = true


### PR DESCRIPTION
adds a `cog.toml` to ignore merge commits