### PR TITLE
test: add test coverage for cancel button

### DIFF
--- a/app/tests/pages/analyst/application/[applicationId]/edit/[section].test.tsx
+++ b/app/tests/pages/analyst/application/[applicationId]/edit/[section].test.tsx
@@ -136,6 +136,22 @@ describe('The analyst edit application page', () => {
     ).toHaveValue('$15');
   });
 
+  it('shows modal on enter key', async() => {
+    pageTestingHelper.setMockRouterValues({
+      query: { applicationId: '1', section: 'estimatedProjectEmployment' },
+    });
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    const people = screen.getAllByLabelText(/Number of people/)[0];
+
+    await userEvent.type(people, '{enter}')
+
+    expect(window.location.hash).toBe("#change-modal")
+
+    window.location.hash = ""
+  })
+
   it('displays the confirmation modal and calls the mutation on save', async () => {
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();

--- a/app/tests/pages/analyst/application/[applicationId]/edit/[section].test.tsx
+++ b/app/tests/pages/analyst/application/[applicationId]/edit/[section].test.tsx
@@ -87,6 +87,19 @@ describe('The analyst edit application page', () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 
+  it('should go back on cancel button', async() => {
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+
+    await act(async () => {
+      fireEvent.click(cancelButton);
+    });
+
+    expect(window.location.hash).toBe("")
+  })
+
   it('should calculate values on estimatedProjectEmployment page', async () => {
     pageTestingHelper.setMockRouterValues({
       query: { applicationId: '1', section: 'estimatedProjectEmployment' },


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Increases test coverage past 80% by adding tests to the cancel button functionality.

Implements # \<issue number\>

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
