### PR TITLE
fix: use bc-sans package

### DIFF
--- a/app/components/BCGovTypography.tsx
+++ b/app/components/BCGovTypography.tsx
@@ -1,5 +1,6 @@
 import Typography from 'typography';
 import { TypographyStyle } from 'react-typography';
+import '@bcgov/bc-sans/css/BCSans.css';
 
 const typography = new Typography({
   baseFontSize: '16px',

--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "@aws-sdk/middleware-apply-body-checksum": "^3.226.0",
     "@bcgov-cas/sso-express": "^3.2.0",
     "@bcgov-cas/sso-react": "^2.0.0",
+    "@bcgov/bc-sans": "^1.0.1",
     "@button-inc/bcgov-theme": "^1.0.1",
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
     "@fortawesome/free-solid-svg-icons": "^6.2.0",


### PR DESCRIPTION
Fix for missing bc sans package

Happo diffs:
https://happo.io/a/336/p/1172/compare/4a5a2bd7043029e607ce20e0bf4be7ad97a6e511/881509bab1e305c1f2fa1bd208e6b63cbe7e631c