### PR TITLE
fix: receive-applications cronjob utc/pst schedule

### DIFF
--- a/helm/app/templates/cronJobs/receive-applications.yaml
+++ b/helm/app/templates/cronJobs/receive-applications.yaml
@@ -5,7 +5,7 @@ metadata:
   labels: {{ include "ccbc.labels" . | nindent 4 }}
 spec:
   suspend: false
-  schedule: "0 9,21 * * *" # run cronjob at At 09:00 and 21:00
+  schedule: "0 1,13 * * *" # run cronjob at At 09:00 and 21:00
   jobTemplate:
     spec:
       backoffLimit: 0


### PR DESCRIPTION
Mars would like this to actually run at 9am/9pm so I adjusted for UTC/PST difference.