### PR TITLE
1119 add admin tab

### DIFF
--- a/app/components/Admin/AdminTabs.tsx
+++ b/app/components/Admin/AdminTabs.tsx
@@ -8,14 +8,14 @@ interface LinkProps {
 
 const StyledA = styled.a<LinkProps>`
   text-decoration: none;
-  font-weight: 700;
+  font-weight: ${(props) => (props.selected ? 700 : 400)};
   font-size: 24px;
+  white-space: nowrap;
   color: ${(props) => (props.selected ? props.theme.color.text : '#9B9B9B')};
-  padding: 0px 16px;
-  border: 1px solid #d6d6d6;
   background-color: ${(props) => props.theme.color.white};
+  padding: 8px 16px 0px 16px;
+  border: 1px solid #d6d6d6;
   border-bottom: ${(props) => (props.selected ? 'none' : '1px solid #d6d6d6')};
-  padding-top: 8px;
   border-radius: 4px 4px 0px 0px;
   margin-right: 16px;
   position: relative;
@@ -23,6 +23,10 @@ const StyledA = styled.a<LinkProps>`
 
   &:hover {
     opacity: ${(props) => (props.selected ? `1` : `0.6`)};
+  }
+
+  @-moz-document url-prefix() {
+    top: ${(props) => (props.selected ? '-1.2px' : '-2px')};
   }
 `;
 

--- a/app/components/Admin/AdminTabs.tsx
+++ b/app/components/Admin/AdminTabs.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import styled from 'styled-components';
+
+interface LinkProps {
+  selected: boolean;
+}
+
+const StyledA = styled.a<LinkProps>`
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 24px;
+  color: ${(props) => (props.selected ? props.theme.color.text : '#9B9B9B')};
+  padding: 0px 16px;
+  border: 1px solid #d6d6d6;
+  background-color: ${(props) => props.theme.color.white};
+  border-bottom: ${(props) => (props.selected ? 'none' : '1px solid #d6d6d6')};
+  padding-top: 8px;
+  border-radius: 4px 4px 0px 0px;
+  margin-right: 16px;
+  position: relative;
+  top: ${(props) => (props.selected ? '-0.8px' : '-1px')};
+
+  &:hover {
+    opacity: ${(props) => (props.selected ? `1` : `0.6`)};
+  }
+`;
+
+const StyledNav = styled.nav`
+  border-bottom: 1px solid #d6d6d6;
+  margin-bottom: 16px;
+`;
+
+const AdminTabs = () => {
+  const router = useRouter();
+  const downloadAttachmentsHref = '/analyst/admin/download-attachments';
+  const applicationIntakesHref = '/analyst/admin/application-intakes';
+  const listOfAnalystsHref = '/analyst/admin/list-of-analysts';
+
+  return (
+    <StyledNav>
+      <Link href={downloadAttachmentsHref} passHref>
+        <StyledA selected={router?.pathname.includes(downloadAttachmentsHref)}>
+          Download attachments
+        </StyledA>
+      </Link>
+      <Link href={applicationIntakesHref} passHref>
+        <StyledA selected={router?.pathname.includes(applicationIntakesHref)}>
+          Application intakes
+        </StyledA>
+      </Link>
+      <Link href={listOfAnalystsHref} passHref>
+        <StyledA selected={router?.pathname.includes(listOfAnalystsHref)}>
+          List of analysts
+        </StyledA>
+      </Link>
+    </StyledNav>
+  );
+};
+
+export default AdminTabs;

--- a/app/components/AnalystDashboard/DashboardTabs.tsx
+++ b/app/components/AnalystDashboard/DashboardTabs.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import styled from 'styled-components';
+
+interface LinkProps {
+  selected: boolean;
+}
+
+const StyledA = styled.a<LinkProps>`
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 32px;
+  color: ${(props) => (props.selected ? props.theme.color.text : '#9B9B9B')};
+  padding: 0px 16px;
+  border-bottom: ${(props) => (props.selected ? '2px solid #000000' : 'none')};
+`;
+
+const StyledNav = styled.nav`
+  border-bottom: 1px solid #d6d6d6;
+  margin-bottom: 16px;
+  padding-bottom: 3px;
+`;
+
+const DashboardTabs = () => {
+  const router = useRouter();
+
+  return (
+    <StyledNav>
+      <Link href="/analyst/dashboard" passHref>
+        <StyledA selected={router?.pathname.startsWith('/analyst/dashboard')}>
+          Dashboard
+        </StyledA>
+      </Link>
+      <Link href="/analyst/admin/download-attachments" passHref>
+        <StyledA selected={router?.pathname.startsWith('/analyst/admin')}>
+          Administrative
+        </StyledA>
+      </Link>
+    </StyledNav>
+  );
+};
+
+export default DashboardTabs;

--- a/app/components/AnalystDashboard/DashboardTabs.tsx
+++ b/app/components/AnalystDashboard/DashboardTabs.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 interface LinkProps {
+  isAdmin: boolean;
   selected: boolean;
 }
 
@@ -12,7 +14,8 @@ const StyledA = styled.a<LinkProps>`
   font-size: 32px;
   color: ${(props) => (props.selected ? props.theme.color.text : '#9B9B9B')};
   padding: 0px 16px;
-  border-bottom: ${(props) => (props.selected ? '2px solid #000000' : 'none')};
+  border-bottom: ${(props) =>
+    props.selected && props.isAdmin ? '2px solid #000000' : 'none'};
 `;
 
 const StyledNav = styled.nav`
@@ -21,18 +24,36 @@ const StyledNav = styled.nav`
   padding-bottom: 3px;
 `;
 
-const DashboardTabs = () => {
+const DashboardTabs = ({ session }) => {
+  const queryFragment = useFragment(
+    graphql`
+      fragment DashboardTabs_query on KeycloakJwt {
+        authRole
+      }
+    `,
+    session
+  );
+
+  const { authRole } = queryFragment;
+
+  const isAdmin = authRole === 'ccbc_admin';
   const router = useRouter();
 
   return (
     <StyledNav>
       <Link href="/analyst/dashboard" passHref>
-        <StyledA selected={router?.pathname.startsWith('/analyst/dashboard')}>
+        <StyledA
+          isAdmin={isAdmin}
+          selected={router?.pathname.startsWith('/analyst/dashboard')}
+        >
           Dashboard
         </StyledA>
       </Link>
       <Link href="/analyst/admin/download-attachments" passHref>
-        <StyledA selected={router?.pathname.startsWith('/analyst/admin')}>
+        <StyledA
+          isAdmin={isAdmin}
+          selected={router?.pathname.startsWith('/analyst/admin')}
+        >
           Administrative
         </StyledA>
       </Link>

--- a/app/components/AnalystDashboard/DashboardTabs.tsx
+++ b/app/components/AnalystDashboard/DashboardTabs.tsx
@@ -16,11 +16,15 @@ const StyledA = styled.a<LinkProps>`
   padding: 0px 16px;
   border-bottom: ${(props) =>
     props.selected && props.isAdmin ? '2px solid #000000' : 'none'};
+
+  &:hover {
+    opacity: ${(props) => (props.selected ? `1` : `0.6`)};
+  }
 `;
 
 const StyledNav = styled.nav`
   border-bottom: 1px solid #d6d6d6;
-  margin-bottom: 16px;
+  margin-bottom: 24px;
   padding-bottom: 3px;
 `;
 

--- a/app/components/AnalystDashboard/DashboardTabs.tsx
+++ b/app/components/AnalystDashboard/DashboardTabs.tsx
@@ -10,7 +10,7 @@ interface LinkProps {
 
 const StyledA = styled.a<LinkProps>`
   text-decoration: none;
-  font-weight: 700;
+  font-weight: ${(props) => (props.selected ? 700 : 400)};
   font-size: 32px;
   color: ${(props) => (props.selected ? props.theme.color.text : '#9B9B9B')};
   padding: 0px 16px;
@@ -39,7 +39,6 @@ const DashboardTabs = ({ session }) => {
   );
 
   const { authRole } = queryFragment;
-
   const isAdmin = authRole === 'ccbc_admin';
   const router = useRouter();
 
@@ -53,14 +52,16 @@ const DashboardTabs = ({ session }) => {
           Dashboard
         </StyledA>
       </Link>
-      <Link href="/analyst/admin/download-attachments" passHref>
-        <StyledA
-          isAdmin={isAdmin}
-          selected={router?.pathname.startsWith('/analyst/admin')}
-        >
-          Administrative
-        </StyledA>
-      </Link>
+      {isAdmin && (
+        <Link href="/analyst/admin/download-attachments" passHref>
+          <StyledA
+            isAdmin={isAdmin}
+            selected={router?.pathname.startsWith('/analyst/admin')}
+          >
+            Administrative
+          </StyledA>
+        </Link>
+      )}
     </StyledNav>
   );
 };

--- a/app/components/AnalystDashboard/index.tsx
+++ b/app/components/AnalystDashboard/index.tsx
@@ -1,3 +1,4 @@
 export { default as AnalystTable } from './AnalystTable';
 export { default as AnalystRow } from './AnalystRow';
+export { default as DashboardTabs } from './DashboardTabs';
 export { default as StatusPill } from '../Analyst/StatusPill';

--- a/app/cypress/integration/analyst/admin/application-intakes.spec.js
+++ b/app/cypress/integration/analyst/admin/application-intakes.spec.js
@@ -1,0 +1,15 @@
+import testSetup from './setup.js';
+
+describe('The admin Application intakes page', () => {
+  beforeEach(() => {
+    testSetup();
+  });
+
+  it('loads', () => {
+    cy.visit('/analyst/admin/application-intakes');
+    cy.contains('a', 'Application intakes');
+    cy.get('body').happoScreenshot({
+      component: 'The admin Application intakes page',
+    });
+  });
+});

--- a/app/cypress/integration/analyst/admin/download-attachments.spec.js
+++ b/app/cypress/integration/analyst/admin/download-attachments.spec.js
@@ -1,0 +1,15 @@
+import testSetup from './setup.js';
+
+describe('The admin Download attachments page', () => {
+  beforeEach(() => {
+    testSetup();
+  });
+
+  it('loads', () => {
+    cy.visit('/analyst/admin/download-attachments');
+    cy.contains('a', 'Download attachments');
+    cy.get('body').happoScreenshot({
+      component: 'The admin Download attachments page',
+    });
+  });
+});

--- a/app/cypress/integration/analyst/admin/list-of-analysts.spec.js
+++ b/app/cypress/integration/analyst/admin/list-of-analysts.spec.js
@@ -1,0 +1,15 @@
+import testSetup from './setup.js';
+
+describe('The admin List of analysts page', () => {
+  beforeEach(() => {
+    testSetup();
+  });
+
+  it('loads', () => {
+    cy.visit('/analyst/admin/list-of-analysts');
+    cy.contains('a', 'List of analysts');
+    cy.get('body').happoScreenshot({
+      component: 'The admin List of analysts page',
+    });
+  });
+});

--- a/app/cypress/integration/analyst/admin/setup.js
+++ b/app/cypress/integration/analyst/admin/setup.js
@@ -1,0 +1,12 @@
+const testSetup = () => {
+  cy.mockLogin('ccbc_admin');
+  const mockedDateString = '2023-10-10';
+  const mockedDate = new Date(mockedDateString);
+  cy.useMockedTime(mockedDate);
+  cy.sqlFixture('e2e/reset_db');
+  cy.sqlFixture('e2e/001_intake');
+  cy.sqlFixture('e2e/001_application');
+  cy.sqlFixture('e2e/001_application_received');
+};
+
+export default testSetup;

--- a/app/cypress/integration/analyst/dashboard.spec.js
+++ b/app/cypress/integration/analyst/dashboard.spec.js
@@ -11,7 +11,7 @@ describe('The analyst dashboard', () => {
 
   it('loads', () => {
     cy.visit('/analyst/dashboard');
-    cy.contains('h1', 'Dashboard');
+    cy.contains('a', 'Dashboard');
     cy.get('body').happoScreenshot({ component: 'Analyst Dashboard' });
   });
 

--- a/app/pages/analyst/admin/application-intakes.tsx
+++ b/app/pages/analyst/admin/application-intakes.tsx
@@ -1,0 +1,43 @@
+import { usePreloadedQuery } from 'react-relay/hooks';
+import { withRelay, RelayProps } from 'relay-nextjs';
+import { graphql } from 'react-relay';
+import { AnalystTable, DashboardTabs } from 'components/AnalystDashboard';
+import styled from 'styled-components';
+import defaultRelayOptions from 'lib/relay/withRelayOptions';
+import { Layout } from 'components';
+import { applicationIntakesQuery } from '__generated__/applicationIntakesQuery.graphql';
+
+const getApplicationIntakesQuery = graphql`
+  query applicationIntakesQuery {
+    session {
+      sub
+    }
+    ...AnalystTable_query
+  }
+`;
+
+const StyledContainer = styled.div`
+  width: 100%;
+`;
+
+const ApplicationIntakes = ({
+  preloadedQuery,
+}: RelayProps<Record<string, unknown>, applicationIntakesQuery>) => {
+  const query = usePreloadedQuery(getApplicationIntakesQuery, preloadedQuery);
+  const { session } = query;
+
+  return (
+    <Layout session={session} title="Connecting Communities BC">
+      <StyledContainer>
+        <DashboardTabs />
+        <AnalystTable query={query} />
+      </StyledContainer>
+    </Layout>
+  );
+};
+
+export default withRelay(
+  ApplicationIntakes,
+  getApplicationIntakesQuery,
+  defaultRelayOptions
+);

--- a/app/pages/analyst/admin/application-intakes.tsx
+++ b/app/pages/analyst/admin/application-intakes.tsx
@@ -14,7 +14,6 @@ const getApplicationIntakesQuery = graphql`
       sub
       ...DashboardTabs_query
     }
-    ...AnalystTable_query
   }
 `;
 

--- a/app/pages/analyst/admin/application-intakes.tsx
+++ b/app/pages/analyst/admin/application-intakes.tsx
@@ -11,6 +11,7 @@ const getApplicationIntakesQuery = graphql`
   query applicationIntakesQuery {
     session {
       sub
+      ...DashboardTabs_query
     }
     ...AnalystTable_query
   }
@@ -29,7 +30,7 @@ const ApplicationIntakes = ({
   return (
     <Layout session={session} title="Connecting Communities BC">
       <StyledContainer>
-        <DashboardTabs />
+        <DashboardTabs session={session} />
         <AnalystTable query={query} />
       </StyledContainer>
     </Layout>

--- a/app/pages/analyst/admin/application-intakes.tsx
+++ b/app/pages/analyst/admin/application-intakes.tsx
@@ -1,10 +1,11 @@
 import { usePreloadedQuery } from 'react-relay/hooks';
 import { withRelay, RelayProps } from 'relay-nextjs';
 import { graphql } from 'react-relay';
-import { AnalystTable, DashboardTabs } from 'components/AnalystDashboard';
+import { DashboardTabs } from 'components/AnalystDashboard';
 import styled from 'styled-components';
 import defaultRelayOptions from 'lib/relay/withRelayOptions';
 import { Layout } from 'components';
+import AdminTabs from 'components/Admin/AdminTabs';
 import { applicationIntakesQuery } from '__generated__/applicationIntakesQuery.graphql';
 
 const getApplicationIntakesQuery = graphql`
@@ -31,7 +32,7 @@ const ApplicationIntakes = ({
     <Layout session={session} title="Connecting Communities BC">
       <StyledContainer>
         <DashboardTabs session={session} />
-        <AnalystTable query={query} />
+        <AdminTabs />
       </StyledContainer>
     </Layout>
   );

--- a/app/pages/analyst/admin/download-attachments.tsx
+++ b/app/pages/analyst/admin/download-attachments.tsx
@@ -14,7 +14,6 @@ const getDownloadAttachmentsQuery = graphql`
       sub
       ...DashboardTabs_query
     }
-    ...AnalystTable_query
   }
 `;
 

--- a/app/pages/analyst/admin/download-attachments.tsx
+++ b/app/pages/analyst/admin/download-attachments.tsx
@@ -11,6 +11,7 @@ const getDownloadAttachmentsQuery = graphql`
   query downloadAttachmentsQuery {
     session {
       sub
+      ...DashboardTabs_query
     }
     ...AnalystTable_query
   }
@@ -29,7 +30,7 @@ const DownloadAttachments = ({
   return (
     <Layout session={session} title="Connecting Communities BC">
       <StyledContainer>
-        <DashboardTabs />
+        <DashboardTabs session={session} />
       </StyledContainer>
     </Layout>
   );

--- a/app/pages/analyst/admin/download-attachments.tsx
+++ b/app/pages/analyst/admin/download-attachments.tsx
@@ -5,6 +5,7 @@ import { DashboardTabs } from 'components/AnalystDashboard';
 import styled from 'styled-components';
 import defaultRelayOptions from 'lib/relay/withRelayOptions';
 import { Layout } from 'components';
+import AdminTabs from 'components/Admin/AdminTabs';
 import { downloadAttachmentsQuery } from '__generated__/downloadAttachmentsQuery.graphql';
 
 const getDownloadAttachmentsQuery = graphql`
@@ -31,6 +32,7 @@ const DownloadAttachments = ({
     <Layout session={session} title="Connecting Communities BC">
       <StyledContainer>
         <DashboardTabs session={session} />
+        <AdminTabs />
       </StyledContainer>
     </Layout>
   );

--- a/app/pages/analyst/admin/download-attachments.tsx
+++ b/app/pages/analyst/admin/download-attachments.tsx
@@ -1,0 +1,42 @@
+import { usePreloadedQuery } from 'react-relay/hooks';
+import { withRelay, RelayProps } from 'relay-nextjs';
+import { graphql } from 'react-relay';
+import { DashboardTabs } from 'components/AnalystDashboard';
+import styled from 'styled-components';
+import defaultRelayOptions from 'lib/relay/withRelayOptions';
+import { Layout } from 'components';
+import { downloadAttachmentsQuery } from '__generated__/downloadAttachmentsQuery.graphql';
+
+const getDownloadAttachmentsQuery = graphql`
+  query downloadAttachmentsQuery {
+    session {
+      sub
+    }
+    ...AnalystTable_query
+  }
+`;
+
+const StyledContainer = styled.div`
+  width: 100%;
+`;
+
+const DownloadAttachments = ({
+  preloadedQuery,
+}: RelayProps<Record<string, unknown>, downloadAttachmentsQuery>) => {
+  const query = usePreloadedQuery(getDownloadAttachmentsQuery, preloadedQuery);
+  const { session } = query;
+
+  return (
+    <Layout session={session} title="Connecting Communities BC">
+      <StyledContainer>
+        <DashboardTabs />
+      </StyledContainer>
+    </Layout>
+  );
+};
+
+export default withRelay(
+  DownloadAttachments,
+  getDownloadAttachmentsQuery,
+  defaultRelayOptions
+);

--- a/app/pages/analyst/admin/list-of-analysts.tsx
+++ b/app/pages/analyst/admin/list-of-analysts.tsx
@@ -11,6 +11,7 @@ const getListOfAnalystsQuery = graphql`
   query listOfAnalystsQuery {
     session {
       sub
+      ...DashboardTabs_query
     }
     ...AnalystTable_query
   }
@@ -29,7 +30,7 @@ const ListOfAnalysts = ({
   return (
     <Layout session={session} title="Connecting Communities BC">
       <StyledContainer>
-        <DashboardTabs />
+        <DashboardTabs session={session} />
       </StyledContainer>
     </Layout>
   );

--- a/app/pages/analyst/admin/list-of-analysts.tsx
+++ b/app/pages/analyst/admin/list-of-analysts.tsx
@@ -14,7 +14,6 @@ const getListOfAnalystsQuery = graphql`
       sub
       ...DashboardTabs_query
     }
-    ...AnalystTable_query
   }
 `;
 

--- a/app/pages/analyst/admin/list-of-analysts.tsx
+++ b/app/pages/analyst/admin/list-of-analysts.tsx
@@ -2,6 +2,7 @@ import { usePreloadedQuery } from 'react-relay/hooks';
 import { withRelay, RelayProps } from 'relay-nextjs';
 import { graphql } from 'react-relay';
 import { DashboardTabs } from 'components/AnalystDashboard';
+import AdminTabs from 'components/Admin/AdminTabs';
 import styled from 'styled-components';
 import defaultRelayOptions from 'lib/relay/withRelayOptions';
 import { Layout } from 'components';
@@ -31,6 +32,7 @@ const ListOfAnalysts = ({
     <Layout session={session} title="Connecting Communities BC">
       <StyledContainer>
         <DashboardTabs session={session} />
+        <AdminTabs />
       </StyledContainer>
     </Layout>
   );

--- a/app/pages/analyst/admin/list-of-analysts.tsx
+++ b/app/pages/analyst/admin/list-of-analysts.tsx
@@ -1,0 +1,42 @@
+import { usePreloadedQuery } from 'react-relay/hooks';
+import { withRelay, RelayProps } from 'relay-nextjs';
+import { graphql } from 'react-relay';
+import { DashboardTabs } from 'components/AnalystDashboard';
+import styled from 'styled-components';
+import defaultRelayOptions from 'lib/relay/withRelayOptions';
+import { Layout } from 'components';
+import { listOfAnalystsQuery } from '__generated__/listOfAnalystsQuery.graphql';
+
+const getListOfAnalystsQuery = graphql`
+  query listOfAnalystsQuery {
+    session {
+      sub
+    }
+    ...AnalystTable_query
+  }
+`;
+
+const StyledContainer = styled.div`
+  width: 100%;
+`;
+
+const ListOfAnalysts = ({
+  preloadedQuery,
+}: RelayProps<Record<string, unknown>, listOfAnalystsQuery>) => {
+  const query = usePreloadedQuery(getListOfAnalystsQuery, preloadedQuery);
+  const { session } = query;
+
+  return (
+    <Layout session={session} title="Connecting Communities BC">
+      <StyledContainer>
+        <DashboardTabs />
+      </StyledContainer>
+    </Layout>
+  );
+};
+
+export default withRelay(
+  ListOfAnalysts,
+  getListOfAnalystsQuery,
+  defaultRelayOptions
+);

--- a/app/pages/analyst/dashboard.tsx
+++ b/app/pages/analyst/dashboard.tsx
@@ -13,6 +13,7 @@ const getDashboardAnalystQuery = graphql`
   query dashboardAnalystQuery {
     session {
       sub
+      ...DashboardTabs_query
     }
     ...AnalystTable_query
   }
@@ -39,7 +40,7 @@ const AnalystDashboard = ({
   return (
     <Layout session={session} title="Connecting Communities BC">
       <StyledDashboardContainer>
-        <DashboardTabs />
+        <DashboardTabs session={session} />
         {exportAttachmentsBtn && (
           <StyledBtnContainer>
             <ButtonLink href="/api/analyst/archive">

--- a/app/pages/analyst/dashboard.tsx
+++ b/app/pages/analyst/dashboard.tsx
@@ -2,11 +2,11 @@ import { usePreloadedQuery } from 'react-relay/hooks';
 import { withRelay, RelayProps } from 'relay-nextjs';
 import { graphql } from 'react-relay';
 import { useFeature } from '@growthbook/growthbook-react';
-import { AnalystTable } from 'components/AnalystDashboard';
+import { AnalystTable, DashboardTabs } from 'components/AnalystDashboard';
 import styled from 'styled-components';
-import defaultRelayOptions from '../../lib/relay/withRelayOptions';
-import { ButtonLink, Layout } from '../../components';
-import { dashboardAnalystQuery } from '../../__generated__/dashboardAnalystQuery.graphql';
+import defaultRelayOptions from 'lib/relay/withRelayOptions';
+import { ButtonLink, Layout } from 'components';
+import { dashboardAnalystQuery } from '__generated__/dashboardAnalystQuery.graphql';
 
 // will probably have to change to cursor for pagination/infinte scroll
 const getDashboardAnalystQuery = graphql`
@@ -39,7 +39,7 @@ const AnalystDashboard = ({
   return (
     <Layout session={session} title="Connecting Communities BC">
       <StyledDashboardContainer>
-        <h1>Dashboard</h1>
+        <DashboardTabs />
         {exportAttachmentsBtn && (
           <StyledBtnContainer>
             <ButtonLink href="/api/analyst/archive">

--- a/app/tests/pages/analyst/admin/application-intakes.test.tsx
+++ b/app/tests/pages/analyst/admin/application-intakes.test.tsx
@@ -1,0 +1,59 @@
+import { screen } from '@testing-library/react';
+import ApplicationIntakes from 'pages/analyst/admin/application-intakes';
+import compiledApplicationIntakesQuery, {
+  applicationIntakesQuery,
+} from '__generated__/applicationIntakesQuery.graphql';
+import PageTestingHelper from '../../../utils/pageTestingHelper';
+import { checkTabStyles, checkRouteAuthorization } from './shared-admin-tests';
+
+const mockQueryPayload = {
+  Query() {
+    return {
+      session: {
+        sub: '4e0ac88c-bf05-49ac-948f-7fd53c7a9fd6',
+        authRole: 'ccbc_admin',
+      },
+    };
+  },
+};
+
+jest.mock('@bcgov-cas/sso-express/dist/helpers');
+
+const pageTestingHelper = new PageTestingHelper<applicationIntakesQuery>({
+  pageComponent: ApplicationIntakes,
+  compiledQuery: compiledApplicationIntakesQuery,
+  defaultQueryResolver: mockQueryPayload,
+  defaultQueryVariables: {},
+});
+
+describe('The Application intakes admin page', () => {
+  beforeEach(() => {
+    pageTestingHelper.reinit();
+    pageTestingHelper.setMockRouterValues({
+      pathname: '/analyst/admin/application-intakes',
+    });
+  });
+
+  // Shared admin dashboard pages route authorization tests
+  checkRouteAuthorization();
+
+  it('highlights the correct nav tabs', async () => {
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    const tabName = 'Application intakes';
+
+    // Shared admin dashboard pages tab styles test
+    checkTabStyles(tabName);
+
+    expect(
+      screen.getByRole('link', {
+        name: tabName,
+      })
+    ).toBeVisible();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+});

--- a/app/tests/pages/analyst/admin/download-attachments.test.tsx
+++ b/app/tests/pages/analyst/admin/download-attachments.test.tsx
@@ -1,0 +1,59 @@
+import { screen } from '@testing-library/react';
+import DownloadAttachments from 'pages/analyst/admin/download-attachments';
+import compiledDownloadAttachmentsQuery, {
+  downloadAttachmentsQuery,
+} from '__generated__/downloadAttachmentsQuery.graphql';
+import PageTestingHelper from '../../../utils/pageTestingHelper';
+import { checkTabStyles, checkRouteAuthorization } from './shared-admin-tests';
+
+const mockQueryPayload = {
+  Query() {
+    return {
+      session: {
+        sub: '4e0ac88c-bf05-49ac-948f-7fd53c7a9fd6',
+        authRole: 'ccbc_admin',
+      },
+    };
+  },
+};
+
+jest.mock('@bcgov-cas/sso-express/dist/helpers');
+
+const pageTestingHelper = new PageTestingHelper<downloadAttachmentsQuery>({
+  pageComponent: DownloadAttachments,
+  compiledQuery: compiledDownloadAttachmentsQuery,
+  defaultQueryResolver: mockQueryPayload,
+  defaultQueryVariables: {},
+});
+
+describe('The Download attachments admin page', () => {
+  beforeEach(() => {
+    pageTestingHelper.reinit();
+    pageTestingHelper.setMockRouterValues({
+      pathname: '/analyst/admin/download-attachments',
+    });
+  });
+
+  // Shared admin dashboard pages route authorization tests
+  checkRouteAuthorization();
+
+  it('highlights the correct nav tabs', async () => {
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    const tabName = 'Download attachments';
+
+    // Shared admin dashboard pages tab styles test
+    checkTabStyles(tabName);
+
+    expect(
+      screen.getByRole('link', {
+        name: tabName,
+      })
+    ).toBeVisible();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+});

--- a/app/tests/pages/analyst/admin/list-of-analyst.test.tsx
+++ b/app/tests/pages/analyst/admin/list-of-analyst.test.tsx
@@ -1,0 +1,59 @@
+import { screen } from '@testing-library/react';
+import ListOfAnalysts from 'pages/analyst/admin/list-of-analysts';
+import compiledListOfAnalystsQuery, {
+  listOfAnalystsQuery,
+} from '__generated__/listOfAnalystsQuery.graphql';
+import PageTestingHelper from '../../../utils/pageTestingHelper';
+import { checkTabStyles, checkRouteAuthorization } from './shared-admin-tests';
+
+const mockQueryPayload = {
+  Query() {
+    return {
+      session: {
+        sub: '4e0ac88c-bf05-49ac-948f-7fd53c7a9fd6',
+        authRole: 'ccbc_admin',
+      },
+    };
+  },
+};
+
+jest.mock('@bcgov-cas/sso-express/dist/helpers');
+
+const pageTestingHelper = new PageTestingHelper<listOfAnalystsQuery>({
+  pageComponent: ListOfAnalysts,
+  compiledQuery: compiledListOfAnalystsQuery,
+  defaultQueryResolver: mockQueryPayload,
+  defaultQueryVariables: {},
+});
+
+describe('The Download attachments admin page', () => {
+  beforeEach(() => {
+    pageTestingHelper.reinit();
+    pageTestingHelper.setMockRouterValues({
+      pathname: '/analyst/admin/list-of-analysts',
+    });
+  });
+
+  // Shared admin dashboard pages route authorization tests
+  checkRouteAuthorization();
+
+  it('highlights the correct nav tabs', async () => {
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    const tabName = 'List of analysts';
+
+    // Shared admin dashboard pages tab styles test
+    checkTabStyles(tabName);
+
+    expect(
+      screen.getByRole('link', {
+        name: tabName,
+      })
+    ).toBeVisible();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+});

--- a/app/tests/pages/analyst/admin/shared-admin-tests.ts
+++ b/app/tests/pages/analyst/admin/shared-admin-tests.ts
@@ -1,0 +1,78 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { mocked } from 'jest-mock';
+import { screen } from '@testing-library/react';
+import { isAuthenticated } from '@bcgov-cas/sso-express/dist/helpers';
+import defaultRelayOptions from 'lib/relay/withRelayOptions';
+
+const checkTabStyles = (subTab) => {
+  const adminTab = screen.getByRole('link', { name: 'Administrative' });
+  const dashboardTab = screen.getByRole('link', { name: 'Dashboard' });
+
+  const applicationIntakesTab = screen.getByRole('link', {
+    name: 'Application intakes',
+  });
+  const downloadAttachmentsTab = screen.getByRole('link', {
+    name: 'Download attachments',
+  });
+  const listOfAnalystsTab = screen.getByRole('link', {
+    name: 'List of analysts',
+  });
+
+  expect(dashboardTab).toBeVisible();
+  expect(adminTab).toBeVisible();
+  expect(applicationIntakesTab).toBeVisible();
+  expect(downloadAttachmentsTab).toBeVisible();
+  expect(listOfAnalystsTab).toBeVisible();
+
+  expect(dashboardTab).toHaveStyle('font-weight: 400;');
+  expect(adminTab).toHaveStyle('font-weight: 700;');
+
+  expect(applicationIntakesTab).toHaveStyle(
+    `font-weight: ${subTab === 'Application intakes' ? 700 : 400};`
+  );
+  expect(downloadAttachmentsTab).toHaveStyle(
+    `font-weight: ${subTab === 'Download attachments' ? 700 : 400};`
+  );
+  expect(listOfAnalystsTab).toHaveStyle(
+    `font-weight: ${subTab === 'List of analysts' ? 700 : 400};`
+  );
+};
+
+const checkRouteAuthorization = () => {
+  it('should redirect an unauthorized user', async () => {
+    const ctx = {
+      req: {
+        url: '/analyst/admin/application-intakes',
+        claims: {
+          client_roles: ['analyst'],
+          identity_provider: 'idir',
+        },
+      },
+    } as any;
+
+    expect(await defaultRelayOptions.serverSideProps(ctx)).toEqual({
+      redirect: {
+        destination: '/analyst',
+      },
+    });
+  });
+
+  it('should not redirect a user with admin privileges', async () => {
+    mocked(isAuthenticated).mockReturnValue(true);
+
+    const ctx = {
+      req: {
+        url: '/analyst/admin/application-intakes',
+        claims: {
+          client_roles: ['admin'],
+          identity_provider: 'idir',
+        },
+      },
+    } as any;
+
+    expect(await defaultRelayOptions.serverSideProps(ctx)).toEqual({});
+  });
+};
+
+// eslint-disable-next-line jest/no-export
+export { checkRouteAuthorization, checkTabStyles };

--- a/app/tests/pages/analyst/dashboard.test.tsx
+++ b/app/tests/pages/analyst/dashboard.test.tsx
@@ -138,8 +138,8 @@ describe('The index page', () => {
     pageTestingHelper.renderPage();
 
     expect(
-      screen.getByText('Dashboard', {
-        selector: 'h1',
+      screen.getByRole('link', {
+        name: 'Dashboard',
       })
     ).toBeVisible();
   });

--- a/app/tests/utils/isRouteAuthorized.test.ts
+++ b/app/tests/utils/isRouteAuthorized.test.ts
@@ -39,18 +39,46 @@ describe('The isRouteAuthorized function', () => {
     expect(isRouteAuthorized('/some/other/route', 'ccbc_admin')).toBe(false);
   });
 
-  it('allows ccbc_admin to access any route under the /analyst/(.*) route', () => {
-    expect(isRouteAuthorized('/analyst/(.*)', 'ccbc_admin')).toBe(true);
-    expect(isRouteAuthorized('/analyst/some/other/route', 'ccbc_admin')).toBe(
-      true
-    );
+  it('allows ccbc_admin to access the /analyst/dashboard route', () => {
+    expect(isRouteAuthorized('/analyst/dashboard', 'ccbc_admin')).toBe(true);
   });
 
-  it('allows ccbc_analyst to access any route under the /analyst/(.*) route', () => {
-    expect(isRouteAuthorized('/analyst/(.*)', 'ccbc_analyst')).toBe(true);
-    expect(isRouteAuthorized('/analyst/some/other/route', 'ccbc_analyst')).toBe(
+  it('allows ccbc_analyst to access the /analyst/dashboard route', () => {
+    expect(isRouteAuthorized('/analyst/dashboard', 'ccbc_analyst')).toBe(true);
+  });
+
+  it('allows ccbc_admin to access any route under the /analyst/admin(.*) route', () => {
+    expect(isRouteAuthorized('/analyst/admin/(.*)', 'ccbc_admin')).toBe(true);
+    expect(
+      isRouteAuthorized('/analyst/admin/some/other/route', 'ccbc_admin')
+    ).toBe(true);
+  });
+
+  it('does not allow ccbc_analyst to access any route under the /analyst/admin(.*) route', () => {
+    expect(isRouteAuthorized('/analyst/admin/(.*)', 'ccbc_analyst')).toBe(
+      false
+    );
+    expect(
+      isRouteAuthorized('/analyst/admin/some/other/route', 'ccbc_analyst')
+    ).toBe(false);
+  });
+
+  it('allows ccbc_admin to access any route under the /analyst/application/(.*) route', () => {
+    expect(isRouteAuthorized('/analyst/application/(.*)', 'ccbc_admin')).toBe(
       true
     );
+    expect(
+      isRouteAuthorized('/analyst/application/some/other/route', 'ccbc_admin')
+    ).toBe(true);
+  });
+
+  it('allows ccbc_analyst to access any route under the /analyst/application/(.*) route', () => {
+    expect(isRouteAuthorized('/analyst/application/(.*)', 'ccbc_analyst')).toBe(
+      true
+    );
+    expect(
+      isRouteAuthorized('/analyst/application/some/other/route', 'ccbc_analyst')
+    ).toBe(true);
   });
 
   it('does not allow ccbc_admin to access any route under the /applicantportal/(.*) route', () => {

--- a/app/utils/isRouteAuthorized.ts
+++ b/app/utils/isRouteAuthorized.ts
@@ -11,9 +11,19 @@ const pagesAuthorization = [
     isProtected: false,
   },
   {
-    routePaths: ['/analyst/(.*)'],
+    routePaths: ['/analyst/application/(.*)'],
     isProtected: true,
     allowedRoles: ['ccbc_admin', 'ccbc_analyst'],
+  },
+  {
+    routePaths: ['/analyst/dashboard'],
+    isProtected: true,
+    allowedRoles: ['ccbc_admin', 'ccbc_analyst'],
+  },
+  {
+    routePaths: ['/analyst/admin/(.*)'],
+    isProtected: true,
+    allowedRoles: ['ccbc_admin'],
   },
   {
     routePaths: ['/applicantportal/(.*)'],


### PR DESCRIPTION
Implements #1119

This also updates the route authorizations. Previously `ccbc_analyst` and `ccbc_admin` users could access any route in the `/analyst/(.*)` side. Now analysts can only access `/analyst/dashboard` and anything in `/analyst/application/(.*)` so that only admins can access `/analyst/admin/(.*)`.

Not sure if there is a better way to do that so we don't have to update this if we add an `analyst/some-other-page` route.