### PR TITLE
fix: use null coalescing operator instead of or operator

### DIFF
--- a/app/components/Form/FormBase.tsx
+++ b/app/components/Form/FormBase.tsx
@@ -29,7 +29,7 @@ const FormBase: React.FC<FormPropsWithTheme<any>> = (props) => {
       customFormats={customFormats}
       transformErrors={transformErrors}
       noHtml5Validate
-      omitExtraData={omitExtraData || true}
+      omitExtraData={omitExtraData ?? true}
       showErrorList={false}
     />
   );


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

When testing the form in test, noticed that the files were disappearing, needed to use the `null coalescing` operator instead of an `or`

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
