### PR TITLE
fix: added permissions to function application_status

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -45,3 +45,9 @@ The `data` folder contains the data that we want do deploy in our various enviro
 In local environments, the `make deploy_dev_data`, `make deploy_test_data` and `make deploy_prod_data` can be used to deploy the sqitch changes and the data in a single command.
 
 The `data` folder is also cypress' fixtures folder, meaning that any of the scripts in it can be run in our cypress tests using commands such as `cy.sqlFixture("dev/001_intake");`
+
+## Metabase 
+
+Metabase uses `ccbc_readonly` user to connect to the database. If `ccbc_readonly` user needs to use any of computed columns, necessary permissions should be granted manually. 
+
+I.e. `grant execute on function ccbc_public.application_status to ccbc_readonly;`

--- a/db/deploy/computed_columns/application_status.sql
+++ b/db/deploy/computed_columns/application_status.sql
@@ -14,7 +14,10 @@ grant execute on function ccbc_public.application_status to ccbc_auth_user;
 grant execute on function ccbc_public.application_status to ccbc_job_executor;
 grant execute on function ccbc_public.application_status to ccbc_analyst;
 grant execute on function ccbc_public.application_status to ccbc_admin;
-grant execute on function ccbc_public.application_status to public; -- needed for Metabase
+
+-- ccbc_readonly user is used by Metabase and it is added outside of this project.
+-- statement below should be run manually to allow Metabase users to use the function.
+-- grant execute on function ccbc_public.application_status to ccbc_readonly;  
 
 comment on function ccbc_public.application_status is 'Computed column to return status of an application';
 

--- a/db/deploy/computed_columns/application_status.sql
+++ b/db/deploy/computed_columns/application_status.sql
@@ -14,6 +14,7 @@ grant execute on function ccbc_public.application_status to ccbc_auth_user;
 grant execute on function ccbc_public.application_status to ccbc_job_executor;
 grant execute on function ccbc_public.application_status to ccbc_analyst;
 grant execute on function ccbc_public.application_status to ccbc_admin;
+grant execute on function ccbc_public.application_status to ccbc_readonly;
 
 comment on function ccbc_public.application_status is 'Computed column to return status of an application';
 

--- a/db/deploy/computed_columns/application_status@1.20.0.sql
+++ b/db/deploy/computed_columns/application_status@1.20.0.sql
@@ -14,7 +14,6 @@ grant execute on function ccbc_public.application_status to ccbc_auth_user;
 grant execute on function ccbc_public.application_status to ccbc_job_executor;
 grant execute on function ccbc_public.application_status to ccbc_analyst;
 grant execute on function ccbc_public.application_status to ccbc_admin;
-grant execute on function ccbc_public.application_status to public; -- needed for Metabase
 
 comment on function ccbc_public.application_status is 'Computed column to return status of an application';
 

--- a/db/revert/computed_columns/application_status.sql
+++ b/db/revert/computed_columns/application_status.sql
@@ -12,6 +12,8 @@ $$ language sql stable;
 
 grant execute on function ccbc_public.application_status to ccbc_auth_user;
 grant execute on function ccbc_public.application_status to ccbc_job_executor;
+grant execute on function ccbc_public.application_status to ccbc_analyst;
+grant execute on function ccbc_public.application_status to ccbc_admin;
 
 comment on function ccbc_public.application_status is 'Computed column to return status of an application';
 

--- a/db/revert/computed_columns/application_status@1.20.0.sql
+++ b/db/revert/computed_columns/application_status@1.20.0.sql
@@ -12,9 +12,6 @@ $$ language sql stable;
 
 grant execute on function ccbc_public.application_status to ccbc_auth_user;
 grant execute on function ccbc_public.application_status to ccbc_job_executor;
-grant execute on function ccbc_public.application_status to ccbc_analyst;
-grant execute on function ccbc_public.application_status to ccbc_admin;
-grant execute on function ccbc_public.application_status to public; -- needed for Metabase
 
 comment on function ccbc_public.application_status is 'Computed column to return status of an application';
 

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -118,4 +118,4 @@ tables/attachment_001_add_analyst_roles 2022-12-06T16:02:43Z Anthony Bushara <an
 @1.22.0 2022-12-08T20:08:49Z Anthony Bushara <anthony@button.is> # release v1.22.0
 @1.23.0 2022-12-11T04:15:58Z Marcel Mueller <marcel@button.is> # release v1.23.0
 @1.23.1 2022-12-13T03:39:09Z Anthony Bushara <anthony@button.is> # release v1.23.1
-computed_columns/application_status [computed_columns/application_status@1.20.0] 2022-12-13T18:14:55Z ,,, ladimir <vladimir@button.is> # ccbc_readonly role
+computed_columns/application_status [computed_columns/application_status@1.20.0] 2022-12-13T18:14:55Z ,,, Vladimir <vladimir@button.is> # ccbc_readonly role

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -118,3 +118,4 @@ tables/attachment_001_add_analyst_roles 2022-12-06T16:02:43Z Anthony Bushara <an
 @1.22.0 2022-12-08T20:08:49Z Anthony Bushara <anthony@button.is> # release v1.22.0
 @1.23.0 2022-12-11T04:15:58Z Marcel Mueller <marcel@button.is> # release v1.23.0
 @1.23.1 2022-12-13T03:39:09Z Anthony Bushara <anthony@button.is> # release v1.23.1
+computed_columns/application_status [computed_columns/application_status@1.20.0] 2022-12-13T18:14:55Z ,,, ladimir <vladimir@button.is> # ccbc_readonly role


### PR DESCRIPTION
Implements #999

Metabase uses ccbc_readonly user which did not have execute permissions on function `application_status`.
This PR fixes the issue.
