### PR TITLE
1106 rfi files

### DIFF
--- a/app/components/Analyst/RFI/ObjectFieldTemplate.tsx
+++ b/app/components/Analyst/RFI/ObjectFieldTemplate.tsx
@@ -22,6 +22,10 @@ const StyledH4 = styled.h4`
   width: 100%;
 `;
 
+const StyledSection = styled.section`
+  display: inline-block;
+`;
+
 const ObjectFieldTemplate: React.FC<ObjectFieldTemplateProps> = ({
   uiSchema,
   title,
@@ -36,7 +40,7 @@ const ObjectFieldTemplate: React.FC<ObjectFieldTemplateProps> = ({
     return <RequestedFilesField properties={properties} />;
   }
   return (
-    <section>
+    <StyledSection>
       {showLabel && <StyledH4>{uiSchema['ui:title'] || title}</StyledH4>}
 
       <StyledContainer columns={columnCount as number}>
@@ -44,7 +48,7 @@ const ObjectFieldTemplate: React.FC<ObjectFieldTemplateProps> = ({
           return <StyledItem key={prop.name}>{prop.content}</StyledItem>;
         })}
       </StyledContainer>
-    </section>
+    </StyledSection>
   );
 };
 

--- a/app/components/Analyst/RFI/RfiForm.tsx
+++ b/app/components/Analyst/RFI/RfiForm.tsx
@@ -10,6 +10,7 @@ import { useCreateRfiMutation } from 'schema/mutations/application/createRfi';
 import { graphql, useFragment } from 'react-relay';
 import { RfiForm_RfiData$key } from '__generated__/RfiForm_RfiData.graphql';
 import { useUpdateWithTrackingRfiMutation } from 'schema/mutations/application/updateWithTrackingRfiMutation';
+import removeFalseyValuesFromObject from 'utils/removeFalseValuesFromObject';
 import RfiTheme from './RfiTheme';
 
 const StyledCancel = styled(Button)`
@@ -39,17 +40,27 @@ const RfiForm = ({ rfiDataKey }: RfiFormProps) => {
     `,
     rfiDataKey
   );
