### PR TITLE
fix: analyst name

### DIFF
--- a/db/deploy/tables/analyst.sql
+++ b/db/deploy/tables/analyst.sql
@@ -32,7 +32,7 @@ insert into ccbc_public.analyst (given_name, family_name) values
 ('Leslie', 'Chiu'),
 ('Daniel', 'Stanyer'),
 ('Lia', 'Wilson'),
-('Careen', 'Unguran'),
+('Carreen', 'Unguran'),
 ('Justin', 'Bauer'),
 ('Cyril', 'Moersch'),
 ('Afshin', 'Shaabany'),


### PR DESCRIPTION
This fixes the spelling mistake in the list of Analysts we were given. This will make sure it's correct in future dev deployments but we still need to manually edit the name in test and prod.