### PR TITLE
806-analyst-header

### DIFF
--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { BaseNavigation } from '@button-inc/bcgov-theme/Navigation';
 import { BaseHeader } from '@button-inc/bcgov-theme/Header';
 import Link from 'next/link';
@@ -42,47 +43,52 @@ interface Props {
   title?: string;
 }
 
-const Navigation: React.FC<Props> = ({ isLoggedIn = false, title = '' }) => (
-  <BaseNavigation>
-    <StyledBaseHeader>
-      <StyledDiv>
-        <BaseHeader.Group className="banner">
-          <Link passHref href="/">
-            <a>
-              <Image
-                style={{ cursor: 'pointer' }}
-                priority
-                src="/icons/BCID_CC_RGB_rev.svg"
-                alt="Logo for Province of British Columbia Connected Communities"
-                height={100}
-                width={300}
-              />
-            </a>
-          </Link>
-        </BaseHeader.Group>
-        <StyledMainTitle>
-          <h1>{title}</h1>
-        </StyledMainTitle>
-        <StyledRightSideLinks>
-          {isLoggedIn && (
-            <>
-              <Link passHref href="/applicantportal/dashboard">
-                <StyledAnchor data-testid="dashboard-btn-test">
-                  Dashboard
-                </StyledAnchor>
-              </Link>
-              |
-            </>
-          )}
-          <NavLoginForm
-            action={isLoggedIn ? '/logout' : '/login'}
-            linkText={isLoggedIn ? 'Logout' : 'Login'}
-          />
-        </StyledRightSideLinks>
-      </StyledDiv>
-    </StyledBaseHeader>
-    <SubHeader />
-  </BaseNavigation>
-);
+const Navigation: React.FC<Props> = ({ isLoggedIn = false, title = '' }) => {
+  const router = useRouter();
+  const isApplicantPortal = router?.pathname.startsWith('/applicantportal');
+
+  return (
+    <BaseNavigation>
+      <StyledBaseHeader>
+        <StyledDiv>
+          <BaseHeader.Group className="banner">
+            <Link passHref href="/">
+              <a>
+                <Image
+                  style={{ cursor: 'pointer' }}
+                  priority
+                  src="/icons/BCID_CC_RGB_rev.svg"
+                  alt="Logo for Province of British Columbia Connected Communities"
+                  height={100}
+                  width={300}
+                />
+              </a>
+            </Link>
+          </BaseHeader.Group>
+          <StyledMainTitle>
+            <h1>{title}</h1>
+          </StyledMainTitle>
+          <StyledRightSideLinks>
+            {isLoggedIn && isApplicantPortal && (
+              <>
+                <Link passHref href="/applicantportal/dashboard">
+                  <StyledAnchor data-testid="dashboard-btn-test">
+                    Dashboard
+                  </StyledAnchor>
+                </Link>
+                |
+              </>
+            )}
+            <NavLoginForm
+              action={isLoggedIn ? '/logout' : '/login'}
+              linkText={isLoggedIn ? 'Logout' : 'Login'}
+            />
+          </StyledRightSideLinks>
+        </StyledDiv>
+      </StyledBaseHeader>
+      {isApplicantPortal && <SubHeader />}
+    </BaseNavigation>
+  );
+};
 
 export default Navigation;

--- a/app/pages/applicantportal/index.tsx
+++ b/app/pages/applicantportal/index.tsx
@@ -1,3 +1,4 @@
+import type { NextPageContext } from 'next';
 import { usePreloadedQuery } from 'react-relay/hooks';
 import { withRelay, RelayProps } from 'relay-nextjs';
 import { graphql } from 'react-relay';
@@ -227,7 +228,25 @@ const Home = ({
 
 export const withRelayOptions = {
   ...defaultRelayOptions,
-  serverSideProps: async () => ({}),
+  serverSideProps: async (ctx: NextPageContext) => {
+    const { default: getAuthRole } = await import('../../utils/getAuthRole');
+
+    const request = ctx.req as any;
+    const authRole = getAuthRole(request);
+    const pgRole = authRole?.pgRole;
+    const isAnalyst = pgRole === 'ccbc_admin' || pgRole === 'ccbc_analyst';
+
+    // Redirect signed in analysts to the analyst landing page
+    if (isAnalyst) {
+      return {
+        redirect: {
+          destination: authRole.landingRoute,
+        },
+      };
+    }
+
+    return {};
+  },
 };
 
 export default withRelay(Home, getApplicantportalQuery, withRelayOptions);

--- a/app/tests/pages/applicantportal/dashboard.test.tsx
+++ b/app/tests/pages/applicantportal/dashboard.test.tsx
@@ -136,6 +136,9 @@ const pageTestingHelper = new PageTestingHelper<dashboardQuery>({
 describe('The index page', () => {
   beforeEach(() => {
     pageTestingHelper.reinit();
+    pageTestingHelper.setMockRouterValues({
+      pathname: '/applicantportal/dashboard',
+    });
   });
 
   it('displays the correct nav links when user is logged in', () => {

--- a/app/tests/pages/applicantportal/index.test.tsx
+++ b/app/tests/pages/applicantportal/index.test.tsx
@@ -95,7 +95,13 @@ describe('The index page', () => {
   });
 
   it('does not redirect an unauthorized user', async () => {
-    expect(await withRelayOptions.serverSideProps()).toEqual({});
+    expect(
+      await withRelayOptions.serverSideProps({
+        pathname: '',
+        query: undefined,
+        AppTree: undefined,
+      })
+    ).toEqual({});
   });
 
   it('Displays the Go to dashboard button for a logged in user', async () => {


### PR DESCRIPTION
Implements #806

I also added a redirect for logged in analysts/admin on the homepage `/applicantportal` route. It now redirects them to the analyst side as the dashboard button led to an error page (due to lack of permissions) as well as the issues with the nav we were trying to fix here. 