### PR TITLE
Change footer project details to program details

### DIFF
--- a/app/components/FooterLinks.tsx
+++ b/app/components/FooterLinks.tsx
@@ -12,7 +12,7 @@ export default function FooterLinks() {
       <StyledUl>
         <li key="0">
           <Link href="https://www.gov.bc.ca/connectingcommunitiesbc">
-            Project details
+            Program details
           </Link>
         </li>
         <li key="1">

--- a/app/cypress/integration/index.spec.js
+++ b/app/cypress/integration/index.spec.js
@@ -504,7 +504,7 @@ context('Homepage', () => {
   });
 
   it('should render the footer', () => {
-    cy.get('footer').contains('Project details');
+    cy.get('footer').contains('Program details');
     cy.get('footer').contains('Disclaimer');
     cy.get('footer').contains('Privacy');
     cy.get('footer').contains('Accessibility');

--- a/app/tests/components/FooterLinks.test.tsx
+++ b/app/tests/components/FooterLinks.test.tsx
@@ -6,14 +6,14 @@ const renderStaticLayout = () => {
 };
 
 describe('The FooterLinks component', () => {
-  it('should render Project details link title', () => {
+  it('should render Program details link title', () => {
     renderStaticLayout();
-    expect(screen.getByText('Project details'));
+    expect(screen.getByText('Program details'));
   });
 
-  it('should render the Project details link href', () => {
+  it('should render the Program details link href', () => {
     renderStaticLayout();
-    const link = screen.getByRole('link', { name: 'Project details' });
+    const link = screen.getByRole('link', { name: 'Program details' });
     expect(link).toHaveAttribute(
       'href',
       'https://www.gov.bc.ca/connectingcommunitiesbc'


### PR DESCRIPTION
Elliott asked me to change this to `Program details` in the footer.