### PR TITLE
fix(frontend): add margin to return to dashboard button

### DIFF
--- a/app/components/Form/SubmitButtons.tsx
+++ b/app/components/Form/SubmitButtons.tsx
@@ -132,6 +132,7 @@ const SubmitButtons = ({
       {isSubmittedAndSubmitPage && (
         <StyledButton
           variant="secondary"
+          style={{ marginLeft: '24px' }}
           onClick={(e: React.MouseEvent<HTMLInputElement>) => {
             e.preventDefault();
             router.push('/dashboard');


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements No issue

<!--
Add detailed description of the changes if the PR title isn't enough
 -->

Adds a margin to the `Return to dashboard` button to match the design