### PR TITLE
Fix: OWASP Zap CI timeout

### DIFF
--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'owasp/zap2docker-stable'
-          target: 'http://localhost:3000/'
+          target: 'http://localhost:3000/applicantportal'
           rules_file_name: '.zap/rules.tsv'
           cmd_options: '-a -d -T 5 -m 2'
           issue_title: OWASP Full Scan


### PR DESCRIPTION
I'm not sure why this wasn't failing when we merged in the PR with the new redirects though I assume that Github might just be running a bit slow today. Seems that this is caused by the target being set to `http://localhost:3000/` and the redirect to `/applicantportal` causing it to time out most of the time.

Passing twice now: 
https://github.com/bcgov/CONN-CCBC-portal/actions/runs/3339970295/jobs/5529555075
https://github.com/bcgov/CONN-CCBC-portal/actions/runs/3340019510/jobs/5529662044