### PR TITLE
feat: align icons to be inline with state for accordion

### DIFF
--- a/app/components/Review/Accordion.tsx
+++ b/app/components/Review/Accordion.tsx
@@ -135,12 +135,9 @@ const Accordion = ({
               <AlertIcon />
             </StyledAlert>
           )}
-          <BaseAccordion.ToggleOff>
-            <Plus />
-          </BaseAccordion.ToggleOff>
-          <BaseAccordion.ToggleOn>
-            <Minus />
-          </BaseAccordion.ToggleOn>
+          <button type="button" onClick={handleToggle}>
+            {isToggled ? <Minus /> : <Plus />}
+          </button>
         </StyledToggleRight>
       </header>
       <section


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # 1168 With the icon being consistent with the state of the accordion
<!--
Add detailed description of the changes if the PR title isn't enough
 -->
