### PR TITLE
fix: using correct dockerfile to copy mock schema

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -52,7 +52,6 @@ RUN chmod +x /usr/local/bin/dumb-init
 ENTRYPOINT ["dumb-init", "--", "/usr/bin/env", "bash", "-c"]
 
 COPY app/ ${APP_HOME}/
-COPY mocks_schema/ ${HOME}/mocks_schema
 
 # FIX CVE-2022-29244
 RUN rm -rf /usr/local/bin/npm \

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -25,6 +25,7 @@ RUN INSTALL_PKGS="postgresql.x86_64 perl-App-cpanminus.noarch" && \
   rm -rf /var/cache
 
 COPY db/ ${HOME}
+COPY mocks_schema/ ${HOME}/mocks_schema
 
 # CPAN needs to install dependencies for all schemas, one directory up
 RUN cpanm --notest --local-lib ./extlib --installdeps .


### PR DESCRIPTION
### Description

The time travel feature was added, but mock_schema was not deployed, so the time travel does not work in dev and test environments.

This PR fixes the issue.
