### PR TITLE
fix: fontawesome css loading bug

### DIFF
--- a/app/components/Analyst/NavItem.tsx
+++ b/app/components/Analyst/NavItem.tsx
@@ -18,7 +18,8 @@ const StyledNavItem = styled.div<StyledProps>`
   padding: 8px;
   display: flex;
   border-radius: 4px;
-  background-color: ${(p) => p.selected};
+  background-color: ${(p) => (p.selected ? '#F1F2F3' : 'inherit')};
+  font-weight: ${(p) => (p.selected ? 700 : 400)};
   cursor: pointer;
 
   &:hover {
@@ -31,10 +32,6 @@ const StyledLink = styled.a`
   text-decoration: none;
 `;
 
-const StyledIconContainer = styled.div`
-  width: 12px;
-`;
-
 const StyledLabelContainer = styled.div`
   padding-left: 8px;
   display: none;
@@ -45,15 +42,11 @@ const StyledLabelContainer = styled.div`
 `;
 
 const NavItem: React.FC<Props> = ({ currentPath, href, icon, label }) => {
-  const selectedColour = currentPath === href ? '#F1F2F3' : 'inherit';
-
   return (
     <Link href={href} passHref>
       <StyledLink>
-        <StyledNavItem selected={selectedColour}>
-          <StyledIconContainer>
-            <FontAwesomeIcon icon={icon} fixedWidth aria-hidden="true" />
-          </StyledIconContainer>
+        <StyledNavItem selected={currentPath === href}>
+          <FontAwesomeIcon icon={icon} fixedWidth aria-hidden="true" />
           <StyledLabelContainer>{label}</StyledLabelContainer>
         </StyledNavItem>
       </StyledLink>

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -6,6 +6,8 @@ import { getInitialPreloadedQuery, getRelayProps } from 'relay-nextjs/app';
 import { Settings } from 'luxon';
 import * as Sentry from '@sentry/nextjs';
 import type { AppProps } from 'next/app';
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css';
 import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react';
 import Error500 from 'pages/500';
 import { getClientEnvironment } from 'lib/relay/client';
@@ -13,6 +15,8 @@ import GlobalStyle from 'styles/GobalStyles';
 import GlobalTheme from 'styles/GlobalTheme';
 import BCGovTypography from 'components/BCGovTypography';
 import { SessionExpiryHandler } from 'components';
+
+config.autoAddCss = false;
 
 const clientEnv = getClientEnvironment();
 const initialPreloadedQuery = getInitialPreloadedQuery({


### PR DESCRIPTION
Fix for the Fontawesome bug which we noticed by the padding between the text and the icon to not work properly:
![before](https://user-images.githubusercontent.com/14259474/200006438-d3a0981f-93f6-4444-bcf9-9cf8cf291a25.png)

Though if you refresh the page it would work again correctly. I should have caught this during development as I thought it was weird that the icons wouldn't size correctly unless they were in a container with a set width. Now they are working correctly and inherit their size from the text size of the parent container.

Also I added bold styling to the selected text which I previously missed. Anyways this might be a good one to pull and test locally to confirm it's working on another machine thank you.
