### PR TITLE
feat: drafts-are-uneditable-between-intakes

### DIFF
--- a/db/deploy/computed_columns/form_data_is_editable.sql
+++ b/db/deploy/computed_columns/form_data_is_editable.sql
@@ -11,11 +11,11 @@ attached_application_status varchar(1000);
 form_data_status varchar(1000):= form_data.form_data_status_type_id;
 begin
 
-  if form_data_status = 'pending' then
+  select id from ccbc_public.open_intake() into open_intake_id;
+
+  if form_data_status = 'pending' and open_intake_id is not null then
     return true;
   end if;
-
-  select id from ccbc_public.open_intake() into open_intake_id;
 
   select app.* into attached_application from ccbc_public.application_form_data as afd, ccbc_public.application as app where afd.form_data_id = form_data.id
   and afd.application_id = app.id ;

--- a/db/test/unit/computed_columns/application_project_name_test.sql
+++ b/db/test/unit/computed_columns/application_project_name_test.sql
@@ -15,6 +15,8 @@ insert into
 overriding system value
 values
   (1, '2022-08-19 09:00:00 America/Vancouver','2022-11-06 09:00:00 America/Vancouver', 1);
+-- set the mocked time to within the intake day
+select mocks.set_mocked_time_in_transaction('2022-08-20 09:00:00 America/Vancouver'::timestamptz);
 
 set jwt.claims.sub to 'testCcbcAuthUser';
 set role ccbc_auth_user;

--- a/db/test/unit/computed_columns/form_data_is_editable_test.sql
+++ b/db/test/unit/computed_columns/form_data_is_editable_test.sql
@@ -76,9 +76,9 @@ select results_eq (
     from ccbc_public.form_data where id = 2;
   $$,
   $$
-    values('t'::boolean)
+    values('f'::boolean)
   $$,
-  'Current form is editable as it is a draft, even if there is no open intake'
+  'Current form is not editable as it is a draft, and there is no open intake'
 );
 
 insert into ccbc_public.application_status (application_id, status) VALUES (1, 'withdrawn');


### PR DESCRIPTION
Implements # 121

Adds the missing criteria in #121 that a draft form is  uneditable when the intake is not open.