### PR TITLE
fix: review schema type of organization display value

### DIFF
--- a/app/formSchema/reviewUiSchema.tsx
+++ b/app/formSchema/reviewUiSchema.tsx
@@ -116,6 +116,9 @@ const reviewUiSchema = {
   },
   organizationProfile: {
     ...organizationProfile,
+    typeOfOrganization: {
+      'ui:widget': 'TextWidget',
+    },
     'ui:field': 'SectionField',
   },
   otherFundingSources: {


### PR DESCRIPTION
Fix for #1062 `typeOfOrganization` radio widgets field displaying as 'Yes' instead of the enum value on the review pages. You can see this is fixed in the Happo diffs here:

https://happo.io/a/336/p/1172/compare/67fd91f05835a7a6a050c9b5269cfdd5c319555a/586a6822219b30bc36bd66dd0c5a5d994b9b76da