### PR TITLE
feat: route uses roundrobin load balancing

### DIFF
--- a/helm/app/templates/routes/secureRoute.yaml
+++ b/helm/app/templates/routes/secureRoute.yaml
@@ -14,6 +14,8 @@ metadata:
   name: ccbc-secure
   labels: {{ include "ccbc.labels" . | nindent 4 }}
     certbot-managed: "true"
+  annotations:
+    haproxy.router.openshift.io/balance: roundrobin
 
 spec:
   host: {{ .Values.secureRoute.host }}


### PR DESCRIPTION
By default, the routes use the `source` strategy, which means that requests coming from the same IP are directed to the same pod. The round-robin strategy provides better load balancing between the replicas
