### PR TITLE
feat: add sentry data tags to get clearer picture

### DIFF
--- a/app/backend/lib/graphql/resolveFileUpload.ts
+++ b/app/backend/lib/graphql/resolveFileUpload.ts
@@ -43,6 +43,7 @@ export const saveRemoteFile = async (stream) => {
     op: 'resolve-file-upload',
     description: 'resolveFileUpload saveRemoteFile function',
   });
+  span.setData('start-of-funciton-call', new Date().toISOString());
 
   try {
     console.time('saveRemoteFile');
@@ -80,14 +81,11 @@ export const saveRemoteFile = async (stream) => {
       console.log(`Uploaded ${uploadProgressInMB}MB`);
       transaction.setMeasurement('memoryUsed', uploadProgressInMB, 'megabtye');
     });
-
+    span.setData('upload-start', new Date().toISOString());
     const data = await parallelUploads3.done();
+    span.setData('upload-finish', new Date().toISOString());
 
     const key = (data as CompleteMultipartUploadCommandOutput)?.Key;
-
-    span.setStatus('ok');
-    span.finish();
-    transaction.finish();
 
     if (!key) {
       throw new Error('Data does not contain a key');
@@ -99,6 +97,7 @@ export const saveRemoteFile = async (stream) => {
 
     return key;
   } catch (err) {
+    span.setData('error-obj', err);
     span.setStatus('unknown_error');
     span.finish();
     transaction.finish();

--- a/app/tests/backend/lib/graphql/resolveFileUpload.test.ts
+++ b/app/tests/backend/lib/graphql/resolveFileUpload.test.ts
@@ -52,6 +52,7 @@ const sentryMocked = jest
         return {
           setStatus: jest.fn(() => ({})),
           finish: jest.fn(() => ({})),
+          setData: jest.fn(() => ({})),
         };
       }),
     };
@@ -102,6 +103,7 @@ describe('The saveRemoteFile function', () => {
             return {
               setStatus: jest.fn(() => 'ok'),
               finish: jest.fn(() => ({})),
+              setData: jest.fn(() => ({})),
             };
           }),
         };


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements nothing in particular, just thought it would be useful after looking at the sentry log info. Can help shed light as to whether this is a problem with our appilcation's resources (is our app hanging waiting to communicate with AWS or is it just taking a long time to setup the connection because the app in general runs slowly)

I'd love to add some log info of the pod load at the same time, but I'm not sure how to get that data in our app

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
