### PR TITLE
change status updates

### DIFF
--- a/app/components/Analyst/AnalystLayout.tsx
+++ b/app/components/Analyst/AnalystLayout.tsx
@@ -15,6 +15,10 @@ const StyledFlex = styled.div`
   display: flex;
 `;
 
+const StyledFormDiv = styled(FormDiv)`
+  max-width: 100%;
+`;
+
 interface Props {
   children: JSX.Element[] | JSX.Element;
   query: any;
@@ -34,7 +38,7 @@ const AnalystLayout: React.FC<Props> = ({ children, query }) => {
       <ApplicationHeader query={queryFragment} />
       <StyledFlex>
         <NavigationSidebar />
-        <FormDiv>{children}</FormDiv>
+        <StyledFormDiv>{children}</StyledFormDiv>
       </StyledFlex>
     </StyledContainer>
   );

--- a/app/components/Analyst/ApplicationHeader.tsx
+++ b/app/components/Analyst/ApplicationHeader.tsx
@@ -24,7 +24,6 @@ const StyledDiv = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  width: 100%;
 `;
 
 interface Props {

--- a/app/components/Analyst/ChangeModal.tsx
+++ b/app/components/Analyst/ChangeModal.tsx
@@ -34,6 +34,7 @@ interface Props {
   onSave: Function;
   saveLabel?: string;
   title?: string;
+  value: string;
 }
 
 const ChangeModal: React.FC<Props> = ({
@@ -46,6 +47,7 @@ const ChangeModal: React.FC<Props> = ({
   onSave,
   saveLabel = 'Save',
   title = 'Reason for change',
+  value,
 }) => {
   return (
     <StyledModal id={id}>
@@ -55,6 +57,7 @@ const ChangeModal: React.FC<Props> = ({
         <StyledTextArea
           maxLength={maxLength}
           onChange={(e) => onChange(e)}
+          value={value}
           data-testid="reason-for-change"
         />
         <ModalButtons>

--- a/app/components/Analyst/ChangeStatus.tsx
+++ b/app/components/Analyst/ChangeStatus.tsx
@@ -97,12 +97,31 @@ const ChangeStatus = ({ query }) => {
 
   const hiddenStatusTypes = ['draft', 'submitted', 'withdrawn'];
 
+  const statusOrder = [
+    'received',
+    'screening',
+    'assessment',
+    'recommendation',
+    'conditionally_approved',
+    'approved',
+    'complete',
+    'on_hold',
+    'cancelled',
+    'closed',
+  ];
+
   // Filter unwanted status types
   const statusTypes = allApplicationStatusTypes.nodes.filter(
     (statusType) => !hiddenStatusTypes.includes(statusType.name)
   );
 
   const [changeReason, setChangeReason] = useState('');
+  const statusTypesOrdered = statusOrder
+    .map((statusName) => {
+      return statusTypes.find((statusType) => statusType?.name === statusName);
+    })
+    .filter(Boolean);
+
   const [currentStatus, setcurrentStatus] = useState(
     getStatus(status, statusTypes)
   );
@@ -163,8 +182,8 @@ const ChangeStatus = ({ query }) => {
         statusStyles={statusStyles[draftStatus?.name]}
         value={draftStatus?.name}
       >
-        {statusTypes &&
-          statusTypes.map((statusType) => {
+        {statusTypesOrdered &&
+          statusTypesOrdered.map((statusType) => {
             const { description, name, id } = statusType;
             return (
               <StyledOption value={name} key={id}>

--- a/app/components/Analyst/ChangeStatus.tsx
+++ b/app/components/Analyst/ChangeStatus.tsx
@@ -152,6 +152,7 @@ const ChangeStatus = ({ query }) => {
         },
       },
       onCompleted: () => {
+        setChangeReason('');
         setcurrentStatus(draftStatus);
       },
     });
@@ -164,6 +165,7 @@ const ChangeStatus = ({ query }) => {
         saveLabel="Save change"
         cancelLabel="Cancel change"
         onSave={handleSave}
+        value={changeReason}
         onCancel={() => setDraftStatus(currentStatus)}
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
           setChangeReason(e.target.value)

--- a/app/components/AnalystDashboard/AnalystRow.tsx
+++ b/app/components/AnalystDashboard/AnalystRow.tsx
@@ -26,6 +26,7 @@ const StyledBaseCell = styled('td')`
 const StyledCcbdIdCell = styled(StyledBaseCell)`
   width: 9.7%;
   padding-left: 12px !important;
+  white-space: nowrap;
 `;
 
 const StyledStatusCell = styled(StyledBaseCell)`

--- a/app/components/AnalystDashboard/AnalystRow.tsx
+++ b/app/components/AnalystDashboard/AnalystRow.tsx
@@ -3,6 +3,7 @@ import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 import { AnalystRow_application$key } from '__generated__/AnalystRow_application.graphql';
 import AssignLead from 'components/Analyst/AssignLead';
+import StatusPill from './StatusPill';
 
 interface Props {
   application: AnalystRow_application$key;
@@ -51,15 +52,6 @@ const StyledPackageCell = styled(StyledBaseCell)`
   width: 5.81%;
 `;
 
-const PillSpan = styled.span`
-  background-color: #1a5a96;
-  color: #ffffff;
-  border-radius: 16px;
-  padding: 4px 12px;
-  text-transform: capitalize;
-  white-space: nowrap;
-`;
-
 const AnalystRow: React.FC<Props> = ({ query, application }) => {
   const queryFragment = useFragment(
     graphql`
@@ -101,7 +93,7 @@ const AnalystRow: React.FC<Props> = ({ query, application }) => {
     <StyledRow onClick={handleOnClick}>
       <StyledCcbdIdCell>{ccbcNumber}</StyledCcbdIdCell>
       <StyledStatusCell>
-        <PillSpan>{status}</PillSpan>
+        <StatusPill status={status} />
       </StyledStatusCell>
       <StyledProjectNameCell>{projectName}</StyledProjectNameCell>
       <StyledOrganizationNameCell>

--- a/app/components/AnalystDashboard/AnalystTable.tsx
+++ b/app/components/AnalystDashboard/AnalystTable.tsx
@@ -4,9 +4,7 @@ import AnalystRow from './AnalystRow';
 
 const StyledTable = styled('table')`
   margin-bottom: 0px;
-  table-layout: fixed;
   width: 100%;
-  max-width: 1170px;
 `;
 
 const StyledTableHead = styled('thead')`

--- a/app/components/AnalystDashboard/StatusPill.tsx
+++ b/app/components/AnalystDashboard/StatusPill.tsx
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+import statusStyles from 'data/statusStyles';
+
+interface Props {
+  status: string;
+}
+
+interface StatusPillProps {
+  statusStyles: {
+    primary: string;
+    backgroundColor: string;
+    pillWidth: string;
+    description: string;
+  };
+}
+
+const StyledStatusPill = styled.div<StatusPillProps>`
+  color: ${(props) => props.statusStyles?.primary};
+  background-color: ${(props) => props.statusStyles?.backgroundColor};
+  border: none;
+  border-radius: 16px;
+  padding: 4px 12px;
+  white-space: nowrap;
+  width: fit-content;
+`;
+
+const StatusPill: React.FC<Props> = ({ status }) => {
+  const pillStyles = statusStyles[status];
+  return (
+    <StyledStatusPill statusStyles={pillStyles}>
+      {pillStyles.description}
+    </StyledStatusPill>
+  );
+};
+
+export default StatusPill;

--- a/app/components/AnalystDashboard/index.tsx
+++ b/app/components/AnalystDashboard/index.tsx
@@ -1,2 +1,3 @@
 export { default as AnalystTable } from './AnalystTable';
 export { default as AnalystRow } from './AnalystRow';
+export { default as StatusPill } from './StatusPill';

--- a/app/data/statusStyles.ts
+++ b/app/data/statusStyles.ts
@@ -3,51 +3,67 @@ const statusStyles = {
     primary: '#FFFFFF',
     backgroundColor: '#1F8234',
     pillWidth: '116px',
+    description: 'Approved',
   },
   assessment: {
     primary: '#003366',
     backgroundColor: '#DBE6F0',
     pillWidth: '136px',
+    description: 'Assessment',
   },
   cancelled: {
     primary: '#414141',
     backgroundColor: '#E8E8E8',
     pillWidth: '120px',
+    description: 'Cancelled',
   },
   closed: {
     primary: '#414141',
     backgroundColor: '#E8E8E8',
     pillWidth: '100px',
+    description: 'Closed',
   },
   complete: {
     primary: '#003366',
     backgroundColor: '#DBE6F0',
     pillWidth: '118px',
+    description: 'Complete',
   },
   conditionally_approved: {
     primary: '#FFFFFF',
     backgroundColor: '#1F8234',
     pillWidth: '212px',
+    description: 'Conditionally approved',
   },
   on_hold: {
     primary: '#A37000',
     backgroundColor: '#FFECC2',
     pillWidth: '106px',
+    description: 'On hold',
   },
   received: {
     primary: '#FFFFFF',
     backgroundColor: '#345FA9',
     pillWidth: '116px',
+    description: 'Received',
   },
   recommendation: {
     primary: '#003366',
     backgroundColor: '#DBE6F0',
     pillWidth: '172px',
+    description: 'Recommendation',
   },
   screening: {
     primary: '#003366',
     backgroundColor: '#DBE6F0',
     pillWidth: '120px',
+    description: 'Screening',
+  },
+  withdrawn: {
+    primary: '#414141',
+    backgroundColor: '#E8E8E8',
+    pillWidth: '120px',
+    description: 'Withdrawn',
   },
 };
 

--- a/app/pages/analyst/application/[applicationId]/edit/[section].tsx
+++ b/app/pages/analyst/application/[applicationId]/edit/[section].tsx
@@ -140,6 +140,7 @@ const EditApplication = ({
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
             setChangeReason(e.target.value)
           }
+          value={changeReason}
         />
       </AnalystLayout>
     </Layout>

--- a/app/pages/analyst/dashboard.tsx
+++ b/app/pages/analyst/dashboard.tsx
@@ -19,7 +19,7 @@ const getDashboardAnalystQuery = graphql`
 `;
 
 const StyledDashboardContainer = styled.div`
-  display: block;
+  width: 100%;
 `;
 
 const StyledBtnContainer = styled.div`

--- a/app/tests/pages/analyst/dashboard.test.tsx
+++ b/app/tests/pages/analyst/dashboard.test.tsx
@@ -18,7 +18,7 @@ const mockQueryPayload = {
       allApplications: {
         nodes: [
           {
-            id: 'someId',
+            id: '1',
             rowId: 1,
             status: 'received',
             projectName: 'Test Proj Name',
@@ -26,12 +26,28 @@ const mockQueryPayload = {
             organizationName: 'Test Org Name',
           },
           {
-            id: 'someOtherId',
+            id: '2',
             rowId: 2,
-            status: 'received',
+            status: 'approved',
             projectName: 'Test Proj Name 2',
             ccbcNumber: 'CCBC-010002',
             organizationName: 'Test Org Name 2',
+          },
+          {
+            id: '3',
+            rowId: 3,
+            status: 'cancelled',
+            projectName: 'Test Proj Name 3',
+            ccbcNumber: 'CCBC-010003',
+            organizationName: 'Test Org Name 3',
+          },
+          {
+            id: '4',
+            rowId: 4,
+            status: 'assessment',
+            projectName: 'Test Proj Name 4',
+            ccbcNumber: 'CCBC-010004',
+            organizationName: 'Test Org Name 4',
           },
         ],
       },
@@ -202,6 +218,46 @@ describe('The index page', () => {
         },
       }
     );
+  });
+
+  it('has the correct received status styles', () => {
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    const statusName = screen.getByText('Received');
+
+    expect(statusName).toHaveStyle('color: #FFFFFF');
+    expect(statusName).toHaveStyle('background-color: #345FA9;');
+  });
+
+  it('has the correct approved status styles', () => {
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    const statusName = screen.getByText('Approved');
+
+    expect(statusName).toHaveStyle('color: #FFFFFF');
+    expect(statusName).toHaveStyle('background-color: #1F8234;');
+  });
+
+  it('has the correct cancelled status styles', () => {
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    const statusName = screen.getByText('Cancelled');
+
+    expect(statusName).toHaveStyle('color: #414141');
+    expect(statusName).toHaveStyle('background-color: #E8E8E8;');
+  });
+
+  it('has the correct assessment status styles', () => {
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    const statusName = screen.getByText('Assessment');
+
+    expect(statusName).toHaveStyle('color: #003366');
+    expect(statusName).toHaveStyle('background-color: #DBE6F0;');
   });
 
   afterEach(() => {


### PR DESCRIPTION
- fix: application header title wrap
- fix: analyst dashboard width
- feat: analyst dashboard status pill component
- test: add dashboard status pill tests
- feat: change status list order
- feat: clear modal textarea on successful save

This PR fixes some minor styling issues and adds features that weren't in the acceptance criteria for the change status ticket such as styled status pills on the analyst dashboard and changing the order of the `ChangeStatus` dropdown. 
