### PR TITLE
feat: use updater to manually link new formData object

### DIFF
--- a/app/pages/analyst/application/[applicationId]/assessments.tsx
+++ b/app/pages/analyst/application/[applicationId]/assessments.tsx
@@ -18,6 +18,7 @@ import { LoadingSpinner } from 'components';
 const getAssessmentsQuery = graphql`
   query assessmentsQuery($rowId: Int!) {
     applicationByRowId(rowId: $rowId) {
+      id
       rowId
       assessmentForm(_slug: "screeningAssessmentSchema") {
         jsonData
@@ -54,6 +55,14 @@ const Assessments = ({
       },
       optimisticResponse: {
         jsonData: e.formData,
+      },
+      updater: (store, data) => {
+        const application = store.get(applicationByRowId.id);
+        application.setLinkedRecord(
+          store.get(data.createAssessmentForm.formData.id),
+          'assessmentForm',
+          { _slug: 'screeningAssessmentSchema' }
+        );
       },
     });
   };

--- a/app/schema/mutations/assessment/createScreeningAssessment.ts
+++ b/app/schema/mutations/assessment/createScreeningAssessment.ts
@@ -8,6 +8,7 @@ const mutation = graphql`
   ) {
     createAssessmentForm(input: $input) {
       formData {
+        id
         rowId
         jsonData
       }


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Issue has to do with creating a new record and Relay not knowing what to link it to: https://github.com/facebook/relay/issues/1652#issuecomment-343332001 

This uses an updater to fix the problem, an optimisticUpdater should also be added to fix this issue since right now it switches back and forth from the old FormData (from the optimistic response not having the data) to the new FormData (after the updater runs with the response)

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
