### PR TITLE
fix: assessment delete attachment error

### DIFF
--- a/app/lib/theme/widgets/FileWidget.tsx
+++ b/app/lib/theme/widgets/FileWidget.tsx
@@ -145,18 +145,29 @@ const FileWidget: React.FC<FileWidgetProps> = ({
       },
     };
 
+    const deleteFileFromFormData = (res) => {
+      const attachmentRowId = res?.updateAttachmentByRowId?.attachment?.rowId;
+      const indexOfFile = value.findIndex(
+        (object) => object.id === attachmentRowId
+      );
+      const newFileList = [...value];
+      newFileList.splice(indexOfFile, 1);
+      const isFileListEmpty = newFileList.length <= 0;
+      onChange(isFileListEmpty ? null : newFileList);
+    };
+
     deleteAttachment({
       variables,
-      onError: () => setError('deleteFailed'),
+      onError: (res) => {
+        /// Allow files to be deleted from form data if attachment record was already archived
+        if (res.message.includes('Deleted records cannot be modified')) {
+          deleteFileFromFormData(res);
+        } else {
+          setError('deleteFailed');
+        }
+      },
       onCompleted: (res) => {
-        const attachmentRowId = res?.updateAttachmentByRowId?.attachment?.rowId;
-        const indexOfFile = value.findIndex(
-          (object) => object.id === attachmentRowId
-        );
-        const newFileList = [...value];
-        newFileList.splice(indexOfFile, 1);
-        const isFileListEmpty = newFileList.length <= 0;
-        onChange(isFileListEmpty ? null : newFileList);
+        deleteFileFromFormData(res);
       },
     });
   };
@@ -241,9 +252,9 @@ const FileWidget: React.FC<FileWidgetProps> = ({
     hiddenFileInput.current.click();
   };
 
-  const showModal =() =>{
+  const showModal = () => {
     window.location.hash = 'file-error';
-  }
+  };
   const buttonLabel = () => {
     if (isFiles && !allowMultipleFiles) {
       return 'Replace';
@@ -262,10 +273,9 @@ const FileWidget: React.FC<FileWidgetProps> = ({
     await fetch(url)
       .then((response) => response.json())
       .then((response) => {
-        if(response.avstatus) {
+        if (response.avstatus) {
           showModal();
-        }
-        else {
+        } else {
           window.open(response, '_blank');
         }
       });

--- a/app/pages/analyst/application/[applicationId]/assessments/screening.tsx
+++ b/app/pages/analyst/application/[applicationId]/assessments/screening.tsx
@@ -39,6 +39,9 @@ const ScreeningAssessment = ({
 
   const { applicationByRowId, session } = query;
   const [createAssessment, isCreating] = useCreateScreeningAssessmentMutation();
+  const [formData, setFormData] = useState(
+    applicationByRowId.assessmentForm?.jsonData
+  );
   const [isFormSaved, setIsFormSaved] = useState(false);
 
   const handleSubmit = async (e: ISubmitEvent<any>) => {
@@ -74,9 +77,10 @@ const ScreeningAssessment = ({
           schema={screening}
           uiSchema={screeningUiSchema}
           noValidate
-          formData={applicationByRowId.assessmentForm?.jsonData}
-          onChange={() => {
+          formData={formData}
+          onChange={(e) => {
             setIsFormSaved(false);
+            setFormData({ ...e.formData });
           }}
           omitExtraData={false}
           formContext={{ query }}


### PR DESCRIPTION
Fixes the error deleting attachments on the assessments page after it has been saved as well as allowing archived attachments to be deleted from the form data incase someone deletes then refreshes the page without saving.