### PR TITLE
chore: update gitleaks to v8.14.1

### DIFF
--- a/.bin/install-gitleaks-linux-x64.sh
+++ b/.bin/install-gitleaks-linux-x64.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xeuo pipefail;
 
-version="8.13.0";
+version="8.14.1";
 releases_api="https://api.github.com/repos/zricethezav/gitleaks/releases/latest";
 releases_json="$(curl -s ${releases_api})";
 


### PR DESCRIPTION
Hotfix for Gitleaks failing due to a new release: https://github.com/zricethezav/gitleaks/releases/tag/v8.14.1

Should we lock in a version and change how the `install-gitleaks-linux-x64.sh` script is handled?

