### PR TITLE
feat: add callout displaying intake state on landing page

### DIFF
--- a/app/components/NavbarLinks.tsx
+++ b/app/components/NavbarLinks.tsx
@@ -9,7 +9,7 @@ const StyledLi = styled.li`
 `;
 
 const StyledUl = styled.ul`
-  padding-left: ${(props) => props.theme.padding.page};
+  padding-left: ${(props) => props.theme.spacing.large};
 `;
 
 const SubHeaderNavbarLinks: React.FC = () => (

--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -35,7 +35,7 @@ const StyledDiv = styled('div')`
 `;
 
 const StyledBaseHeader = styled(BaseHeader)`
-  padding-right: ${(props) => props.theme.padding.page};
+  padding-right: ${(props) => props.theme.spacing.large};
 `;
 interface Props {
   isLoggedIn?: boolean;

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -36,8 +36,7 @@ const BoldText = styled('strong')`
 `;
 
 const StyledCallout = styled(Callout)`
-  margin-top: 16px;
-  margin-bottom: 16px;
+  margin: ${(props) => props.theme.spacing.medium} 0;
 `;
 
 const getPagesQuery = graphql`

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -3,6 +3,9 @@ import { withRelay, RelayProps } from 'relay-nextjs';
 import { graphql } from 'react-relay';
 import Link from '@button-inc/bcgov-theme/Link';
 import styled from 'styled-components';
+import { useMemo } from 'react';
+import { Callout } from '@button-inc/bcgov-theme';
+import { DateTime } from 'luxon';
 import defaultRelayOptions from '../lib/relay/withRelayOptions';
 import { ButtonLink, IntakeAlert, Layout, LoginForm } from '../components';
 import { pagesQuery } from '../__generated__/pagesQuery.graphql';
@@ -25,6 +28,13 @@ const StyledBtnContainer = styled('div')`
   margin: 24px 0;
 `;
 
+// while a `strong` element may be displayed as bold,
+// that should not be relied upon and font-weight should be used instead.
+// Using a `strong` element is still useful on a semantic level.
+const BoldText = styled('strong')`
+  font-weight: bold;
+`;
+
 const getPagesQuery = graphql`
   query pagesQuery {
     session {
@@ -32,6 +42,7 @@ const getPagesQuery = graphql`
     }
     openIntake {
       openTimestamp
+      closeTimestamp
     }
     nextIntake {
       openTimestamp
@@ -47,6 +58,34 @@ const Home = ({
     preloadedQuery
   );
 
+  const intakeCalloutChildren = useMemo(() => {
+    if (!openIntake)
+      return (
+        <>
+          <BoldText>Applications are not currently being accepted.</BoldText>
+          <br />
+          Please check the{' '}
+          <Link href="https://www.gov.bc.ca/connectingcommunitiesbc">
+            program webpage
+          </Link>{' '}
+          for updates.
+        </>
+      );
+
+    return (
+      <BoldText>
+        Applications are accepted until{' '}
+        {DateTime.fromISO(openIntake.closeTimestamp).toLocaleString(
+          DateTime.DATETIME_FULL
+        )}
+        .
+        <br />
+        Review of applications will not begin until this date. Draft and
+        submitted applications can be edited until then.
+      </BoldText>
+    );
+  }, [openIntake]);
+
   return (
     <Layout session={session} title="Connecting Communities BC">
       <div>
@@ -55,17 +94,15 @@ const Home = ({
           <IntakeAlert openTimestamp={nextIntake?.openTimestamp} />
         )}
         <section>
-          <h3>Before you begin</h3>
-          <ul>
-            <li>
-              Refer to{' '}
-              <Link href="https://www.gov.bc.ca/connectingcommunitiesbc">
-                program details
-              </Link>{' '}
-              for the application materials and full information about the
-              Connecting Communities British Columbia (CCBC) program.
-            </li>
-          </ul>
+          Refer to{' '}
+          <Link href="https://www.gov.bc.ca/connectingcommunitiesbc">
+            program details
+          </Link>{' '}
+          for the application materials and full information about the
+          Connecting Communities British Columbia (CCBC) program.
+          <Callout style={{ marginTop: '16px', marginBottom: '16px' }}>
+            {intakeCalloutChildren}
+          </Callout>
         </section>
         <section>
           <h3>Get started</h3>

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -35,6 +35,11 @@ const BoldText = styled('strong')`
   font-weight: bold;
 `;
 
+const StyledCallout = styled(Callout)`
+  margin-top: 16px;
+  margin-bottom: 16px;
+`;
+
 const getPagesQuery = graphql`
   query pagesQuery {
     session {
@@ -100,9 +105,7 @@ const Home = ({
           </Link>{' '}
           for the application materials and full information about the
           Connecting Communities British Columbia (CCBC) program.
-          <Callout style={{ marginTop: '16px', marginBottom: '16px' }}>
-            {intakeCalloutChildren}
-          </Callout>
+          <StyledCallout>{intakeCalloutChildren}</StyledCallout>
         </section>
         <section>
           <h3>Get started</h3>

--- a/app/styles/GlobalTheme.tsx
+++ b/app/styles/GlobalTheme.tsx
@@ -26,8 +26,10 @@ export const theme = {
     stepperHover: 'rgba(196, 196, 196, 0.06)',
     stepperBlue: 'rgb(229, 239, 249)',
   },
-  padding: {
-    page: '20px',
+  spacing: {
+    small: '8px',
+    medium: '16px',
+    large: '20px',
   },
   breakpoint: {
     smallUp: '@media (min-width: 600px)',

--- a/app/tests/components/Form/ApplicationFormStatus.test.tsx
+++ b/app/tests/components/Form/ApplicationFormStatus.test.tsx
@@ -1,11 +1,11 @@
 import { graphql } from 'react-relay';
-import ComponentTestingHelper from '../../utils/componentTestingHelper';
 import compiledQuery, {
   ApplicationFormStatusTestQuery,
 } from '__generated__/ApplicationFormStatusTestQuery.graphql';
 import { screen } from '@testing-library/react';
 import { Settings, DateTime } from 'luxon';
 import ApplicationFormStatus from 'components/Form/ApplicationFormStatus';
+import ComponentTestingHelper from '../../utils/componentTestingHelper';
 
 const testQuery = graphql`
   query ApplicationFormStatusTestQuery @relay_test_operation {
@@ -21,7 +21,7 @@ const mockQueryPayload = {
     return {
       id: 'TestApplicationID',
       formData: { projectInformation: { projectTitle: 'test title' } },
-      updatedAt: DateTime.utc(2020, 1, 1, 4, 42).toISO(),
+      updatedAt: DateTime.local(2020, 1, 1, 4, 42).toISO(),
       status: 'draft',
     };
   },
@@ -45,7 +45,9 @@ describe('The application form', () => {
   });
 
   it('displays  the saved time when it was saved on the same day', () => {
-    const mockCurrentTime = DateTime.local(2020, 1, 1, 5, { zone: "America/Vancouver" });
+    const mockCurrentTime = DateTime.local(2020, 1, 1, 5, {
+      zone: 'America/Vancouver',
+    });
     Settings.now = () => mockCurrentTime.toMillis();
 
     componentTestingHelper.loadQuery();
@@ -56,9 +58,10 @@ describe('The application form', () => {
   });
 
   it('displays the saved date when it was saved on a different day', () => {
-    const mockCurrentTime = DateTime.local(2020, 1, 2, 0, { zone: "America/Vancouver" });
+    const mockCurrentTime = DateTime.local(2020, 1, 2, 0, {
+      zone: 'America/Vancouver',
+    });
     Settings.now = () => mockCurrentTime.toMillis();
-    Settings.defaultLocale = "en-CA";
 
     componentTestingHelper.loadQuery();
     componentTestingHelper.renderComponent();
@@ -68,7 +71,9 @@ describe('The application form', () => {
   });
 
   it('displays the error message if provided', () => {
-    const mockCurrentTime = DateTime.local(2020, 1, 2, 0, { zone: "America/Vancouver" });
+    const mockCurrentTime = DateTime.local(2020, 1, 2, 0, {
+      zone: 'America/Vancouver',
+    });
     Settings.now = () => mockCurrentTime.toMillis();
 
     componentTestingHelper.loadQuery();

--- a/app/tests/jest-setup.ts
+++ b/app/tests/jest-setup.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import { Settings } from 'luxon';
 
 // Some rjsf features require window.crypto, which isn't provided by jsdom
 Object.defineProperty(global.self, 'crypto', {
@@ -6,3 +7,6 @@ Object.defineProperty(global.self, 'crypto', {
     getRandomValues: (arr) => crypto.randomBytes(arr.length),
   },
 });
+
+Settings.defaultLocale = 'en-CA';
+Settings.defaultZone = 'America/Vancouver';

--- a/app/tests/pages/form/success.test.tsx
+++ b/app/tests/pages/form/success.test.tsx
@@ -1,6 +1,5 @@
-import { withRelayOptions } from '../../../pages/form/[id]/success';
 import { screen } from '@testing-library/react';
-import Success from '../../../pages/form/[id]/success';
+import Success, { withRelayOptions } from '../../../pages/form/[id]/success';
 import PageTestingHelper from '../../utils/pageTestingHelper';
 import compiledsuccessQuery, {
   successQuery,
@@ -70,7 +69,7 @@ it('displays the correct save time', () => {
   pageTestingHelper.renderPage();
 
   expect(
-    screen.getByText(/2022-08-15 at 01:43 PM \(PDT\)/i)
+    screen.getByText(/2022-08-15 at 01:43 p.m. \(PDT\)/i)
   ).toBeInTheDocument();
 });
 

--- a/db/data/dev/001_intake.sql
+++ b/db/data/dev/001_intake.sql
@@ -4,7 +4,8 @@ insert into
   ccbc_public.intake(id, open_timestamp, close_timestamp, ccbc_intake_number)
 overriding system value
 values
-  (1, '2022-08-19 09:00:00 America/Vancouver','2022-11-06 09:00:00 America/Vancouver', 1)
+  (1, '2022-08-19 09:00:00 America/Vancouver','2022-11-06 09:00:00 America/Vancouver', 1),
+  (2, '2022-01-15 00:00:00 America/Vancouver','2023-03-15 00:00:00 America/Vancouver', 2)
 on conflict (id) do update set
 open_timestamp = excluded.open_timestamp,
 close_timestamp = excluded.close_timestamp,

--- a/db/data/dev/001_intake.sql
+++ b/db/data/dev/001_intake.sql
@@ -5,7 +5,7 @@ insert into
 overriding system value
 values
   (1, '2022-08-19 09:00:00 America/Vancouver','2022-11-06 09:00:00 America/Vancouver', 1),
-  (2, '2022-01-15 00:00:00 America/Vancouver','2023-03-15 00:00:00 America/Vancouver', 2)
+  (2, '2023-01-15 00:00:00 America/Vancouver','2023-03-15 00:00:00 America/Vancouver', 2)
 on conflict (id) do update set
 open_timestamp = excluded.open_timestamp,
 close_timestamp = excluded.close_timestamp,

--- a/db/data/test/001_intake.sql
+++ b/db/data/test/001_intake.sql
@@ -4,7 +4,8 @@ insert into
   ccbc_public.intake(id, open_timestamp, close_timestamp, ccbc_intake_number)
 overriding system value
 values
-  (1, '2022-08-19 09:00:00 America/Vancouver','2022-11-06 09:00:00 America/Vancouver', 1)
+  (1, '2022-08-19 09:00:00 America/Vancouver','2022-11-06 09:00:00 America/Vancouver', 1),
+  (2, '2022-01-15 00:00:00 America/Vancouver','2023-03-15 00:00:00 America/Vancouver', 2)
 on conflict (id) do update set
 open_timestamp = excluded.open_timestamp,
 close_timestamp = excluded.close_timestamp,

--- a/db/data/test/001_intake.sql
+++ b/db/data/test/001_intake.sql
@@ -5,7 +5,7 @@ insert into
 overriding system value
 values
   (1, '2022-08-19 09:00:00 America/Vancouver','2022-11-06 09:00:00 America/Vancouver', 1),
-  (2, '2022-01-15 00:00:00 America/Vancouver','2023-03-15 00:00:00 America/Vancouver', 2)
+  (2, '2023-01-15 00:00:00 America/Vancouver','2023-03-15 00:00:00 America/Vancouver', 2)
 on conflict (id) do update set
 open_timestamp = excluded.open_timestamp,
 close_timestamp = excluded.close_timestamp,


### PR DESCRIPTION
Implements #699 + adds second intake in dev and test data
