### PR TITLE
feat: computed function for application history

### DIFF
--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -13437,8 +13437,11 @@ type HistoryItem {
   """
   recordId: UUID
 
-  """Record in Json format."""
+  """New record in Json format."""
   record: JSON
+
+  """Old record in Json format."""
+  oldRecord: JSON
 
   """
   Main object affected by the operation (i.e. status, or file name or RFI type).
@@ -13485,6 +13488,9 @@ input HistoryItemFilter {
 
   """Filter by the object’s `record` field."""
   record: JSONFilter
+
+  """Filter by the object’s `oldRecord` field."""
+  oldRecord: JSONFilter
 
   """Filter by the object’s `item` field."""
   item: StringFilter
@@ -21578,6 +21584,8 @@ enum HistoryItemsOrderBy {
   RECORD_ID_DESC
   RECORD_ASC
   RECORD_DESC
+  OLD_RECORD_ASC
+  OLD_RECORD_DESC
   ITEM_ASC
   ITEM_DESC
   FAMILY_NAME_ASC
@@ -21610,6 +21618,9 @@ input HistoryItemCondition {
 
   """Checks for equality with the object’s `record` field."""
   record: JSON
+
+  """Checks for equality with the object’s `oldRecord` field."""
+  oldRecord: JSON
 
   """Checks for equality with the object’s `item` field."""
   item: String
@@ -23860,8 +23871,11 @@ input HistoryItemInput {
   """
   recordId: UUID
 
-  """Record in Json format."""
+  """New record in Json format."""
   record: JSON
+
+  """Old record in Json format."""
+  oldRecord: JSON
 
   """
   Main object affected by the operation (i.e. status, or file name or RFI type).

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -8828,6 +8828,32 @@ type Application implements Node {
 
   """Computed column to return whether the rfi is open"""
   hasRfiOpen: Boolean
+
+  """Computed column that returns list of audit records for application"""
+  history(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: HistoryItemFilter
+  ): HistoryItemsConnection!
   intakeNumber: Int
 
   """Computed column to display organization name from json data"""
@@ -13374,6 +13400,112 @@ input ApplicationPackageCondition {
 
   """Checks for equality with the object’s `archivedAt` field."""
   archivedAt: Datetime
+}
+
+"""A connection to a list of `HistoryItem` values."""
+type HistoryItemsConnection {
+  """A list of `HistoryItem` objects."""
+  nodes: [HistoryItem]!
+
+  """
+  A list of edges which contains the `HistoryItem` and cursor to aid in pagination.
+  """
+  edges: [HistoryItemsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `HistoryItem` you could get from the connection."""
+  totalCount: Int!
+}
+
+type HistoryItem {
+  """Application Id."""
+  applicationId: Int
+
+  """Timestamp of the operation recorded."""
+  createdAt: Datetime
+
+  """Type of operation: INSERT/UPDATE/DELETE/TRUNCATE/SNAPSHOT."""
+  op: Operation
+
+  """Table name."""
+  tableName: String
+
+  """
+  Identifier that uniquely identifies a record by primary key [primary key + table_oid].
+  """
+  recordId: UUID
+
+  """Record in Json format."""
+  record: JSON
+
+  """
+  Main object affected by the operation (i.e. status, or file name or RFI type).
+  """
+  item: String
+
+  """First Name of the user who performed the operation."""
+  familyName: String
+
+  """Last Name of the user who performed the operation."""
+  givenName: String
+
+  """Session sub of the user who performed the operation."""
+  sessionSub: String
+}
+
+"""A `HistoryItem` edge in the connection."""
+type HistoryItemsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `HistoryItem` at the end of the edge."""
+  node: HistoryItem
+}
+
+"""
+A filter to be used against `HistoryItem` object types. All fields are combined with a logical ‘and.’
+"""
+input HistoryItemFilter {
+  """Filter by the object’s `applicationId` field."""
+  applicationId: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `op` field."""
+  op: OperationFilter
+
+  """Filter by the object’s `tableName` field."""
+  tableName: StringFilter
+
+  """Filter by the object’s `recordId` field."""
+  recordId: UUIDFilter
+
+  """Filter by the object’s `record` field."""
+  record: JSONFilter
+
+  """Filter by the object’s `item` field."""
+  item: StringFilter
+
+  """Filter by the object’s `familyName` field."""
+  familyName: StringFilter
+
+  """Filter by the object’s `givenName` field."""
+  givenName: StringFilter
+
+  """Filter by the object’s `sessionSub` field."""
+  sessionSub: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [HistoryItemFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [HistoryItemFilter!]
+
+  """Negates the expression."""
+  not: HistoryItemFilter
 }
 
 """
@@ -21431,68 +21563,6 @@ input FormTypeCondition {
   description: String
 }
 
-"""A connection to a list of `HistoryItem` values."""
-type HistoryItemsConnection {
-  """A list of `HistoryItem` objects."""
-  nodes: [HistoryItem]!
-
-  """
-  A list of edges which contains the `HistoryItem` and cursor to aid in pagination.
-  """
-  edges: [HistoryItemsEdge!]!
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-
-  """The count of *all* `HistoryItem` you could get from the connection."""
-  totalCount: Int!
-}
-
-type HistoryItem {
-  """Application Id."""
-  applicationId: Int
-
-  """Timestamp of the operation recorded."""
-  createdAt: Datetime
-
-  """Type of operation: INSERT/UPDATE/DELETE/TRUNCATE/SNAPSHOT."""
-  op: Operation
-
-  """Table name."""
-  tableName: String
-
-  """
-  Identifier that uniquely identifies a record by primary key [primary key + table_oid].
-  """
-  recordId: UUID
-
-  """Record in Json format."""
-  record: JSON
-
-  """
-  Main object affected by the operation (i.e. status, or file name or RFI type).
-  """
-  item: String
-
-  """First Name of the user who performed the operation."""
-  familyName: String
-
-  """Last Name of the user who performed the operation."""
-  givenName: String
-
-  """Session sub of the user who performed the operation."""
-  sessionSub: String
-}
-
-"""A `HistoryItem` edge in the connection."""
-type HistoryItemsEdge {
-  """A cursor for use in pagination."""
-  cursor: Cursor
-
-  """The `HistoryItem` at the end of the edge."""
-  node: HistoryItem
-}
-
 """Methods to use when ordering `HistoryItem`."""
 enum HistoryItemsOrderBy {
   NATURAL
@@ -21552,50 +21622,6 @@ input HistoryItemCondition {
 
   """Checks for equality with the object’s `sessionSub` field."""
   sessionSub: String
-}
-
-"""
-A filter to be used against `HistoryItem` object types. All fields are combined with a logical ‘and.’
-"""
-input HistoryItemFilter {
-  """Filter by the object’s `applicationId` field."""
-  applicationId: IntFilter
-
-  """Filter by the object’s `createdAt` field."""
-  createdAt: DatetimeFilter
-
-  """Filter by the object’s `op` field."""
-  op: OperationFilter
-
-  """Filter by the object’s `tableName` field."""
-  tableName: StringFilter
-
-  """Filter by the object’s `recordId` field."""
-  recordId: UUIDFilter
-
-  """Filter by the object’s `record` field."""
-  record: JSONFilter
-
-  """Filter by the object’s `item` field."""
-  item: StringFilter
-
-  """Filter by the object’s `familyName` field."""
-  familyName: StringFilter
-
-  """Filter by the object’s `givenName` field."""
-  givenName: StringFilter
-
-  """Filter by the object’s `sessionSub` field."""
-  sessionSub: StringFilter
-
-  """Checks for all expressions in this list."""
-  and: [HistoryItemFilter!]
-
-  """Checks for any expressions in this list."""
-  or: [HistoryItemFilter!]
-
-  """Negates the expression."""
-  not: HistoryItemFilter
 }
 
 """A connection to a list of `RfiDataStatusType` values."""
@@ -22690,14 +22716,6 @@ type Mutation {
     """
     input: DeleteRfiDataStatusTypeByNameInput!
   ): DeleteRfiDataStatusTypePayload
-
-  """Computed column that returns list of audit records for application"""
-  applicationHistory(
-    """
-    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
-    """
-    input: ApplicationHistoryInput!
-  ): ApplicationHistoryPayload
   createApplication(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -27193,61 +27211,6 @@ input DeleteRfiDataStatusTypeByNameInput {
 
   """The name of the status type"""
   name: String!
-}
-
-"""The output of our `applicationHistory` mutation."""
-type ApplicationHistoryPayload {
-  """
-  The exact same `clientMutationId` that was provided in the mutation input,
-  unchanged and unused. May be used by a client to track mutations.
-  """
-  clientMutationId: String
-  historyItems: [HistoryItem]
-
-  """
-  Our root query field type. Allows us to run any query from our mutation payload.
-  """
-  query: Query
-}
-
-"""All input for the `applicationHistory` mutation."""
-input ApplicationHistoryInput {
-  """
-  An arbitrary string value with no semantic meaning. Will be included in the
-  payload verbatim. May be used to track mutations by the client.
-  """
-  clientMutationId: String
-  application: ApplicationInput!
-}
-
-"""An input for mutations affecting `Application`"""
-input ApplicationInput {
-  """Reference number assigned to the application"""
-  ccbcNumber: String
-
-  """The owner of the application, identified by its JWT sub"""
-  owner: String!
-
-  """The intake associated with the application, set when it is submitted"""
-  intakeId: Int
-
-  """created by user id"""
-  createdBy: Int
-
-  """created at timestamp"""
-  createdAt: Datetime
-
-  """updated by user id"""
-  updatedBy: Int
-
-  """updated at timestamp"""
-  updatedAt: Datetime
-
-  """archived by user id"""
-  archivedBy: Int
-
-  """archived at timestamp"""
-  archivedAt: Datetime
 }
 
 """The output of our `createApplication` mutation."""

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -22481,6 +22481,14 @@ type Mutation {
     """
     input: DeleteRfiDataStatusTypeByNameInput!
   ): DeleteRfiDataStatusTypePayload
+
+  """Computed column that returns list of audit records for application"""
+  applicationHistory(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: ApplicationHistoryInput!
+  ): ApplicationHistoryPayload
   createApplication(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -26904,6 +26912,74 @@ input DeleteRfiDataStatusTypeByNameInput {
 
   """The name of the status type"""
   name: String!
+}
+
+"""The output of our `applicationHistory` mutation."""
+type ApplicationHistoryPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  results: [ApplicationHistoryRecord]
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""The return type of our `applicationHistory` mutation."""
+type ApplicationHistoryRecord {
+  createdAt: Datetime
+  op: Operation
+  tableName: String
+  recordId: UUID
+  record: JSON
+  item: String
+  familyName: String
+  givenName: String
+  sessionSub: String
+}
+
+"""All input for the `applicationHistory` mutation."""
+input ApplicationHistoryInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  application: ApplicationInput!
+}
+
+"""An input for mutations affecting `Application`"""
+input ApplicationInput {
+  """Reference number assigned to the application"""
+  ccbcNumber: String
+
+  """The owner of the application, identified by its JWT sub"""
+  owner: String!
+
+  """The intake associated with the application, set when it is submitted"""
+  intakeId: Int
+
+  """created by user id"""
+  createdBy: Int
+
+  """created at timestamp"""
+  createdAt: Datetime
+
+  """updated by user id"""
+  updatedBy: Int
+
+  """updated at timestamp"""
+  updatedAt: Datetime
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """archived at timestamp"""
+  archivedAt: Datetime
 }
 
 """The output of our `createApplication` mutation."""

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -563,6 +563,40 @@ type Query implements Node {
     filter: FormTypeFilter
   ): FormTypesConnection
 
+  """Reads and enables pagination through a set of `HistoryItem`."""
+  allHistoryItems(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `HistoryItem`."""
+    orderBy: [HistoryItemsOrderBy!] = [NATURAL]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: HistoryItemCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: HistoryItemFilter
+  ): HistoryItemsConnection
+
   """Reads and enables pagination through a set of `Intake`."""
   allIntakes(
     """Only read the first `n` values of the set."""
@@ -21397,6 +21431,173 @@ input FormTypeCondition {
   description: String
 }
 
+"""A connection to a list of `HistoryItem` values."""
+type HistoryItemsConnection {
+  """A list of `HistoryItem` objects."""
+  nodes: [HistoryItem]!
+
+  """
+  A list of edges which contains the `HistoryItem` and cursor to aid in pagination.
+  """
+  edges: [HistoryItemsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `HistoryItem` you could get from the connection."""
+  totalCount: Int!
+}
+
+type HistoryItem {
+  """Application Id."""
+  applicationId: Int
+
+  """Timestamp of the operation recorded."""
+  createdAt: Datetime
+
+  """Type of operation: INSERT/UPDATE/DELETE/TRUNCATE/SNAPSHOT."""
+  op: Operation
+
+  """Table name."""
+  tableName: String
+
+  """
+  Identifier that uniquely identifies a record by primary key [primary key + table_oid].
+  """
+  recordId: UUID
+
+  """Record in Json format."""
+  record: JSON
+
+  """
+  Main object affected by the operation (i.e. status, or file name or RFI type).
+  """
+  item: String
+
+  """First Name of the user who performed the operation."""
+  familyName: String
+
+  """Last Name of the user who performed the operation."""
+  givenName: String
+
+  """Session sub of the user who performed the operation."""
+  sessionSub: String
+}
+
+"""A `HistoryItem` edge in the connection."""
+type HistoryItemsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `HistoryItem` at the end of the edge."""
+  node: HistoryItem
+}
+
+"""Methods to use when ordering `HistoryItem`."""
+enum HistoryItemsOrderBy {
+  NATURAL
+  APPLICATION_ID_ASC
+  APPLICATION_ID_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  OP_ASC
+  OP_DESC
+  TABLE_NAME_ASC
+  TABLE_NAME_DESC
+  RECORD_ID_ASC
+  RECORD_ID_DESC
+  RECORD_ASC
+  RECORD_DESC
+  ITEM_ASC
+  ITEM_DESC
+  FAMILY_NAME_ASC
+  FAMILY_NAME_DESC
+  GIVEN_NAME_ASC
+  GIVEN_NAME_DESC
+  SESSION_SUB_ASC
+  SESSION_SUB_DESC
+}
+
+"""
+A condition to be used against `HistoryItem` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input HistoryItemCondition {
+  """Checks for equality with the object’s `applicationId` field."""
+  applicationId: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `op` field."""
+  op: Operation
+
+  """Checks for equality with the object’s `tableName` field."""
+  tableName: String
+
+  """Checks for equality with the object’s `recordId` field."""
+  recordId: UUID
+
+  """Checks for equality with the object’s `record` field."""
+  record: JSON
+
+  """Checks for equality with the object’s `item` field."""
+  item: String
+
+  """Checks for equality with the object’s `familyName` field."""
+  familyName: String
+
+  """Checks for equality with the object’s `givenName` field."""
+  givenName: String
+
+  """Checks for equality with the object’s `sessionSub` field."""
+  sessionSub: String
+}
+
+"""
+A filter to be used against `HistoryItem` object types. All fields are combined with a logical ‘and.’
+"""
+input HistoryItemFilter {
+  """Filter by the object’s `applicationId` field."""
+  applicationId: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `op` field."""
+  op: OperationFilter
+
+  """Filter by the object’s `tableName` field."""
+  tableName: StringFilter
+
+  """Filter by the object’s `recordId` field."""
+  recordId: UUIDFilter
+
+  """Filter by the object’s `record` field."""
+  record: JSONFilter
+
+  """Filter by the object’s `item` field."""
+  item: StringFilter
+
+  """Filter by the object’s `familyName` field."""
+  familyName: StringFilter
+
+  """Filter by the object’s `givenName` field."""
+  givenName: StringFilter
+
+  """Filter by the object’s `sessionSub` field."""
+  sessionSub: StringFilter
+
+  """Checks for all expressions in this list."""
+  and: [HistoryItemFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [HistoryItemFilter!]
+
+  """Negates the expression."""
+  not: HistoryItemFilter
+}
+
 """A connection to a list of `RfiDataStatusType` values."""
 type RfiDataStatusTypesConnection {
   """A list of `RfiDataStatusType` objects."""
@@ -21727,6 +21928,14 @@ type Mutation {
     """
     input: CreateFormTypeInput!
   ): CreateFormTypePayload
+
+  """Creates a single `HistoryItem`."""
+  createHistoryItem(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateHistoryItemInput!
+  ): CreateHistoryItemPayload
 
   """Creates a single `Intake`."""
   createIntake(
@@ -23577,6 +23786,78 @@ input FormTypeInput {
 
   """Description of the type of form"""
   description: String
+}
+
+"""The output of our create `HistoryItem` mutation."""
+type CreateHistoryItemPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `HistoryItem` that was created by this mutation."""
+  historyItem: HistoryItem
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """An edge for our `HistoryItem`. May be used by Relay 1."""
+  historyItemEdge(
+    """The method to use when ordering `HistoryItem`."""
+    orderBy: [HistoryItemsOrderBy!] = [NATURAL]
+  ): HistoryItemsEdge
+}
+
+"""All input for the create `HistoryItem` mutation."""
+input CreateHistoryItemInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `HistoryItem` to be created by this mutation."""
+  historyItem: HistoryItemInput!
+}
+
+"""An input for mutations affecting `HistoryItem`"""
+input HistoryItemInput {
+  """Application Id."""
+  applicationId: Int
+
+  """Timestamp of the operation recorded."""
+  createdAt: Datetime
+
+  """Type of operation: INSERT/UPDATE/DELETE/TRUNCATE/SNAPSHOT."""
+  op: Operation
+
+  """Table name."""
+  tableName: String
+
+  """
+  Identifier that uniquely identifies a record by primary key [primary key + table_oid].
+  """
+  recordId: UUID
+
+  """Record in Json format."""
+  record: JSON
+
+  """
+  Main object affected by the operation (i.e. status, or file name or RFI type).
+  """
+  item: String
+
+  """First Name of the user who performed the operation."""
+  familyName: String
+
+  """Last Name of the user who performed the operation."""
+  givenName: String
+
+  """Session sub of the user who performed the operation."""
+  sessionSub: String
 }
 
 """The output of our create `Intake` mutation."""
@@ -26921,25 +27202,12 @@ type ApplicationHistoryPayload {
   unchanged and unused. May be used by a client to track mutations.
   """
   clientMutationId: String
-  results: [ApplicationHistoryRecord]
+  historyItems: [HistoryItem]
 
   """
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
-}
-
-"""The return type of our `applicationHistory` mutation."""
-type ApplicationHistoryRecord {
-  createdAt: Datetime
-  op: Operation
-  tableName: String
-  recordId: UUID
-  record: JSON
-  item: String
-  familyName: String
-  givenName: String
-  sessionSub: String
 }
 
 """All input for the `applicationHistory` mutation."""

--- a/db/deploy/computed_columns/application_history.sql
+++ b/db/deploy/computed_columns/application_history.sql
@@ -3,52 +3,47 @@
 begin;
 
 create or replace function ccbc_public.application_history(application ccbc_public.application) 
-RETURNS TABLE (created_at timestamptz, op audit.operation, table_name name, record_id uuid, 
-    record jsonb, item varchar,family_name varchar,given_name varchar, session_sub varchar)
+RETURNS SETOF ccbc_public.history_item
 AS $function$
 DECLARE
         current_rfi ccbc_public.rfi_data%ROWTYPE;
 	    rfi_entries refcursor;
+        item_row ccbc_public.history_item;
+        
 BEGIN
-
-    create temporary table tmp_history
-    (
-    created_at timestamptz, op audit.operation, table_name name, record_id uuid, 
-    record jsonb, item varchar,family_name varchar,given_name varchar, session_sub varchar
-    );
+    delete from ccbc_public.history_item where application_id=application.id;
 
     -- first get all simple inserts
-    insert into tmp_history
-    select v.created_at, v.op, v.table_name, v.record_id, v.record, 'application' as item,
+    insert into ccbc_public.history_item
+    select application.id, v.created_at, v.op, v.table_name, v.record_id, v.record, 'application' as item,
         u.family_name, u.given_name, u.session_sub
     from ccbc_public.record_version as v 
         inner join ccbc_public.ccbc_user u on v.created_by=u.id
     where v.op='INSERT' and v.table_name='application' and v.record->>'id'=application.id::varchar(10) ;
 
-    insert into tmp_history
-    select v.created_at, v.op, v.table_name, v.record_id, v.record, v.record->>'status' as item,
+    insert into ccbc_public.history_item
+    select application.id,  v.created_at, v.op, v.table_name, v.record_id, v.record, v.record->>'status' as item,
         u.family_name, u.given_name, u.session_sub
     from ccbc_public.record_version as v 
         inner join ccbc_public.ccbc_user u on v.created_by=u.id
     where v.op='INSERT' and v.table_name='application_status' 
         and v.record->>'application_id'=application.id::varchar(10);
 
-    insert into tmp_history
-    select v.created_at, v.op, v.table_name, v.record_id, v.record, v.record->>'file_name' as item,
+    insert into ccbc_public.history_item
+    select application.id,  v.created_at, v.op, v.table_name, v.record_id, v.record, v.record->>'file_name' as item,
         u.family_name, u.given_name, u.session_sub
     from ccbc_public.record_version as v 
         inner join ccbc_public.ccbc_user u on v.created_by=u.id
     where v.op='INSERT' and v.table_name='attachment' 
         and v.record->>'application_id'=application.id::varchar(10) and v.record->>'archived_by' is null;
 
-    insert into tmp_history
-    select v.created_at, v.op, v.table_name, v.record_id, v.record, v.record->>'assessment_data_type' as item,
+    insert into ccbc_public.history_item
+    select application.id,  v.created_at, v.op, v.table_name, v.record_id, v.record, v.record->>'assessment_data_type' as item,
         u.family_name, u.given_name, u.session_sub
     from ccbc_public.record_version as v 
         inner join ccbc_public.ccbc_user u on v.created_by=u.id
     where v.op='INSERT' and v.table_name='assessment_data' 
         and v.record->>'application_id'=application.id::varchar(10) and v.record->>'archived_by' is null;
-
 
     -- now get double-removed (rfi)
     open rfi_entries for 
@@ -60,22 +55,21 @@ BEGIN
     loop
         fetch rfi_entries into current_rfi;
         exit when not found;
-        insert into tmp_history
-        select v.created_at, v.op, v.table_name, v.record_id, v.record, 
+    
+        insert into ccbc_public.history_item
+        select application.id,  v.created_at, v.op, v.table_name, v.record_id, v.record, 
             v.record-> 'json_data' ->>'rfiType' as item,
-            u.family_name, u.given_name, u.session_sub
+            u.family_name, u.given_name, u.session_sub    
         from ccbc_public.record_version as v 
             inner join ccbc_public.ccbc_user u on v.created_by=u.id
         where v.op='INSERT' and v.table_name='rfi_data' 
             and v.record->>'id'=current_rfi.id::varchar(10) and v.record->>'archived_by' is null;
         end loop;
 
-    RETURN QUERY 
-    SELECT t.created_at, t.op, t.table_name, t.record_id, t.record, t.item,t.family_name,t.given_name, t.session_sub
-    from tmp_history as t order by t.created_at asc;
-    drop table tmp_history;
+    return query select * from ccbc_public.history_item where application_id=application.id order by created_at asc;
+
 END;
-$function$ language plpgsql volatile;
+$function$ language plpgsql;
 
 grant execute on function ccbc_public.application_history to ccbc_admin;
 grant execute on function ccbc_public.application_history to ccbc_analyst;

--- a/db/deploy/computed_columns/application_history.sql
+++ b/db/deploy/computed_columns/application_history.sql
@@ -1,0 +1,85 @@
+-- Deploy ccbc:computed_columns/application_history to pg
+
+begin;
+
+create or replace function ccbc_public.application_history(application ccbc_public.application) 
+RETURNS TABLE (created_at timestamptz, op audit.operation, table_name name, record_id uuid, 
+    record jsonb, item varchar,family_name varchar,given_name varchar, session_sub varchar)
+AS $function$
+DECLARE
+        current_rfi ccbc_public.rfi_data%ROWTYPE;
+	    rfi_entries refcursor;
+BEGIN
+
+    create temporary table tmp_history
+    (
+    created_at timestamptz, op audit.operation, table_name name, record_id uuid, 
+    record jsonb, item varchar,family_name varchar,given_name varchar, session_sub varchar
+    );
+
+    -- first get all simple inserts
+    insert into tmp_history
+    select v.created_at, v.op, v.table_name, v.record_id, v.record, 'application' as item,
+        u.family_name, u.given_name, u.session_sub
+    from ccbc_public.record_version as v 
+        inner join ccbc_public.ccbc_user u on v.created_by=u.id
+    where v.op='INSERT' and v.table_name='application' and v.record->>'id'=application.id::varchar(10) ;
+
+    insert into tmp_history
+    select v.created_at, v.op, v.table_name, v.record_id, v.record, v.record->>'status' as item,
+        u.family_name, u.given_name, u.session_sub
+    from ccbc_public.record_version as v 
+        inner join ccbc_public.ccbc_user u on v.created_by=u.id
+    where v.op='INSERT' and v.table_name='application_status' 
+        and v.record->>'id'=application.id::varchar(10);
+
+    insert into tmp_history
+    select v.created_at, v.op, v.table_name, v.record_id, v.record, v.record->>'file_name' as item,
+        u.family_name, u.given_name, u.session_sub
+    from ccbc_public.record_version as v 
+        inner join ccbc_public.ccbc_user u on v.created_by=u.id
+    where v.op='INSERT' and v.table_name='attachment' 
+        and v.record->>'id'=application.id::varchar(10) and v.record->>'archived_by' is null;
+
+    insert into tmp_history
+    select v.created_at, v.op, v.table_name, v.record_id, v.record, v.record->>'assessment_data_type' as item,
+        u.family_name, u.given_name, u.session_sub
+    from ccbc_public.record_version as v 
+        inner join ccbc_public.ccbc_user u on v.created_by=u.id
+    where v.op='INSERT' and v.table_name='assessment_data' 
+        and v.record->>'id'=application.id::varchar(10) and v.record->>'archived_by' is null;
+
+
+    -- now get double-removed (rfi)
+    open rfi_entries for 
+        select rd.id from ccbc_public.rfi_data as rd
+        inner join ccbc_public.application_rfi_data arf
+        on arf.rfi_data_id = rd.id
+        where arf.application_id = application.id;
+
+    loop
+        fetch rfi_entries into current_rfi;
+        exit when not found;
+        insert into tmp_history
+        select v.created_at, v.op, v.table_name, v.record_id, v.record, 
+            v.record-> 'json_data' ->>'rfiType' as item,
+            u.family_name, u.given_name, u.session_sub
+        from ccbc_public.record_version as v 
+            inner join ccbc_public.ccbc_user u on v.created_by=u.id
+        where v.op='INSERT' and v.table_name='rfi_data' 
+            and v.record->>'id'=current_rfi.id::varchar(10) and v.record->>'archived_by' is null;
+        end loop;
+
+    RETURN QUERY 
+    SELECT t.created_at, t.op, t.table_name, t.record_id, t.record, t.item,t.family_name,t.given_name, t.session_sub
+    from tmp_history as t order by t.created_at asc;
+    drop table tmp_history;
+END;
+$function$ language plpgsql volatile;
+
+grant execute on function ccbc_public.application_history to ccbc_admin;
+grant execute on function ccbc_public.application_history to ccbc_analyst;
+
+comment on function ccbc_public.application_history is 'Computed column that returns list of audit records for application';
+
+commit;

--- a/db/deploy/computed_columns/application_history.sql
+++ b/db/deploy/computed_columns/application_history.sql
@@ -31,7 +31,7 @@ BEGIN
     from ccbc_public.record_version as v 
         inner join ccbc_public.ccbc_user u on v.created_by=u.id
     where v.op='INSERT' and v.table_name='application_status' 
-        and v.record->>'id'=application.id::varchar(10);
+        and v.record->>'application_id'=application.id::varchar(10);
 
     insert into tmp_history
     select v.created_at, v.op, v.table_name, v.record_id, v.record, v.record->>'file_name' as item,
@@ -39,7 +39,7 @@ BEGIN
     from ccbc_public.record_version as v 
         inner join ccbc_public.ccbc_user u on v.created_by=u.id
     where v.op='INSERT' and v.table_name='attachment' 
-        and v.record->>'id'=application.id::varchar(10) and v.record->>'archived_by' is null;
+        and v.record->>'application_id'=application.id::varchar(10) and v.record->>'archived_by' is null;
 
     insert into tmp_history
     select v.created_at, v.op, v.table_name, v.record_id, v.record, v.record->>'assessment_data_type' as item,
@@ -47,7 +47,7 @@ BEGIN
     from ccbc_public.record_version as v 
         inner join ccbc_public.ccbc_user u on v.created_by=u.id
     where v.op='INSERT' and v.table_name='assessment_data' 
-        and v.record->>'id'=application.id::varchar(10) and v.record->>'archived_by' is null;
+        and v.record->>'application_id'=application.id::varchar(10) and v.record->>'archived_by' is null;
 
 
     -- now get double-removed (rfi)

--- a/db/deploy/extensions/audit_form_data.sql
+++ b/db/deploy/extensions/audit_form_data.sql
@@ -1,0 +1,7 @@
+-- Deploy ccbc:extenstions/audit_form_data to pg
+
+BEGIN;
+
+select audit.enable_tracking('ccbc_public.form_data'::regclass);
+
+COMMIT;

--- a/db/deploy/tables/history_item.sql
+++ b/db/deploy/tables/history_item.sql
@@ -1,0 +1,52 @@
+-- Deploy ccbc:types/history_item to pg
+
+BEGIN;
+
+create table if not exists ccbc_public.history_item (
+    application_id integer, 
+    created_at timestamptz,  
+    op audit.operation,  
+    table_name name,  
+    record_id uuid,  
+    record jsonb,  
+    item varchar,  
+    family_name varchar,  
+    given_name varchar,  
+    session_sub varchar
+);
+
+do
+$policy$
+begin
+  perform ccbc_private.grant_permissions('insert', 'history_item', 'ccbc_admin');
+  perform ccbc_private.grant_permissions('insert', 'history_item', 'ccbc_analyst');
+  perform ccbc_private.grant_permissions('select', 'history_item', 'ccbc_admin');
+  perform ccbc_private.grant_permissions('select', 'history_item', 'ccbc_analyst');
+  perform ccbc_private.grant_permissions('delete', 'history_item', 'ccbc_admin');
+  perform ccbc_private.grant_permissions('delete', 'history_item', 'ccbc_analyst');
+
+end
+$policy$;
+
+comment on column ccbc_public.history_item.application_id is
+  'Application Id.';
+comment on column ccbc_public.history_item.created_at is
+  'Timestamp of the operation recorded.';
+comment on column ccbc_public.history_item.op is
+  'Type of operation: INSERT/UPDATE/DELETE/TRUNCATE/SNAPSHOT.';
+comment on column ccbc_public.history_item.table_name is
+  'Table name.';
+comment on column ccbc_public.history_item.record_id is
+  'Identifier that uniquely identifies a record by primary key [primary key + table_oid].';
+comment on column ccbc_public.history_item.record is
+  'Record in Json format.';
+comment on column ccbc_public.history_item.item is
+  'Main object affected by the operation (i.e. status, or file name or RFI type).';
+comment on column ccbc_public.history_item.family_name is
+  'First Name of the user who performed the operation.';
+comment on column ccbc_public.history_item.given_name is
+  'Last Name of the user who performed the operation.';
+comment on column ccbc_public.history_item.session_sub is
+  'Session sub of the user who performed the operation.';
+
+COMMIT;

--- a/db/deploy/tables/history_item.sql
+++ b/db/deploy/tables/history_item.sql
@@ -9,6 +9,7 @@ create table if not exists ccbc_public.history_item (
     table_name name,  
     record_id uuid,  
     record jsonb,  
+    old_record jsonb,
     item varchar,  
     family_name varchar,  
     given_name varchar,  
@@ -39,7 +40,9 @@ comment on column ccbc_public.history_item.table_name is
 comment on column ccbc_public.history_item.record_id is
   'Identifier that uniquely identifies a record by primary key [primary key + table_oid].';
 comment on column ccbc_public.history_item.record is
-  'Record in Json format.';
+  'New record in Json format.';
+comment on column ccbc_public.history_item.old_record is
+  'Old record in Json format.';
 comment on column ccbc_public.history_item.item is
   'Main object affected by the operation (i.e. status, or file name or RFI type).';
 comment on column ccbc_public.history_item.family_name is

--- a/db/revert/computed_columns/application_history.sql
+++ b/db/revert/computed_columns/application_history.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:computed_columns/application_history from pg
+
+BEGIN;
+
+drop function ccbc_public.application_history(ccbc_public.application);
+
+COMMIT;

--- a/db/revert/extenstions/audit_form_data.sql
+++ b/db/revert/extenstions/audit_form_data.sql
@@ -1,0 +1,7 @@
+-- Deploy ccbc:extenstions/audit_form_data to pg
+
+BEGIN;
+
+select audit.disable_tracking('ccbc_public.form_data'::regclass);
+
+COMMIT;

--- a/db/revert/tables/history_item.sql
+++ b/db/revert/tables/history_item.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
-drop type ccbc_public.history_item;
+drop table ccbc_public.history_item;
 
 COMMIT;

--- a/db/revert/tables/history_item.sql
+++ b/db/revert/tables/history_item.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:types/history_item from pg
+
+BEGIN;
+
+drop type ccbc_public.history_item;
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -190,3 +190,4 @@ tables/analyst_003_permissions 2023-02-24T19:05:15Z Marcel Mueller <marcel@butto
 @1.46.0 2023-03-01T20:32:23Z Anthony Bushara <anthony@button.is> # release v1.46.0
 tables/history_item 2023-03-01T20:14:20Z ,,,  Vladimir <vladimir@button.is> # add ccbc_public.history_item
 computed_columns/application_history 2023-02-28T12:50:04Z ,,, Vladimir <vladimir@button.is> # add computed_columns/application_history
+extensions/audit_form_data 2023-03-02T18:55:44Z ,,, Vladimir <vladimir@button.is> # add form_data auditing.

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -188,4 +188,5 @@ backfill_history 2023-02-24T21:31:50Z ,,, Vladimir <vladimir@button.is> # backfi
 tables/analyst_003_permissions 2023-02-24T19:05:15Z Marcel Mueller <marcel@button.is> # add update and insert permissions on analyst table
 @1.45.0 2023-02-28T18:53:10Z Marcel Mueller <marcel@m2> # release v1.45.0
 @1.46.0 2023-03-01T20:32:23Z Anthony Bushara <anthony@button.is> # release v1.46.0
+tables/history_item 2023-03-01T20:14:20Z ,,,  Vladimir <vladimir@button.is> # add ccbc_public.history_item
 computed_columns/application_history 2023-02-28T12:50:04Z ,,, Vladimir <vladimir@button.is> # add computed_columns/application_history

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -188,3 +188,4 @@ backfill_history 2023-02-24T21:31:50Z ,,, Vladimir <vladimir@button.is> # backfi
 tables/analyst_003_permissions 2023-02-24T19:05:15Z Marcel Mueller <marcel@button.is> # add update and insert permissions on analyst table
 @1.45.0 2023-02-28T18:53:10Z Marcel Mueller <marcel@m2> # release v1.45.0
 @1.46.0 2023-03-01T20:32:23Z Anthony Bushara <anthony@button.is> # release v1.46.0
+computed_columns/application_history 2023-02-28T12:50:04Z ,,, Vladimir <vladimir@button.is> # add computed_columns/application_history

--- a/db/test/unit/computed_columns/application_history_test.sql
+++ b/db/test/unit/computed_columns/application_history_test.sql
@@ -1,0 +1,115 @@
+begin;
+
+select plan(6);
+
+truncate table
+  ccbc_public.application,
+  ccbc_public.application_status,
+  ccbc_public.attachment,
+  ccbc_public.form_data,
+  ccbc_public.application_form_data,
+  ccbc_public.intake,
+  ccbc_public.application_analyst_lead,
+  ccbc_public.record_version,
+  ccbc_public.ccbc_user
+restart identity cascade;
+
+select has_function(
+  'ccbc_public', 'application_history',
+  'Function application_history should exist'
+);
+
+insert into ccbc_public.intake(open_timestamp, close_timestamp, ccbc_intake_number)
+values('2022-03-01 09:00:00-07', '2024-05-01 09:00:00-07', 1);
+
+--select mocks.set_mocked_time_in_transaction('2022-04-01 09:00:00-07'::timestamptz);
+
+set jwt.claims.sub to 'testCcbcAuthUser';
+insert into ccbc_public.ccbc_user
+  (given_name, family_name, email_address, session_sub) values
+  ('foo1', 'bar', 'foo1@bar.com', 'testCcbcAuthUser');
+set role ccbc_auth_user;
+
+select ccbc_public.create_application();
+
+set role ccbc_admin;
+
+select results_eq (
+  $$
+  select count(*) from  ccbc_public.record_version 
+  $$,
+  $$
+    values(2::bigint)
+  $$,
+  'Should have two records in record_version'
+); 
+
+set role ccbc_analyst;
+
+select results_eq (
+  $$
+  select count(*) from (select ccbc_public.application_history(
+    (select row(application.*)::ccbc_public.application from ccbc_public.application where id=1)) 
+  ) as test
+  $$,
+  $$
+    values(0::bigint)
+  $$,
+  'Should not get any record until application status is not received'
+); 
+
+set role ccbc_auth_user;
+
+insert into ccbc_public.application_status (application_id, status) VALUES (1,'received');
+
+set role ccbc_analyst;
+
+select results_eq (
+  $$
+  select count(*) from (select ccbc_public.application_history(
+    (select row(application.*)::ccbc_public.application from ccbc_public.application where id=1)) 
+  ) as test
+  $$,
+  $$
+    values(3::bigint)
+  $$,
+  'Should have three records: application created,  status set to draft and then status set to received'
+);
+
+-- RFI always saves rfiAdditionalFiles object even when no files were selected
+select ccbc_public.create_rfi(1, '{"rfiAdditionalFiles": {}}'::jsonb);
+
+select results_eq (
+  $$
+  select count(*) from (select ccbc_public.application_history(
+    (select row(application.*)::ccbc_public.application from ccbc_public.application where id=1)) 
+  ) as test
+  $$,
+  $$
+    values(4::bigint)
+  $$,
+  'Should have four records: application created,  status set to draft, status set to received, rfi created'
+);
+
+set role ccbc_auth_user;
+
+insert into ccbc_public.attachment(file_name, application_id) values ('foo', 1);
+
+set role ccbc_analyst;
+
+select results_eq (
+  $$
+  select count(*) from (select ccbc_public.application_history(
+    (select row(application.*)::ccbc_public.application from ccbc_public.application where id=1)) 
+  ) as test
+  $$,
+  $$
+    values(5::bigint)
+  $$,
+  'Should have five records: application created,  status set to draft, status set to received, rfi created, attachment added'
+);
+
+
+select finish();
+
+rollback;

--- a/db/test/unit/computed_columns/application_history_test.sql
+++ b/db/test/unit/computed_columns/application_history_test.sql
@@ -39,9 +39,9 @@ select results_eq (
   select count(*) from  ccbc_public.record_version 
   $$,
   $$
-    values(2::bigint)
+    values(3::bigint)
   $$,
-  'Should have two records in record_version'
+  'Should have three records in record_version (application, application_status, form_data)'
 ); 
 
 set role ccbc_analyst;
@@ -71,9 +71,9 @@ select results_eq (
   ) as test
   $$,
   $$
-    values(3::bigint)
+    values(4::bigint)
   $$,
-  'Should have three records: application created,  status set to draft and then status set to received'
+  'Should have three records: application created, form_data inserted, status set to draft and then status set to received'
 );
 
 -- RFI always saves rfiAdditionalFiles object even when no files were selected
@@ -86,9 +86,9 @@ select results_eq (
   ) as test
   $$,
   $$
-    values(4::bigint)
+    values(5::bigint)
   $$,
-  'Should have four records: application created,  status set to draft, status set to received, rfi created'
+  'Should have four records: application created, form_data inserted, status set to draft, status set to received, rfi created'
 );
 
 set role ccbc_auth_user;
@@ -104,9 +104,9 @@ select results_eq (
   ) as test
   $$,
   $$
-    values(5::bigint)
+    values(6::bigint)
   $$,
-  'Should have five records: application created,  status set to draft, status set to received, rfi created, attachment added'
+  'Should have five records: application created, form_data inserted, status set to draft, status set to received, rfi created, attachment added'
 );
 
 

--- a/db/verify/tables/analyst_003_permissions.sql
+++ b/db/verify/tables/analyst_003_permissions.sql
@@ -1,7 +1,0 @@
--- Verify ccbc:tables/analyst_003_permissions on pg
-
-BEGIN;
-
--- XXX Add verifications here.
-
-ROLLBACK;


### PR DESCRIPTION
Implements #1211

created function to return audit records related to application. Includes:
- record when application was created;
- records when application status was changed;
- records when attachments were added to the application;
- records when assessment entries were created;
- records when RFI entries were created;