### PR TITLE
ci: use current date for cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,11 +52,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: current-day
+        uses: josStorer/get-current-time@v2.0.1
+        with:
+          format: YYYY-MM-DD
+          utcOffset: "-7:00"
       - name: Cache Docker layers
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ matrix.name }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ matrix.name }}-${{ github.sha }}-${{ steps.current-time.outputs.formattedTime }}
           restore-keys: |
             ${{ runner.os }}-buildx-${{ matrix.name }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,8 +52,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: current-day
+      - name: Get current day
         uses: josStorer/get-current-time@v2.0.1
+        id: current-day
         with:
           format: YYYY-MM-DD
           utcOffset: "-7:00"
@@ -61,7 +62,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ matrix.name }}-${{ github.sha }}-${{ steps.current-time.outputs.formattedTime }}
+          key: ${{ runner.os }}-buildx-${{ matrix.name }}-${{ github.sha }}-${{ steps.current-day.outputs.formattedTime }}
           restore-keys: |
             ${{ runner.os }}-buildx-${{ matrix.name }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,8 +51,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get current day
+      - name: Get current day for cache
+        # To avoid trivvy scans from pulling stale cached images
         uses: josStorer/get-current-time@v2.0.1
         id: current-day
         with:
@@ -62,9 +62,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ matrix.name }}-${{ github.sha }}-${{ steps.current-day.outputs.formattedTime }}
+          key: ${{ runner.os }}-buildx-${{ matrix.name }}-${{ steps.current-day.outputs.formattedTime }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.name }}
+            ${{ runner.os }}-buildx-${{ matrix.name }}-${{ steps.current-day.outputs.formattedTime }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Adds current date for cache in build to avoid trivvy scan pulling in stale artifacts