### PR TITLE
chore: upgrade gitleaks

### DIFF
--- a/.bin/install-gitleaks-linux-x64.sh
+++ b/.bin/install-gitleaks-linux-x64.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -xeuo pipefail;
 
-version="8.15.2";
-releases_api="https://api.github.com/repos/zricethezav/gitleaks/releases/latest";
+version="8.15.3";
+releases_api="https://api.github.com/repos/zricethezav/gitleaks/releases/tags/v${version}";
 releases_json="$(curl -s ${releases_api})";
 
 case "$OSTYPE" in


### PR DESCRIPTION
I upgraded Gitleaks and slightly modified the script so it is locked into this version and shouldn't break CI when a new release comes out.
