### PR TITLE
fix: submit button is disabled if acknowledgements not checked

### DIFF
--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -187,7 +187,11 @@ const ApplicationForm: React.FC<Props> = ({
       return areAllAcknowledgementsChecked || isSubmitted;
 
     if (sectionName === 'submission')
-      return areAllSubmissionFieldsSet && !isSubmitted;
+      return (
+        areAllSubmissionFieldsSet &&
+        areAllAcknowledgementsChecked &&
+        !isSubmitted
+      );
 
     return true;
   }, [

--- a/app/tests/components/Form/ApplicationForm.test.tsx
+++ b/app/tests/components/Form/ApplicationForm.test.tsx
@@ -68,6 +68,11 @@ const submissionPayload = {
           submissionCompletedBy: 'test',
           submissionTitle: 'test',
         },
+        acknowledgements: {
+          acknowledgementsList: [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+          ],
+        },
       },
     };
   },
@@ -306,6 +311,11 @@ describe('The application form', () => {
         submissionDate: '2022-08-10',
         submissionCompletedBy: 'Bob Loblaw',
         submissionTitle: 'some title',
+      },
+      acknowledgements: {
+        acknowledgementsList: [
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+        ],
       },
     };
     componentTestingHelper.loadQuery({


### PR DESCRIPTION
Fix for submit button being disabled if all acknowledgements aren't checked