### PR TITLE
fix: replace schemaspy snapshot tag with latest

### DIFF
--- a/.github/workflows/schemaspy.yaml
+++ b/.github/workflows/schemaspy.yaml
@@ -37,7 +37,7 @@ jobs:
           mkdir output
           chmod a+rwx -R output
       - name: Run Schemaspy
-        run: docker run --network host -v "$PWD/output:/output" schemaspy/schemaspy:snapshot -t pgsql -db ccbc -host 127.0.0.1 -port 5432 -u postgres -p postgres -schemas ccbc_public
+        run: docker run --network host -v "$PWD/output:/output" schemaspy/schemaspy:latest -t pgsql -db ccbc -host 127.0.0.1 -port 5432 -u postgres -p postgres -schemas ccbc_public
       - name: Deploy to Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
Replaced the `snapshot` tag with `latest`. Snapshot is the latest development build which is volatile by nature, while latest is the latest release and only behind by a few weeks at the moment. If this issue comes up again we can lock in a specific version in the future.

Successful test run:

https://github.com/bcgov/CONN-CCBC-portal/actions/runs/4736614960/jobs/8408408417
