### PR TITLE
fix/datetime

### DIFF
--- a/app/lib/theme/fields/SubmissionDescriptionField.tsx
+++ b/app/lib/theme/fields/SubmissionDescriptionField.tsx
@@ -1,5 +1,6 @@
 import { FieldProps } from '@rjsf/core';
-import { DateTime } from 'luxon';
+import { useFeature } from '@growthbook/growthbook-react';
+import dateTimeSubtracted from 'utils/dateTimeSubtracted';
 import Description from '../components/Description';
 
 /*
@@ -16,18 +17,17 @@ const SubmissionField: React.FC<FieldProps> = (props) => {
     registry,
   } = props;
 
+  const showSubtractedTime = useFeature('show_subtracted_time').value || {};
+
   // Remove the title so it isn't rendered twice.
   const submissionSchemaWithoutTitle = { ...schema };
   delete submissionSchemaWithoutTitle.title;
   const { ObjectField } = registry.fields;
 
-  const submissionDescriptionText = `Certify that you have the authority to submit this information on behalf of the Applicant. After submission, you can continue to edit this application until the intake closes on ${DateTime.fromISO(
+  const submissionDescriptionText = `Certify that you have the authority to submit this information on behalf of the Applicant. After submission, you can continue to edit this application until the intake closes on ${dateTimeSubtracted(
     intakeCloseTimestamp,
-    {
-      locale: 'en-CA',
-      zone: 'America/Vancouver',
-    }
-  ).toFormat('MMMM dd, yyyy, ttt')}`;
+    showSubtractedTime ? 30 : 0
+  )}`;
 
   return (
     <>

--- a/app/lib/theme/fields/SubmissionDescriptionField.tsx
+++ b/app/lib/theme/fields/SubmissionDescriptionField.tsx
@@ -17,7 +17,7 @@ const SubmissionField: React.FC<FieldProps> = (props) => {
     registry,
   } = props;
 
-  const showSubtractedTime = useFeature('show_subtracted_time').value || {};
+  const showSubtractedTime = useFeature('show_subtracted_time').value || 0;
 
   // Remove the title so it isn't rendered twice.
   const submissionSchemaWithoutTitle = { ...schema };
@@ -26,7 +26,7 @@ const SubmissionField: React.FC<FieldProps> = (props) => {
 
   const submissionDescriptionText = `Certify that you have the authority to submit this information on behalf of the Applicant. After submission, you can continue to edit this application until the intake closes on ${dateTimeSubtracted(
     intakeCloseTimestamp,
-    showSubtractedTime ? 30 : 0
+    showSubtractedTime
   )}`;
 
   return (

--- a/app/pages/applicantportal/dashboard.tsx
+++ b/app/pages/applicantportal/dashboard.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { withRelay, RelayProps } from 'relay-nextjs';
 import { usePreloadedQuery } from 'react-relay/hooks';
 import { graphql } from 'react-relay';
-import { DateTime } from 'luxon';
+import dateTimeSubtracted from 'utils/dateTimeSubtracted';
 import styled from 'styled-components';
 import Link from '@button-inc/bcgov-theme/Link';
 import { useFeature } from '@growthbook/growthbook-react';
@@ -92,6 +92,7 @@ const Dashboard = ({
 
   const openIntakeBanner = useFeature('open_intake_alert').value || {};
   const closedIntakeBanner = useFeature('closed_intake_alert').value || {};
+  const showSubtractedTime = useFeature('show_subtracted_time').value || {};
 
   return (
     <Layout session={session} title="Connecting Communities BC">
@@ -117,11 +118,8 @@ const Dashboard = ({
           {openIntake ? (
             <p>
               Review of applications will begin on{' '}
-              {DateTime.fromISO(closeTimestamp, {
-                locale: 'en-CA',
-                zone: 'America/Vancouver',
-              }).toFormat('MMMM dd, yyyy, ttt')}
-              . You can edit draft and submitted applications until this date.
+              {dateTimeSubtracted(closeTimestamp, showSubtractedTime ? 30 : 0)}.
+              You can edit draft and submitted applications until this date.
             </p>
           ) : (
             <div>

--- a/app/pages/applicantportal/dashboard.tsx
+++ b/app/pages/applicantportal/dashboard.tsx
@@ -92,7 +92,7 @@ const Dashboard = ({
 
   const openIntakeBanner = useFeature('open_intake_alert').value || {};
   const closedIntakeBanner = useFeature('closed_intake_alert').value || {};
-  const showSubtractedTime = useFeature('show_subtracted_time').value || {};
+  const showSubtractedTime = useFeature('show_subtracted_time').value || 0;
 
   return (
     <Layout session={session} title="Connecting Communities BC">
@@ -118,8 +118,8 @@ const Dashboard = ({
           {openIntake ? (
             <p>
               Review of applications will begin on{' '}
-              {dateTimeSubtracted(closeTimestamp, showSubtractedTime ? 30 : 0)}.
-              You can edit draft and submitted applications until this date.
+              {dateTimeSubtracted(closeTimestamp, showSubtractedTime)}. You can
+              edit draft and submitted applications until this date.
             </p>
           ) : (
             <div>

--- a/app/pages/applicantportal/index.tsx
+++ b/app/pages/applicantportal/index.tsx
@@ -6,7 +6,7 @@ import Link from '@button-inc/bcgov-theme/Link';
 import styled from 'styled-components';
 import { useMemo } from 'react';
 import { Button, Callout } from '@button-inc/bcgov-theme';
-import { DateTime } from 'luxon';
+import dateTimeSubtracted from 'utils/dateTimeSubtracted';
 import { ButtonLink, DynamicAlert, Layout, LoginForm } from '../../components';
 import defaultRelayOptions from '../../lib/relay/withRelayOptions';
 import { applicantportalQuery } from '../../__generated__/applicantportalQuery.graphql';
@@ -75,6 +75,10 @@ const Home = ({
     preloadedQuery
   );
 
+  const openIntakeBanner = useFeature('open_intake_alert').value || {};
+  const closedIntakeBanner = useFeature('closed_intake_alert').value || {};
+  const showSubtractedTime = useFeature('show_subtracted_time').value || {};
+
   const intakeCalloutChildren = useMemo(() => {
     if (!openIntake)
       return (
@@ -89,9 +93,10 @@ const Home = ({
         </>
       );
 
-    const formattedClosingDate = DateTime.fromISO(openIntake.closeTimestamp)
-      .minus({ minutes: 30 })
-      .toLocaleString(DateTime.DATETIME_FULL);
+    const formattedClosingDate = dateTimeSubtracted(
+      openIntake.closeTimestamp,
+      showSubtractedTime ? 30 : 0
+    );
 
     return (
       <BoldText>
@@ -102,9 +107,6 @@ const Home = ({
       </BoldText>
     );
   }, [openIntake]);
-
-  const openIntakeBanner = useFeature('open_intake_alert').value || {};
-  const closedIntakeBanner = useFeature('closed_intake_alert').value || {};
 
   return (
     <Layout session={session} title="Connecting Communities BC">

--- a/app/pages/applicantportal/index.tsx
+++ b/app/pages/applicantportal/index.tsx
@@ -77,7 +77,7 @@ const Home = ({
 
   const openIntakeBanner = useFeature('open_intake_alert').value || {};
   const closedIntakeBanner = useFeature('closed_intake_alert').value || {};
-  const showSubtractedTime = useFeature('show_subtracted_time').value || {};
+  const showSubtractedTime = useFeature('show_subtracted_time').value || 0;
 
   const intakeCalloutChildren = useMemo(() => {
     if (!openIntake)
@@ -95,7 +95,7 @@ const Home = ({
 
     const formattedClosingDate = dateTimeSubtracted(
       openIntake.closeTimestamp,
-      showSubtractedTime ? 30 : 0
+      showSubtractedTime
     );
 
     return (

--- a/app/tests/pages/applicantportal/dashboard.test.tsx
+++ b/app/tests/pages/applicantportal/dashboard.test.tsx
@@ -39,6 +39,14 @@ const mockClosedIntake: FeatureResult<JSONValue> = {
   ruleId: 'open_intake_alert',
 };
 
+const mockSubtractedValue: FeatureResult<JSONValue> = {
+  value: 30,
+  source: 'defaultValue',
+  on: null,
+  off: null,
+  ruleId: 'show_subtracted_time',
+};
+
 const mockQueryPayload = {
   Query() {
     return {
@@ -155,6 +163,16 @@ describe('The index page', () => {
     expect(screen.getByTestId('custom-alert')).toBeInTheDocument();
     expect(screen.getByText(openedIntakeMessage)).toBeInTheDocument();
     expect(screen.queryByText(closedIntakeMessage)).toBeNull();
+  });
+
+  it('displays the close intake message when there an open intake', async () => {
+    jest.spyOn(moduleApi, 'useFeature').mockReturnValue(mockSubtractedValue);
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    expect(
+      screen.getByText(/August 19, 2027, 8:30:00 a.m. PDT/)
+    ).toBeInTheDocument();
   });
 
   it('has create intake button enabled when there is an open intake', async () => {

--- a/app/tests/pages/applicantportal/index.test.tsx
+++ b/app/tests/pages/applicantportal/index.test.tsx
@@ -72,7 +72,15 @@ const mockClosedIntake: FeatureResult<JSONValue> = {
   source: 'defaultValue',
   on: null,
   off: null,
-  ruleId: 'open_intake_alert',
+  ruleId: 'closed_intake_alert',
+};
+
+const mockSubtractedValue: FeatureResult<JSONValue> = {
+  value: 30,
+  source: 'defaultValue',
+  on: null,
+  off: null,
+  ruleId: 'show_subtracted_time',
 };
 
 const pageTestingHelper = new PageTestingHelper<applicantportalQuery>({
@@ -118,12 +126,13 @@ describe('The index page', () => {
   });
 
   it('Displays the callout message with correct time when there is an open intake', () => {
+    jest.spyOn(moduleApi, 'useFeature').mockReturnValue(mockSubtractedValue);
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
 
     expect(
       screen.getByText(
-        /Applications are accepted until August 19, 2027 at 8:30 a.m. PDT./
+        /Applications are accepted until August 19, 2027, 8:30:00 a.m. PDT./
       )
     ).toBeInTheDocument();
   });

--- a/app/tests/utils/dateTimeSubtract.test.ts
+++ b/app/tests/utils/dateTimeSubtract.test.ts
@@ -1,0 +1,21 @@
+import dateTimeSubtracted from 'utils/dateTimeSubtracted';
+
+describe('The isRouteAuthorized function', () => {
+  it('returns the correct subtracted datetime', () => {
+    expect(dateTimeSubtracted('2023-03-15T00:00:00-07:00', 30)).toBe(
+      'March 14, 2023, 11:30:00 p.m. PDT'
+    );
+  });
+
+  it('returns the correct datetime with no minutes passed in', () => {
+    expect(dateTimeSubtracted('2023-03-15T00:00:00-07:00')).toBe(
+      'March 15, 2023, 12:00:00 a.m. PDT'
+    );
+  });
+
+  it('returns the correct datetime with 0 minutes passed in', () => {
+    expect(dateTimeSubtracted('2023-03-15T00:00:00-07:00', 0)).toBe(
+      'March 15, 2023, 12:00:00 a.m. PDT'
+    );
+  });
+});

--- a/app/utils/dateTimeSubtracted.ts
+++ b/app/utils/dateTimeSubtracted.ts
@@ -1,11 +1,13 @@
 import { DateTime } from 'luxon';
 
-const dateTimeSubtracted = (timeStamp: string, minutesToSubtract?: number) => {
+const dateTimeSubtracted = (timeStamp, minutes) => {
+  // not ideal but checking type here for now due mockOpenIntake applicantportal/index test mocking useFeature and returning object
+  const minutesToSubtract = typeof minutes === 'number' ? minutes : 0;
   return DateTime.fromISO(timeStamp, {
     locale: 'en-CA',
     zone: 'America/Vancouver',
   })
-    .minus({ minutes: minutesToSubtract || 0 })
+    .minus({ minutes: minutesToSubtract })
     .toFormat('MMMM dd, yyyy, ttt');
 };
 

--- a/app/utils/dateTimeSubtracted.ts
+++ b/app/utils/dateTimeSubtracted.ts
@@ -1,0 +1,12 @@
+import { DateTime } from 'luxon';
+
+const dateTimeSubtracted = (timeStamp: string, minutesToSubtract?: number) => {
+  return DateTime.fromISO(timeStamp, {
+    locale: 'en-CA',
+    zone: 'America/Vancouver',
+  })
+    .minus({ minutes: minutesToSubtract || 0 })
+    .toFormat('MMMM dd, yyyy, ttt');
+};
+
+export default dateTimeSubtracted;


### PR DESCRIPTION
This is using a feature flag `show_subtracted_time` which returns a number which is set at 30. Either the number can be changed or the feature can be disabled and the time will show as normal.
