### PR TITLE
chore: update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,49 +1,11 @@
 ---
 name: Pull Request Template
 about: Default pull request template
-title: ''
+title: '<type>[optional scope]: <description>'
 labels: ''
 assignees: ''
-
 ---
-
-### Description: 
-
-_(Brief description of the pull request.)_
 
 References # \<issue number\>
 
-### Type of change:
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-
-
-### Checklist for DoD:
-- [ ] Code produced (all ‘to do’ items in code completed) 
-- [ ]  Acceptance Criteria were executed without fail. 
-- [ ]  Code commented, checked in and ran against current version in source control 
-- [ ]  Obey “Conventional commits” (https://www.conventionalcommits.org/en/v1.0.0/)
-- [ ] Code review (https://google.github.io/eng-practices/review/)
-- [ ]  Peer reviewed (or produced with pair programming) and meeting development standards ([Google](https://google.github.io/eng-practices/review/reviewer/)) 
-- [ ]  Defects = 0% (?). (How to measure this?) 
-- [ ]  Unit tests are written and passing 
-- [ ]  Test coverage > 80%(?) 
-- [ ]  Deployed to the system test(?) environment and passed system tests 
-- [ ]  Any build / deployment / configuration changes are implemented / documented / communicated 
-- [ ]  Relevant documentation / diagrams produced and / or updated 
-- [ ]  Don’t introduce breaking changes. 
-- [ ]  Don’t (avoid) introducing more tech debt. 
-- [ ]  Automatic Tests implemented and running 
-- [ ]  Exploratory Test executed if it applies 
-- [ ]  Week-notes (~5 bullets of accomplished this sprint + ~5 bullets of what's coming) 
-- [ ]  Written discoveries and recommendations 
-- [ ]  Presentation to Stakeholders 
-- [ ]  User Manual/FAQ updated 
-- [ ]  GitHub DOCs updated 
-
-### Additional Notes:
-
-_(Include any notes you have about this pull request)_
+<!-- Detailed description of the change -->

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,0 +1,17 @@
+name: 'Lint PR'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@91682d013dea3ff257520b9b68c9cb93ced4fe9b
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-code.yaml
+++ b/.github/workflows/test-code.yaml
@@ -71,23 +71,6 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
 
-  cocogitto:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Tag the base ref for pull requests
-        shell: bash
-        working-directory: .
-        if: github.event_name == 'pull_request'
-        run: git checkout "$GITHUB_BASE_REF" && git tag latest && git checkout "$GITHUB_HEAD_REF"
-      - name: Conventional commits check
-        uses: oknozor/cocogitto-action@v3
-        with:
-          check-latest-tag-only: true
-
   gitleaks:
     runs-on: ubuntu-latest
     steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,4 +3,3 @@ yarn 1.22.18
 kubectl 1.21.6
 postgres 14.1
 python 3.10.6
-rust 1.63.0

--- a/Makefile
+++ b/Makefile
@@ -195,15 +195,6 @@ lint_chart:
 	helm dep up ./helm/app; \
 	helm template --set metabase.namespace=dummy-namespace -f ./helm/app/values.yaml ccbc ./helm/app --validate;
 
-.PHONY: install_cocogitto
-install_cocogitto:
-	@cargo install --locked cocogitto
-
-.PHONY: install_cocogitto_hook
-install_cocogitto_hook: install_cocogitto
-install_cocogitto_hook:
-	@cog install-hook commit-msg
-
 .PHONY: install_git_hooks
 install_git_hooks: install_cocogitto_hook
 install_git_hooks:


### PR DESCRIPTION
Relates to #441 

This change simplifies the PR template and enforces the conventional commit convention on the PR title, rather than on commits themselves.
This enables a workflow where PRs are squash-merged, while retaining the ability to generate a changelog.