+
   const rfiUrl = `/analyst/application/${applicationId}/rfi`;
   const [createRfi] = useCreateRfiMutation();
   const [updateRfi] = useUpdateWithTrackingRfiMutation();
 
   const handleSubmit = (e: ISubmitEvent<any>) => {
+    const formData = {
+      ...e.formData,
+      rfiAdditionalFiles: {
+        // Remove fields with false values from object to prevent unintended bugs when
+        // a user unchecks a previously checked field.
+        ...removeFalseyValuesFromObject(e.formData.rfiAdditionalFiles),
+      },
+    };
+
     if (isNewRfiForm) {
       createRfi({
         variables: {
           input: {
             applicationRowId: parseInt(applicationId as string, 10),
-            jsonData: e.formData,
+            jsonData: formData,
           },
         },
         onCompleted: () => {
@@ -64,7 +75,7 @@ const RfiForm = ({ rfiDataKey }: RfiFormProps) => {
       updateRfi({
         variables: {
           input: {
-            jsonData: e.formData,
+            jsonData: formData,
             rfiRowId: parseInt(rfiId as string, 10),
           },
         },

--- a/app/tests/utils/removeFalseyValuesFromObject.test.ts
+++ b/app/tests/utils/removeFalseyValuesFromObject.test.ts
@@ -1,0 +1,24 @@
+import removeFalseyValuesFromObject from 'utils/removeFalseValuesFromObject';
+
+const mockObject = {
+  key1: true,
+  key2: false,
+  key3: 100,
+  key4: 'test',
+  key5: false,
+  key6: false,
+};
+
+describe('The removeFalseyValuesFromObject function', () => {
+  it('returns the correct object', () => {
+    expect(removeFalseyValuesFromObject(mockObject)).toStrictEqual({
+      key1: true,
+      key3: 100,
+      key4: 'test',
+    });
+  });
+
+  it('handles an empty object', () => {
+    expect(removeFalseyValuesFromObject({})).toStrictEqual({});
+  });
+});

--- a/app/utils/removeFalseValuesFromObject.ts
+++ b/app/utils/removeFalseValuesFromObject.ts
@@ -1,0 +1,14 @@
+// Removes keys with falsey values from a shallow object
+const removeFalseyValuesFromObject = (object) => {
+  const hasKeys = Object.keys(object).length > 0;
+  if (!hasKeys) return {};
+
+  return Object.keys(object).reduce((acc, key) => {
+    if (object[key]) {
+      acc[key] = object[key];
+    }
+    return acc;
+  }, {});
+};
+
+export default removeFalseyValuesFromObject;

--- a/db/deploy/computed_columns/application_has_rfi_open.sql
+++ b/db/deploy/computed_columns/application_has_rfi_open.sql
@@ -6,7 +6,7 @@ create or replace function ccbc_public.application_has_rfi_open(application ccbc
 $$
   -- id is not null and ( rfiDueBy ? rfiDueByTimestamp > now() : true)
   -- Subtract 1 day from now() as it was returning false 1 day earlier than the due date
-  select (id is not null) and (coalesce(to_timestamp(json_data ->> 'rfiDueBy', 'YYYY-MM-DD') > now() - interval '1' day, 'true'::boolean)) from ccbc_public.application_rfi(application);
+  select (id is not null) and (coalesce(to_timestamp(json_data ->> 'rfiDueBy', 'YYYY-MM-DD') > now() - interval '1' day, 'false'::boolean)) from ccbc_public.application_rfi(application);
 
 $$ language sql stable;
 

--- a/db/deploy/computed_columns/application_has_rfi_open.sql
+++ b/db/deploy/computed_columns/application_has_rfi_open.sql
@@ -4,9 +4,13 @@ begin;
 
 create or replace function ccbc_public.application_has_rfi_open(application ccbc_public.application) returns boolean as
 $$
-  -- id is not null and ( rfiDueBy ? rfiDueByTimestamp > now() : true)
+  -- id is not null and ( rfiDueBy ? rfiDueByTimestamp > now() : true) and rfiAdditionalFiles is not empty
   -- Subtract 1 day from now() as it was returning false 1 day earlier than the due date
-  select (id is not null) and (coalesce(to_timestamp(json_data ->> 'rfiDueBy', 'YYYY-MM-DD') > now() - interval '1' day, 'false'::boolean)) from ccbc_public.application_rfi(application);
+  select (id is not null) and
+    (coalesce(to_timestamp(json_data ->> 'rfiDueBy', 'YYYY-MM-DD') > now() - interval '1' day
+       and json_data ->> 'rfiAdditionalFiles' <> '{}',
+    'false'::boolean))
+  from ccbc_public.application_rfi(application);
 
 $$ language sql stable;
 

--- a/db/test/unit/computed_columns/application_has_rfi_open_test.sql
+++ b/db/test/unit/computed_columns/application_has_rfi_open_test.sql
@@ -52,9 +52,9 @@ select results_eq (
   )
   $$,
   $$
-    values('t'::boolean)
+    values('f'::boolean)
   $$,
-  'The current rfi is open as it has no end date'
+  'The current rfi is not open as no due date was set'
 );
 
 select ccbc_public.create_rfi(1, '{"rfiDueBy": "2022-04-01"}'::jsonb);

--- a/db/test/unit/computed_columns/application_has_rfi_open_test.sql
+++ b/db/test/unit/computed_columns/application_has_rfi_open_test.sql
@@ -1,6 +1,6 @@
 begin;
 
-select plan(10);
+select plan(12);
 
 truncate table
   ccbc_public.application,
@@ -43,7 +43,8 @@ select results_eq (
   'No existing open rfi '
 );
 
-select ccbc_public.create_rfi(1, '{}'::jsonb);
+-- RFI always saves rfiAdditionalFiles object even when no files were selected
+select ccbc_public.create_rfi(1, '{"rfiAdditionalFiles": {}}'::jsonb);
 
 select results_eq (
   $$
@@ -54,10 +55,10 @@ select results_eq (
   $$
     values('f'::boolean)
   $$,
-  'The current rfi is not open as no due date was set'
+  'The current rfi is not open as no due date was set and no files were requested'
 );
 
-select ccbc_public.create_rfi(1, '{"rfiDueBy": "2022-04-01"}'::jsonb);
+select ccbc_public.create_rfi(1, '{"rfiDueBy": "2022-04-01", "rfiAdditionalFiles": {"testField": "true"}}'::jsonb);
 
 select results_eq (
   $$
@@ -68,10 +69,10 @@ select results_eq (
   $$
     values('t'::boolean)
   $$,
-  'The current rfi is open with a due by date of current date'
+  'The current rfi is open with a due by date of current date and file fields exists'
 );
 
-select ccbc_public.create_rfi(1, '{"rfiDueBy": "2022-03-31"}'::jsonb);
+select ccbc_public.create_rfi(1, '{"rfiDueBy": "2022-03-31", "rfiAdditionalFiles": {"testField": "true"}}'::jsonb);
 
 select results_eq (
   $$
@@ -85,7 +86,7 @@ select results_eq (
   'The current rfi is closed with a due by date before the current date'
 );
 
-select ccbc_public.create_rfi(1, '{"rfiDueBy": "2022-04-02"}'::jsonb);
+select ccbc_public.create_rfi(1, '{"rfiDueBy": "2022-04-02", "rfiAdditionalFiles": {"testField": "true"}}'::jsonb);
 
 select results_eq (
   $$
@@ -96,7 +97,35 @@ select results_eq (
   $$
     values('t'::boolean)
   $$,
-  'The current rfi is open with a due by date after the current date'
+  'The current rfi is open with a due by date after the current date and there are requested files'
+);
+
+select ccbc_public.create_rfi(1, '{"rfiDueBy": "2023-04-02", "rfiAdditionalFiles": {}}'::jsonb);
+
+select results_eq (
+  $$
+  select ccbc_public.application_has_rfi_open(
+    (select row(application.*)::ccbc_public.application from ccbc_public.application)
+  )
+  $$,
+  $$
+    values('f'::boolean)
+  $$,
+  'The current rfi is closed with no files requested'
+);
+
+select ccbc_public.create_rfi(1, '{"rfiDueBy": "2023-04-02", "rfiAdditionalFiles": {"testField": "true"}}'::jsonb);
+
+select results_eq (
+  $$
+  select ccbc_public.application_has_rfi_open(
+    (select row(application.*)::ccbc_public.application from ccbc_public.application)
+  )
+  $$,
+  $$
+    values('t'::boolean)
+  $$,
+  'The current rfi is open with files requested'
 );
 
 select function_privs_are(


### PR DESCRIPTION
This is branched off #1107 though we can probably just merge this one. Since we haven't made a release since the last changes to `application_has_rfi_open` no `sqitch rework` was needed.

Takes care a few issues from #1105 and #1106:
- #1105 
- #1106
- Also fixes bug if a user unchecks requested files RJSF would leave that field in the form data but set to false. So I created a function `removeFalseyValuesFromObject` to sanitize the form data of those false fields when we submit.
- Fixed a weird CSS bug on the analyst RFI side.
