### PR TITLE
fix: use analyst status on analyst dashboard

### DIFF
--- a/app/components/AnalystDashboard/AnalystRow.tsx
+++ b/app/components/AnalystDashboard/AnalystRow.tsx
@@ -71,7 +71,7 @@ const AnalystRow: React.FC<Props> = ({ query, application }) => {
   const {
     analystLead,
     rowId,
-    status,
+    analystStatus,
     package: applicationPackage,
     projectName,
     ccbcNumber,
@@ -81,7 +81,7 @@ const AnalystRow: React.FC<Props> = ({ query, application }) => {
     graphql`
       fragment AnalystRow_application on Application {
         rowId
-        status
+        analystStatus
         analystLead
         package
         projectName
@@ -104,7 +104,7 @@ const AnalystRow: React.FC<Props> = ({ query, application }) => {
       <StyledIntakeNumberCell>{intakeNumber}</StyledIntakeNumberCell>
       <StyledCcbdIdCell>{ccbcNumber}</StyledCcbdIdCell>
       <StyledStatusCell>
-        <StatusPill status={status} styles={statusStyles} />
+        <StatusPill status={analystStatus} styles={statusStyles} />
       </StyledStatusCell>
       <StyledProjectNameCell>{projectName}</StyledProjectNameCell>
       <StyledOrganizationNameCell>

--- a/app/tests/pages/analyst/dashboard.test.tsx
+++ b/app/tests/pages/analyst/dashboard.test.tsx
@@ -23,7 +23,7 @@ const mockQueryPayload = {
             node: {
               id: '1',
               rowId: 1,
-              status: 'received',
+              analystStatus: 'received',
               projectName: 'Test Proj Name',
               ccbcNumber: 'CCBC-010001',
               organizationName: 'Test Org Name',
@@ -34,7 +34,7 @@ const mockQueryPayload = {
             node: {
               id: '2',
               rowId: 2,
-              status: 'approved',
+              analystStatus: 'approved',
               projectName: 'Test Proj Name 2',
               ccbcNumber: 'CCBC-010002',
               organizationName: 'Test Org Name 2',
@@ -45,7 +45,7 @@ const mockQueryPayload = {
             node: {
               id: '3',
               rowId: 3,
-              status: 'cancelled',
+              analystStatus: 'cancelled',
               projectName: 'Test Proj Name 3',
               ccbcNumber: 'CCBC-010003',
               organizationName: 'Test Org Name 3',
@@ -56,7 +56,7 @@ const mockQueryPayload = {
             node: {
               id: '4',
               rowId: 4,
-              status: 'assessment',
+              analystStatus: 'assessment',
               projectName: 'Test Proj Name 4',
               ccbcNumber: 'CCBC-010004',
               organizationName: 'Test Org Name 4',


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements fix for analyst dashboard showing applicant status

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
