### PR TITLE
chore: fix PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,10 @@
----
-name: Pull Request Template
-about: Default pull request template
-title: '<type>[(optional scope)]: <description>'
-labels: ''
-assignees: ''
----
+<!--
+PR title should follow the `<type>[(optional scope)]: <description>` format.
+See docs/Team_Agreements.md#commit-message-guidelines
+-->
 
-<!-- see docs/Team_Agreements.md#commit-message-guidelines -->
+Implements # \<issue number\>
 
-References # \<issue number\>
-
-<!-- Detailed description of the change -->
+<!--
+Add detailed description of the changes if the PR title isn't enough
+ -->


### PR DESCRIPTION
Implements #441 

The PR templates don't support custom titles, as the issues templates does. 
As per the [github docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates#pull-request-templates), PR templates only display the markdown's contents in the PR body.
