### PR TITLE
fix: reply rfi requires due date set to display on applicant portal

### DIFF
--- a/db/deploy/computed_columns/application_has_rfi_open.sql
+++ b/db/deploy/computed_columns/application_has_rfi_open.sql
@@ -6,7 +6,7 @@ create or replace function ccbc_public.application_has_rfi_open(application ccbc
 $$
   -- id is not null and ( rfiDueBy ? rfiDueByTimestamp > now() : true)
   -- Subtract 1 day from now() as it was returning false 1 day earlier than the due date
-  select (id is not null) and (coalesce(to_timestamp(json_data ->> 'rfiDueBy', 'YYYY-MM-DD') > now() - interval '1' day, 'true'::boolean)) from ccbc_public.application_rfi(application);
+  select (id is not null) and (coalesce(to_timestamp(json_data ->> 'rfiDueBy', 'YYYY-MM-DD') > now() - interval '1' day, 'false'::boolean)) from ccbc_public.application_rfi(application);
 
 $$ language sql stable;
 

--- a/db/test/unit/computed_columns/application_has_rfi_open_test.sql
+++ b/db/test/unit/computed_columns/application_has_rfi_open_test.sql
@@ -52,9 +52,9 @@ select results_eq (
   )
   $$,
   $$
-    values('t'::boolean)
+    values('f'::boolean)
   $$,
-  'The current rfi is open as it has no end date'
+  'The current rfi is not open as no due date was set'
 );
 
 select ccbc_public.create_rfi(1, '{"rfiDueBy": "2022-04-01"}'::jsonb);


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements #1105

<!--
Add detailed description of the changes if the PR title isn't enough
 -->

This changed the `application_has_rfi_open` function to return false if there was no due date set. Previously it returned true so an RFI would remain open indefinitely.

Also I didn't do a `sqitch rework` on the function because we haven't made a release since #1096 which also edited this file was merged.
