### PR TITLE
fix: FileWidget cannot call two mutations concurrently

### DIFF
--- a/app/lib/theme/widgets/FileWidget.tsx
+++ b/app/lib/theme/widgets/FileWidget.tsx
@@ -106,7 +106,7 @@ const Error = ({ error, fileTypes }) => {
   }
 
   if (error === 'fileSize') {
-    return <StyledError>Files must be less than 100mb.</StyledError>;
+    return <StyledError>Files must be less than 100MB.</StyledError>;
   }
   return null;
 };

--- a/app/tests/components/Form/FileWidget.test.tsx
+++ b/app/tests/components/Form/FileWidget.test.tsx
@@ -263,4 +263,35 @@ describe('The FileWidget', () => {
       )
     ).toBeVisible();
   });
+
+  it("doesn't allow uploading a second file if the mutation is in flight", () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent();
+
+    const file = new File([new ArrayBuffer(1)], 'file.kmz', {
+      type: 'application/vnd.google-earth.kmz',
+    });
+
+    const inputFile = screen.getAllByTestId('file-test')[0];
+
+    fireEvent.change(inputFile, { target: { files: [file] } });
+
+    const getOperationNames = () =>
+      componentTestingHelper.environment.mock
+        .getAllOperations()
+        .map((op) => op.fragment.node.name);
+
+    expect(getOperationNames()).toEqual([
+      'FileWidgetTestQuery',
+      'createAttachmentMutation',
+    ]);
+
+    fireEvent.change(inputFile, { target: { files: [file] } });
+
+    // we have not resolved the mutation, so there should not be another mutation
+    expect(getOperationNames()).toEqual([
+      'FileWidgetTestQuery',
+      'createAttachmentMutation',
+    ]);
+  });
 });

--- a/app/tests/components/Form/FileWidget.test.tsx
+++ b/app/tests/components/Form/FileWidget.test.tsx
@@ -168,19 +168,17 @@ describe('The FileWidget', () => {
 
     deleteButton.click();
 
-    act(() => {
-      componentTestingHelper.expectMutationToBeCalled(
-        'deleteAttachmentMutation',
-        {
-          input: {
-            attachmentPatch: {
-              archivedAt: expect.any(String),
-            },
-            rowId: 3,
+    componentTestingHelper.expectMutationToBeCalled(
+      'deleteAttachmentMutation',
+      {
+        input: {
+          attachmentPatch: {
+            archivedAt: expect.any(String),
           },
-        }
-      );
-    });
+          rowId: 3,
+        },
+      }
+    );
 
     act(() => {
       componentTestingHelper.environment.mock.resolveMostRecentOperation({
@@ -310,5 +308,71 @@ describe('The FileWidget', () => {
     fireEvent.change(inputFile, { target: { files: [file] } });
 
     expect(screen.getByText(/Files must be less than 100MB/)).toBeVisible();
+  });
+
+  it('displays an error message when the createAttachment mutation fails', () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent();
+
+    const file = new File([new ArrayBuffer(1)], 'file.kmz', {
+      type: 'application/vnd.google-earth.kmz',
+    });
+
+    const inputFile = screen.getAllByTestId('file-test')[0];
+
+    fireEvent.change(inputFile, { target: { files: [file] } });
+
+    act(() =>
+      componentTestingHelper.environment.mock.rejectMostRecentOperation(
+        new Error()
+      )
+    );
+
+    expect(screen.getByText(/File failed to upload/)).toBeVisible();
+  });
+
+  it('displays an error message when the deleteAttachment mutation fails', async () => {
+    componentTestingHelper.loadQuery({
+      ...mockQueryPayload,
+      Application() {
+        return {
+          id: 'TestApplicationID',
+          formData: {
+            jsonData: {
+              coverage: {
+                coverageAssessmentStatistics: [
+                  {
+                    id: 3,
+                    uuid: 'a365945b-5631-4e52-af9f-515e6fdcf614',
+                    name: 'file-2.kmz',
+                    size: 0,
+                    type: 'application/vnd.google-earth.kmz',
+                  },
+                ],
+              },
+            },
+          },
+          status: 'draft',
+        };
+      },
+    });
+    componentTestingHelper.renderComponent();
+
+    expect(screen.getByText('file-2.kmz')).toBeVisible();
+    expect(screen.getByText('Replace')).toBeVisible();
+
+    const deleteButton = screen.getByTestId('file-delete-btn');
+
+    deleteButton.click();
+
+    act(() => {
+      componentTestingHelper.environment.mock.rejectMostRecentOperation(
+        new Error()
+      );
+    });
+
+    expect(screen.getByText('file-2.kmz')).toBeVisible();
+    expect(screen.getByText('Replace')).toBeVisible();
+    expect(screen.getByText(/Delete file failed/)).toBeVisible();
   });
 });

--- a/app/tests/components/Form/FileWidget.test.tsx
+++ b/app/tests/components/Form/FileWidget.test.tsx
@@ -294,4 +294,21 @@ describe('The FileWidget', () => {
       'createAttachmentMutation',
     ]);
   });
+
+  it('displays an error message when attempting to upload a file that is too large', () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent();
+
+    const file = {
+      name: 'file-3.kmz',
+      size: 104857601,
+      type: 'application/vnd.google-earth.kmz',
+    };
+
+    const inputFile = screen.getAllByTestId('file-test')[0];
+
+    fireEvent.change(inputFile, { target: { files: [file] } });
+
+    expect(screen.getByText(/Files must be less than 100MB/)).toBeVisible();
+  });
 });


### PR DESCRIPTION
Potential fix for #807.

I managed to confirm that the mutation was sent twice, resulting in double uploads, but I am unable to manually reproduce the bug.

This ensures that `handleChange` will not trigger another mutation if the previous one is still in flight.