### PR TITLE
fix: navigation sidebar padding

### DIFF
--- a/app/components/Analyst/NavItem.tsx
+++ b/app/components/Analyst/NavItem.tsx
@@ -36,10 +36,10 @@ const StyledIconContainer = styled.div`
 `;
 
 const StyledLabelContainer = styled.div`
-  padding-left: 8px;
   display: none;
 
   ${(props) => props.theme.breakpoint.largeUp} {
+    padding-left: 8px;
     display: block;
   }
 `;


### PR DESCRIPTION
Fixes this issue where the padding between the icon and the text doesn't get applied initially on page load:

![before](https://user-images.githubusercontent.com/14259474/199845989-bd7965a2-f86f-4a63-9169-6906e00de76b.png)


This was a weird one that slipped through as it seems to only happen on the initial load of the page and then is fixed on the refresh. I believe it was due to the `display: none` underneath it and something to do with CSS cascading style order.

I moved it into the breakpoint and it seems to have fixed the issue.

