### PR TITLE
chore: update gitleaks release url and bump to v8.16.0

### DIFF
--- a/.bin/install-gitleaks-linux-x64.sh
+++ b/.bin/install-gitleaks-linux-x64.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -xeuo pipefail;
 
-version="8.15.3";
-releases_api="https://api.github.com/repos/zricethezav/gitleaks/releases/tags/v${version}";
+version="8.16.0";
+releases_api="https://api.github.com/repositories/119190187/releases/tags/v${version}";
 releases_json="$(curl -s ${releases_api})";
 
 case "$OSTYPE" in


### PR DESCRIPTION
Gitleaks action was broken again, this time due to the release api url changing.

https://github.com/bcgov/CONN-CCBC-portal/actions/runs/4361309832/jobs/7625090142

```
+ releases_api=https://api.github.com/repos/zricethezav/gitleaks/releases/tags/v8.15.3
++ curl -s https://api.github.com/repos/zricethezav/gitleaks/releases/tags/v8.15.3
+ releases_json='{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/[11](https://github.com/bcgov/CONN-CCBC-portal/actions/runs/4361309832/jobs/7625090142#step:3:12)9190187/releases/tags/v8.15.3",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}'
+ case "$OSTYPE" in
+ arch=linux_x64
++ jq -r '.assets[] | select(.name | contains("linux_x64")) | .browser_download_url'
++ echo '{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/119190187/releases/tags/v8.15.3",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}'
```