### PR TITLE
feat: update relay store for external status change

### DIFF
--- a/app/components/Analyst/Project/ConditionalApproval/ConditionalApprovalModal.tsx
+++ b/app/components/Analyst/Project/ConditionalApproval/ConditionalApprovalModal.tsx
@@ -1,6 +1,7 @@
 import Button from '@button-inc/bcgov-theme/Button';
 import Modal from '@button-inc/bcgov-theme/Modal';
 import styled from 'styled-components';
+import formatStatus from 'utils/formatStatus';
 import { useSubmitConditionalApprovalMutation } from 'schema/mutations/project/submitConditionalApproval';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
@@ -44,6 +45,7 @@ const StyledHeader = styled(Modal.Header)`
 `;
 
 interface Props {
+  applicationId: string;
   rowId: number;
   formData: any;
   newFormStatus: string;
@@ -54,6 +56,7 @@ interface Props {
 }
 
 const ConditionalApprovalModal: React.FC<Props> = ({
+  applicationId,
   rowId,
   formData,
   newFormStatus,
@@ -76,6 +79,11 @@ const ConditionalApprovalModal: React.FC<Props> = ({
       onCompleted: () => {
         setOldFormData();
         setIsFormEditMode();
+      },
+      updater: (store) => {
+        store
+          .get(applicationId)
+          .setValue(formatStatus(newFormStatus), 'externalStatus');
       },
     });
   };

--- a/app/components/Analyst/Project/ConditionalApproval/ConditionalApprovalModal.tsx
+++ b/app/components/Analyst/Project/ConditionalApproval/ConditionalApprovalModal.tsx
@@ -45,7 +45,7 @@ const StyledHeader = styled(Modal.Header)`
 `;
 
 interface Props {
-  applicationId: string;
+  applicationStoreId: string;
   rowId: number;
   formData: any;
   newFormStatus: string;
@@ -56,7 +56,7 @@ interface Props {
 }
 
 const ConditionalApprovalModal: React.FC<Props> = ({
-  applicationId,
+  applicationStoreId,
   rowId,
   formData,
   newFormStatus,
@@ -82,7 +82,7 @@ const ConditionalApprovalModal: React.FC<Props> = ({
       },
       updater: (store) => {
         store
-          .get(applicationId)
+          .get(applicationStoreId)
           .setValue(formatStatus(newFormStatus), 'externalStatus');
       },
     });

--- a/app/pages/analyst/application/[applicationId]/project.tsx
+++ b/app/pages/analyst/application/[applicationId]/project.tsx
@@ -89,8 +89,7 @@ const Project = ({
     <Layout session={session} title="Connecting Communities BC">
       <AnalystLayout query={query}>
         <ConditionalApprovalModal
-          applicationByRowId={query.applicationByRowId}
-          applicationId={id}
+          applicationStoreId={id}
           rowId={rowId}
           formData={newFormData}
           newFormStatus={newFormStatus}

--- a/app/pages/analyst/application/[applicationId]/project.tsx
+++ b/app/pages/analyst/application/[applicationId]/project.tsx
@@ -24,6 +24,7 @@ const getProjectQuery = graphql`
       sub
     }
     applicationByRowId(rowId: $rowId) {
+      id
       rowId
       conditionalApproval {
         id
@@ -39,7 +40,7 @@ const Project = ({
 }: RelayProps<Record<string, unknown>, projectQuery>) => {
   const query = usePreloadedQuery(getProjectQuery, preloadedQuery);
   const {
-    applicationByRowId: { rowId, conditionalApproval },
+    applicationByRowId: { id, rowId, conditionalApproval },
     session,
   } = query;
 
@@ -88,6 +89,8 @@ const Project = ({
     <Layout session={session} title="Connecting Communities BC">
       <AnalystLayout query={query}>
         <ConditionalApprovalModal
+          applicationByRowId={query.applicationByRowId}
+          applicationId={id}
           rowId={rowId}
           formData={newFormData}
           newFormStatus={newFormStatus}

--- a/app/tests/utils/formatStatus.test.ts
+++ b/app/tests/utils/formatStatus.test.ts
@@ -1,0 +1,17 @@
+import formatStatus from '../../utils/formatStatus';
+
+describe('The formatStatus function', () => {
+  it('returns the correct status for Conditionally Approved', () => {
+    expect(formatStatus('Conditionally Approved')).toBe(
+      'applicant_conditionally_approved'
+    );
+  });
+
+  it('returns the correct status for Received', () => {
+    expect(formatStatus('Received')).toBe('applicant_received');
+  });
+
+  it('returns the correct unhandled status', () => {
+    expect(formatStatus('unhandled_status')).toBe('unhandled_status');
+  });
+});

--- a/app/utils/formatStatus.ts
+++ b/app/utils/formatStatus.ts
@@ -1,0 +1,11 @@
+const formatStatus = (status: string) => {
+  if (status === 'Received') {
+    return 'applicant_received';
+  }
+  if (status === 'Conditionally Approved') {
+    return 'applicant_conditionally_approved';
+  }
+  return status;
+};
+
+export default formatStatus;


### PR DESCRIPTION
External status in header should update instantly on change now
