### PR TITLE
697 - Returning to submit page at a later date changes the date to the previous date

### DIFF
--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -104,10 +104,10 @@ const ApplicationForm: React.FC<Props> = ({
         formData {
           jsonData
           isEditable
+          updatedAt
           id
         }
         status
-        updatedAt
         intakeByIntakeId {
           closeTimestamp
         }
@@ -129,9 +129,8 @@ const ApplicationForm: React.FC<Props> = ({
   );
   const {
     rowId,
-    formData: { jsonData, id: formDataId, isEditable },
+    formData: { jsonData, id: formDataId, isEditable, updatedAt },
     status,
-    updatedAt,
   } = application;
 
   const formErrorSchema = useMemo(() => validate(jsonData), [jsonData]);

--- a/app/tests/components/Form/ApplicationForm.test.tsx
+++ b/app/tests/components/Form/ApplicationForm.test.tsx
@@ -30,9 +30,9 @@ const mockQueryPayload = {
         id: 'TestFormId',
         jsonData: {},
         isEditable: true,
+        updatedAt: '2022-09-12T14:04:10.790848-07:00',
       },
       status: 'draft',
-      updatedAt: '2022-09-12T14:04:10.790848-07:00',
     };
   },
   Query() {
@@ -62,11 +62,10 @@ const submissionPayload = {
   Application() {
     return {
       status: 'draft',
-      updatedAt: '2022-09-12T14:04:10.790848-07:00',
-
       formData: {
         id: 'TestFormId',
         isEditable: true,
+        updatedAt: '2022-09-12T14:04:10.790848-07:00',
         jsonData: {
           organizationProfile: {
             organizationName: 'Testing organization name',
@@ -174,9 +173,9 @@ describe('The application form', () => {
                 organizationName: 'Test org',
               },
             },
+            updatedAt: '2022-09-12T14:04:10.790848-07:00',
           },
           status: 'draft',
-          updatedAt: '2022-09-12T14:04:10.790848-07:00',
         };
       },
       Query() {
@@ -697,9 +696,9 @@ describe('The application form', () => {
             id: 'TestFormId',
             jsonData: {},
             isEditable: false,
+            updatedAt: '2022-09-12T14:04:10.790848-07:00',
           },
           status: 'draft',
-          updatedAt: '2022-09-12T14:04:10.790848-07:00',
         };
       },
     };
@@ -722,9 +721,9 @@ describe('The application form', () => {
             id: 'TestFormId',
             jsonData: {},
             isEditable: false,
+            updatedAt: '2022-09-12T14:04:10.790848-07:00',
           },
           status: 'draft',
-          updatedAt: '2022-09-12T14:04:10.790848-07:00',
         };
       },
     };
@@ -745,9 +744,9 @@ describe('The application form', () => {
             id: 'TestFormId',
             jsonData: {},
             isEditable: false,
+            updatedAt: '2022-09-12T14:04:10.790848-07:00',
           },
           status: 'draft',
-          updatedAt: '2022-09-12T14:04:10.790848-07:00',
         };
       },
     };
@@ -770,9 +769,9 @@ describe('The application form', () => {
             id: 'TestFormId',
             jsonData: {},
             isEditable: false,
+            updatedAt: '2022-09-12T14:04:10.790848-07:00',
           },
           status: 'draft',
-          updatedAt: '2022-09-12T14:04:10.790848-07:00',
         };
       },
     };


### PR DESCRIPTION
This bug was from when we moved the form_data to it's own table. Just had to use the `updated_at` column from `form_data` instead of the `application` table one.