### PR TITLE
test: add mutation test for create rfi

### DIFF
--- a/app/tests/pages/analyst/application/[applicationId]/rfi/[rfiId]/index.test.tsx
+++ b/app/tests/pages/analyst/application/[applicationId]/rfi/[rfiId]/index.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 import RfiId from 'pages/analyst/application/[applicationId]/rfi/[rfiId]';
+import userEvent from '@testing-library/user-event';
 import PageTestingHelper from 'tests/utils/pageTestingHelper';
 import compiledhistoryQuery, {
   historyQuery,
@@ -191,6 +192,25 @@ describe('The index page', () => {
         name: 'Cancel',
       })
     ).toBeVisible();
+  });
+
+  it('calls the mutation on save', async () => {
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+    const user = userEvent.setup();
+
+    const button = screen.getByRole('button', {
+      name: 'Save',
+    });
+
+    await user.click(button);
+
+    pageTestingHelper.expectMutationToBeCalled('createRfiMutation', {
+      input: {
+        applicationRowId: 1,
+        jsonData: {},
+      },
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
I had this completed but must have reverted some work and lost it and it should be in there.

@AntBush I saw your sonarcloud failing, if you modify this test file for `/assessments` page it should pass no  problem.
