### PR TITLE
chore: add gitAuthor to renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,6 @@
   "commitMessagePrefix": "chore:",
   "platform": "github",
   "onboarding": false,
-  "repositories": ["bcgov/CONN-CCBC-portal"]
+  "repositories": ["bcgov/CONN-CCBC-portal"],
+  "gitAuthor": "CCBC Service Account <ccbc@button.is>"
 }


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements No Issue

Adds `gitAuthor` so that commits come from the ccbc user