### PR TITLE
fix: use url query param instead of next router

### DIFF
--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -73,8 +73,8 @@ const Table: React.FC<Props> = ({
         if (mode === 'replace') router.replace(url, url, { shallow: true });
         else router.push(url, url, { shallow: true });
 
-        if (router.query.orderBy) {
-          cookie.set('analyst.sort', router.query.orderBy);
+        if (url.query?.orderBy) {
+          cookie.set('analyst.sort', url.query?.orderBy);
         }
       };
 


### PR DESCRIPTION
Looks like we missed a minor issue where the first click of a sort column would not save the query param though it would save fine after that. For some reason next router was behind, though I am just grabbing it from the url now which seems to be working great.
