### PR TITLE
feat: backfill history

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -134,7 +134,9 @@
     "wait-on": "^6.0.1"
   },
   "resolutions": {
-    "json5": "2.2.3"
+    "@sideway/formula" : "3.0.1",
+    "json5": "2.2.3",
+    "jsonwebtoken" : "9.0.0"
   },
   "relay": {
     "src": "./",

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -22515,6 +22515,36 @@ type Mutation {
     """
     input: CreateUserFromSessionInput!
   ): CreateUserFromSessionPayload
+  importApplicationStatuses(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ImportApplicationStatusesInput!
+  ): ImportApplicationStatusesPayload
+  importApplications(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ImportApplicationsInput!
+  ): ImportApplicationsPayload
+  importAssessmentData(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ImportAssessmentDataInput!
+  ): ImportAssessmentDataPayload
+  importAttachments(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ImportAttachmentsInput!
+  ): ImportAttachmentsPayload
+  importRfiData(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ImportRfiDataInput!
+  ): ImportRfiDataPayload
 
   """Detects closed intake and marks all submitted applications as Received"""
   receiveApplications(
@@ -27145,6 +27175,126 @@ type CreateUserFromSessionPayload {
 
 """All input for the `createUserFromSession` mutation."""
 input CreateUserFromSessionInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+}
+
+"""The output of our `importApplicationStatuses` mutation."""
+type ImportApplicationStatusesPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  resultIds: [Int]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the `importApplicationStatuses` mutation."""
+input ImportApplicationStatusesInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+}
+
+"""The output of our `importApplications` mutation."""
+type ImportApplicationsPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  resultIds: [Int]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the `importApplications` mutation."""
+input ImportApplicationsInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+}
+
+"""The output of our `importAssessmentData` mutation."""
+type ImportAssessmentDataPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  resultIds: [Int]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the `importAssessmentData` mutation."""
+input ImportAssessmentDataInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+}
+
+"""The output of our `importAttachments` mutation."""
+type ImportAttachmentsPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  resultIds: [Int]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the `importAttachments` mutation."""
+input ImportAttachmentsInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+}
+
+"""The output of our `importRfiData` mutation."""
+type ImportRfiDataPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  resultIds: [Int]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the `importRfiData` mutation."""
+input ImportRfiDataInput {
   """
   An arbitrary string value with no semantic meaning. Will be included in the
   payload verbatim. May be used to track mutations by the client.

--- a/db/deploy/backfill_history.sql
+++ b/db/deploy/backfill_history.sql
@@ -6,13 +6,14 @@ $do$
 begin
     -- run only once
     if exists (select true from pg_proc where proname='import_once') then
-        select ccbc_public.import_applications();
-        select ccbc_public.import_attachments() ;
-        select ccbc_public.import_application_statuses();
-        select ccbc_public.import_assessment_data();
-        select ccbc_public.import_rfi_data();
+        perform ccbc_public.import_applications();
+        perform ccbc_public.import_attachments() ;
+        perform ccbc_public.import_application_statuses();
+        perform ccbc_public.import_assessment_data();
+        perform ccbc_public.import_rfi_data();
         drop function ccbc_public.import_once;
     end if;
+    
 end
 $do$;
 

--- a/db/deploy/backfill_history.sql
+++ b/db/deploy/backfill_history.sql
@@ -1,0 +1,19 @@
+-- Deploy ccbc:backfill_history to pg
+
+BEGIN;
+do
+$do$
+begin
+    -- run only once
+    if exists (select true from pg_proc where proname='import_once') then
+        select ccbc_public.import_applications();
+        select ccbc_public.import_attachments() ;
+        select ccbc_public.import_application_statuses();
+        select ccbc_public.import_assessment_data();
+        select ccbc_public.import_rfi_data();
+        drop function ccbc_public.import_once;
+    end if;
+end
+$do$;
+
+COMMIT;

--- a/db/deploy/import/application.sql
+++ b/db/deploy/import/application.sql
@@ -54,5 +54,5 @@ as $function$
     return query select cnt as result_id; 
 end;
 $function$ language plpgsql volatile;
-grant execute on function ccbc_public.import_applications to ccbc;
+-- grant execute on function ccbc_public.import_applications to ccbc;
 COMMIT;

--- a/db/deploy/import/application.sql
+++ b/db/deploy/import/application.sql
@@ -1,0 +1,58 @@
+-- Deploy ccbc:import/application to pg
+
+BEGIN;
+
+create or replace function ccbc_public.import_applications() returns table(result_id int)
+as $function$
+    declare
+        current_app    ccbc_public.application%ROWTYPE;
+        cnt             int;
+        table_oid       int;
+	    applications    refcursor;
+        pkey_cols       text[];  
+        record_jsonb    jsonb; 
+        record_id       uuid;  
+    begin
+    select count(*) into cnt from ccbc_public.application;
+    select oid into table_oid from  pg_class where relname='application';
+    pkey_cols := audit.primary_key_columns(table_oid);
+    open applications for select *
+		    from ccbc_public.application;
+
+    loop
+        fetch applications into current_app;
+        exit when not found;
+        record_jsonb := to_jsonb(current_app);
+        record_id := audit.to_record_id(table_oid, pkey_cols, record_jsonb);
+        insert into ccbc_public.record_version(
+                record_id, 
+                op,
+                table_oid,
+                table_schema,
+                table_name,
+                created_by,
+                created_at,
+                record
+                )
+            select
+                record_id,
+                'INSERT',
+                table_oid,
+                'ccbc_public',
+                'application',
+                created_by,
+                created_at,
+                record_jsonb from ccbc_public.application 
+            where record_jsonb not in 
+                (select record_jsonb from ccbc_public.record_version 
+                where table_name='application' and op = 'INSERT');
+        
+    end loop;
+
+    close applications;
+
+    return query select cnt as result_id; 
+end;
+$function$ language plpgsql volatile;
+grant execute on function ccbc_public.import_applications to ccbc;
+COMMIT;

--- a/db/deploy/import/application_status.sql
+++ b/db/deploy/import/application_status.sql
@@ -1,0 +1,58 @@
+-- Deploy ccbc:import/application_status to pg
+
+BEGIN;
+create or replace function ccbc_public.import_application_statuses() returns table(result_id int)
+as $function$
+    declare
+        current_app    ccbc_public.application_status%ROWTYPE;
+        cnt             int;
+        table_oid       int;
+	    application_statuses    refcursor;
+        pkey_cols       text[];  
+        record_jsonb    jsonb; 
+        record_id       uuid;  
+    begin
+    select count(*) into cnt from ccbc_public.application_status;
+    select oid into table_oid from  pg_class where relname='application_status';
+    pkey_cols := audit.primary_key_columns(table_oid);
+    open application_statuses for select *
+		    from ccbc_public.application_status;
+
+    loop
+        fetch application_statuses into current_app;
+        exit when not found;
+        record_jsonb := to_jsonb(current_app);
+        record_id := audit.to_record_id(table_oid, pkey_cols, record_jsonb);
+        insert into ccbc_public.record_version(
+                record_id, 
+                op,
+                table_oid,
+                table_schema,
+                table_name,
+                created_by,
+                created_at,
+                record
+                )
+            select
+                record_id,
+                'INSERT',
+                table_oid,
+                'ccbc_public',
+                'application_status',
+                created_by,
+                created_at,
+                record_jsonb from ccbc_public.application_status 
+            where record_jsonb not in 
+                (select record_jsonb from ccbc_public.record_version 
+                where table_name='application_status' and op = 'INSERT');
+        
+    end loop;
+
+    close application_statuses;
+
+    return query select cnt as result_id; 
+end;
+$function$ language plpgsql volatile;
+grant execute on function ccbc_public.import_application_statuses to ccbc;
+COMMIT;
+

--- a/db/deploy/import/application_status.sql
+++ b/db/deploy/import/application_status.sql
@@ -53,6 +53,6 @@ as $function$
     return query select cnt as result_id; 
 end;
 $function$ language plpgsql volatile;
-grant execute on function ccbc_public.import_application_statuses to ccbc;
+-- grant execute on function ccbc_public.import_application_statuses to ccbc;
 COMMIT;
 

--- a/db/deploy/import/assessment_data.sql
+++ b/db/deploy/import/assessment_data.sql
@@ -54,5 +54,5 @@ as $function$
     return query select cnt as result_id; 
 end;
 $function$ language plpgsql volatile;
-grant execute on function ccbc_public.import_assessment_data to ccbc;
+-- grant execute on function ccbc_public.import_assessment_data to ccbc;
 COMMIT;

--- a/db/deploy/import/assessment_data.sql
+++ b/db/deploy/import/assessment_data.sql
@@ -1,0 +1,58 @@
+-- Deploy ccbc:import/assessment_data to pg
+
+BEGIN;
+
+create or replace function ccbc_public.import_assessment_data() returns table(result_id int)
+as $function$
+    declare
+        current_app    ccbc_public.assessment_data%ROWTYPE;
+        cnt             int;
+        table_oid       int;
+	    assessment_data_rows    refcursor;
+        pkey_cols       text[];  
+        record_jsonb    jsonb; 
+        record_id       uuid;  
+    begin
+    select count(*) into cnt from ccbc_public.assessment_data;
+    select oid into table_oid from  pg_class where relname='assessment_data';
+    pkey_cols := audit.primary_key_columns(table_oid);
+    open assessment_data_rows for select *
+		    from ccbc_public.assessment_data;
+
+    loop
+        fetch assessment_data_rows into current_app;
+        exit when not found;
+        record_jsonb := to_jsonb(current_app);
+        record_id := audit.to_record_id(table_oid, pkey_cols, record_jsonb);
+        insert into ccbc_public.record_version(
+                record_id, 
+                op,
+                table_oid,
+                table_schema,
+                table_name,
+                created_by,
+                created_at,
+                record
+                )
+            select
+                record_id,
+                'INSERT',
+                table_oid,
+                'ccbc_public',
+                'assessment_data',
+                created_by,
+                created_at,
+                record_jsonb from ccbc_public.assessment_data 
+            where record_jsonb not in 
+                (select record_jsonb from ccbc_public.record_version 
+                where table_name='assessment_data' and op = 'INSERT');
+        
+    end loop;
+
+    close assessment_data_rows;
+
+    return query select cnt as result_id; 
+end;
+$function$ language plpgsql volatile;
+grant execute on function ccbc_public.import_assessment_data to ccbc;
+COMMIT;

--- a/db/deploy/import/attachment.sql
+++ b/db/deploy/import/attachment.sql
@@ -1,0 +1,58 @@
+-- Deploy ccbc:import/attachment to pg
+
+BEGIN;
+
+create or replace function ccbc_public.import_attachments() returns table(result_id int)
+as $function$
+    declare
+        current_app    ccbc_public.attachment%ROWTYPE;
+        cnt             int;
+        table_oid       int;
+	    attachments    refcursor;
+        pkey_cols       text[];  
+        record_jsonb    jsonb; 
+        record_id       uuid;  
+    begin
+    select count(*) into cnt from ccbc_public.attachment;
+    select oid into table_oid from  pg_class where relname='attachment';
+    pkey_cols := audit.primary_key_columns(table_oid);
+    open attachments for select *
+		    from ccbc_public.attachment;
+
+    loop
+        fetch attachments into current_app;
+        exit when not found;
+        record_jsonb := to_jsonb(current_app);
+        record_id := audit.to_record_id(table_oid, pkey_cols, record_jsonb);
+        insert into ccbc_public.record_version(
+                record_id, 
+                op,
+                table_oid,
+                table_schema,
+                table_name,
+                created_by,
+                created_at,
+                record
+                )
+            select
+                record_id,
+                'INSERT',
+                table_oid,
+                'ccbc_public',
+                'attachment',
+                created_by,
+                created_at,
+                record_jsonb from ccbc_public.attachment 
+            where record_jsonb not in 
+                (select record_jsonb from ccbc_public.record_version 
+                where table_name='attachment' and op = 'INSERT');
+        
+    end loop;
+
+    close attachments;
+
+    return query select cnt as result_id; 
+end;
+$function$ language plpgsql volatile;
+grant execute on function ccbc_public.import_attachments to ccbc;
+COMMIT;

--- a/db/deploy/import/attachment.sql
+++ b/db/deploy/import/attachment.sql
@@ -54,5 +54,5 @@ as $function$
     return query select cnt as result_id; 
 end;
 $function$ language plpgsql volatile;
-grant execute on function ccbc_public.import_attachments to ccbc;
+-- grant execute on function ccbc_public.import_attachments to ccbc;
 COMMIT;

--- a/db/deploy/import/import_once.sql
+++ b/db/deploy/import/import_once.sql
@@ -1,0 +1,11 @@
+-- Deploy ccbc:import/import_once to pg
+
+BEGIN;
+
+create or replace function ccbc_public.import_once() returns table(result_id int)
+as $function$
+    return query select 0 as result_id; 
+end;
+$function$ language plpgsql volatile;
+grant execute on function ccbc_public.import_once to ccbc;
+COMMIT;

--- a/db/deploy/import/import_once.sql
+++ b/db/deploy/import/import_once.sql
@@ -4,6 +4,7 @@ BEGIN;
 
 create or replace function ccbc_public.import_once() returns table(result_id int)
 as $function$
+begin
     return query select 0 as result_id; 
 end;
 $function$ language plpgsql volatile;

--- a/db/deploy/import/import_once.sql
+++ b/db/deploy/import/import_once.sql
@@ -7,5 +7,5 @@ as $function$
     return query select 0 as result_id; 
 end;
 $function$ language plpgsql volatile;
-grant execute on function ccbc_public.import_once to ccbc;
+-- grant execute on function ccbc_public.import_once to ccbc;
 COMMIT;

--- a/db/deploy/import/rfi_data.sql
+++ b/db/deploy/import/rfi_data.sql
@@ -54,5 +54,5 @@ as $function$
     return query select cnt as result_id; 
 end;
 $function$ language plpgsql volatile;
-grant execute on function ccbc_public.import_rfi_data to ccbc;
+-- grant execute on function ccbc_public.import_rfi_data to ccbc;
 COMMIT;

--- a/db/deploy/import/rfi_data.sql
+++ b/db/deploy/import/rfi_data.sql
@@ -1,0 +1,58 @@
+-- Deploy ccbc:import/rfi_data to pg
+
+BEGIN;
+
+create or replace function ccbc_public.import_rfi_data() returns table(result_id int)
+as $function$
+    declare
+        current_app    ccbc_public.rfi_data%ROWTYPE;
+        cnt             int;
+        table_oid       int;
+	    rfi_data_rows    refcursor;
+        pkey_cols       text[];  
+        record_jsonb    jsonb; 
+        record_id       uuid;  
+    begin
+    select count(*) into cnt from ccbc_public.rfi_data;
+    select oid into table_oid from  pg_class where relname='rfi_data';
+    pkey_cols := audit.primary_key_columns(table_oid);
+    open rfi_data_rows for select *
+		    from ccbc_public.rfi_data;
+
+    loop
+        fetch rfi_data_rows into current_app;
+        exit when not found;
+        record_jsonb := to_jsonb(current_app);
+        record_id := audit.to_record_id(table_oid, pkey_cols, record_jsonb);
+        insert into ccbc_public.record_version(
+                record_id, 
+                op,
+                table_oid,
+                table_schema,
+                table_name,
+                created_by,
+                created_at,
+                record
+                )
+            select
+                record_id,
+                'INSERT',
+                table_oid,
+                'ccbc_public',
+                'rfi_data',
+                created_by,
+                created_at,
+                record_jsonb from ccbc_public.rfi_data 
+            where record_jsonb not in 
+                (select record_jsonb from ccbc_public.record_version 
+                where table_name='rfi_data' and op = 'INSERT');
+        
+    end loop;
+
+    close rfi_data_rows;
+
+    return query select cnt as result_id; 
+end;
+$function$ language plpgsql volatile;
+grant execute on function ccbc_public.import_rfi_data to ccbc;
+COMMIT;

--- a/db/revert/backfill_history.sql
+++ b/db/revert/backfill_history.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:backfill_history from pg
+
+BEGIN;
+
+-- XXX Add DDLs here.
+
+COMMIT;

--- a/db/revert/import/application.sql
+++ b/db/revert/import/application.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:import/application from pg
+
+BEGIN;
+
+drop function ccbc_public.import_applications;
+
+COMMIT;

--- a/db/revert/import/application_status.sql
+++ b/db/revert/import/application_status.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:import/application_status from pg
+
+BEGIN;
+
+drop function ccbc_public.import_application_statuses;
+
+COMMIT;

--- a/db/revert/import/assessment_data.sql
+++ b/db/revert/import/assessment_data.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:import/assessment_data from pg
+
+BEGIN;
+
+drop function ccbc_public.import_assessment_data;
+
+COMMIT;

--- a/db/revert/import/attachment.sql
+++ b/db/revert/import/attachment.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:import/attachment from pg
+
+BEGIN;
+
+drop function ccbc_public.import_attachments;
+
+COMMIT;

--- a/db/revert/import/import_once.sql
+++ b/db/revert/import/import_once.sql
@@ -1,0 +1,7 @@
+-- Deploy ccbc:import/import_once to pg
+
+BEGIN;
+
+drop function ccbc_public.import_once();
+
+COMMIT;

--- a/db/revert/import/rfi_data.sql
+++ b/db/revert/import/rfi_data.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:import/rfi_data from pg
+
+BEGIN;
+
+drop function ccbc_public.import_rfi_data;
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -182,6 +182,6 @@ import/application 2023-02-24T02:26:52Z ,,, Vladimir <vladimir@button.is> # add 
 import/application_status 2023-02-24T02:27:50Z ,,, Vladimir <vladimir@button.is> # add application_status import
 import/rfi_data 2023-02-24T02:28:29Z ,,, Vladimir <vladimir@button.is> # add rfi_data import
 import/attachment 2023-02-24T02:28:53Z ,,, Vladimir <vladimir@button.is> # add attachment import
-import/assessment 2023-02-24T02:29:22Z ,,, Vladimir <vladimir@button.is> # add assesstment import
-import/import_once 2023-02-24T02:26:52Z ,,, Vladimir <vladimir@button.is> # run import once
+import/assessment_data 2023-02-24T02:29:22Z ,,, Vladimir <vladimir@button.is> # add assesstment import
+import/import_once 2023-02-24T02:30:52Z ,,, Vladimir <vladimir@button.is> # run import once
 backfill_history 2023-02-24T21:31:50Z ,,, Vladimir <vladimir@button.is> # backfill history once

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -178,3 +178,10 @@ extensions/audit 2023-02-22T00:25:20Z ,,, Vladimir <vladimir@button.is> # add au
 @1.43.0 2023-02-23T21:53:09Z Marcel Mueller <marcel@button.is> # release v1.43.0
 computed_columns/application_status_sort_filter 2023-02-14T21:37:47Z Marcel Mueller <marcel@button.is> # computed column to return string with status order with status name appended
 @1.44.0 2023-02-27T17:27:37Z Marcel Mueller <marcel@m2> # release v1.44.0
+import/application 2023-02-24T02:26:52Z ,,, Vladimir <vladimir@button.is> # add application import
+import/application_status 2023-02-24T02:27:50Z ,,, Vladimir <vladimir@button.is> # add application_status import
+import/rfi_data 2023-02-24T02:28:29Z ,,, Vladimir <vladimir@button.is> # add rfi_data import
+import/attachment 2023-02-24T02:28:53Z ,,, Vladimir <vladimir@button.is> # add attachment import
+import/assessment 2023-02-24T02:29:22Z ,,, Vladimir <vladimir@button.is> # add assesstment import
+import/import_once 2023-02-24T02:26:52Z ,,, Vladimir <vladimir@button.is> # run import once
+backfill_history 2023-02-24T21:31:50Z ,,, Vladimir <vladimir@button.is> # backfill history once


### PR DESCRIPTION
Implements #1209 

- created functions to populate record_version table with existing records 
- no duplicate records are created in record_version table;
- after deployment import function should be run once;