### PR TITLE
chore: add recreateClosed to renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,6 @@
   "platform": "github",
   "onboarding": false,
   "repositories": ["bcgov/CONN-CCBC-portal"],
-  "gitAuthor": "CCBC Service Account <ccbc@button.is>"
+  "gitAuthor": "CCBC Service Account <ccbc@button.is>",
+  "recreateClosed": true
 }


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements No Issue

Adds `recreateClosed` so that if the "fix" for a vulnerability is to clear the cache rather than update the dependency, we can close a renovate PR without worrying about it later