### PR TITLE
docs: add signed commits section to contributing doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - [Modifying the database](db/README.md)
 - [Database style rules](db/test/style/README.md)
 - [Process to manipulate data in production](docs/process_to_manipulate_data.md)
-- [Database backup with pg_dump](docs/Data_Dump_With_Pg_D)
+- [Database backup with pg_dump](docs/Data_Dump_With_Pg_Dump)
 
 ##### Infrastructure
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Once that is running in a second terminal run:
 
 `yarn test:e2e`
 
+### Happo screenshot testing
+
+This project uses [Happo](https://happo.io/) for screenshot testing. Everyone who has contributor access to this repository has access to the Happo tests. If you require admin access needed to modify the project or testing thresholds contact a developer from this project or the [CAS](https://github.com/bcgov/cas-cif) team for access.
+
 ### Object storage:
 
 The `resolveFileUpload` middleware is set up to use AWS S3 storage. If no namespace is set and any AWS environment variables are missing the uploads will save to the local system in the `/app/uploads` folder.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -63,6 +63,13 @@ Our work is tracked in GitHub issues, located in this repository. We use Zenhub 
 - Branches are automatically deleted on Github when a PR is merged. Each teammate should set git config fetch.prune true to mirror this behaviour to their local workstation.
 - Squash merge has been disabled to increase the efficiency of git bisect.
 
+## Signing commits
+
+Signed commits are a requirement to merge code into this project to give the team confidence of the origin of a change that has been made. This is enforced so that all commits in a pull request must have verified signatures before they are merged into main.
+
+[About commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
+[Signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
+
 ## Commit Message Guidelines
 
 Similar to [Angular's guidelines](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines), we follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format for our commit messages. This leads to more readable messages that are easy to follow when looking through the project history. We use the git commit messages to generate the change log upon releasing.


### PR DESCRIPTION
Added a small section on Happo screenshot testing as well as a section on signed commits.
