### PR TITLE
fix/prettier ignore schema

### DIFF
--- a/.bin/pre-commit-format.sh
+++ b/.bin/pre-commit-format.sh
@@ -7,4 +7,4 @@ files=("$@")
 files=("${files[@]/#/../}") # add ../ to each element
 
 # --ignore-unknown prevents prettier from complaining about file types it doesn't know about
-yarn run prettier --ignore-unknown --write "${files[@]}"
+yarn run prettier --ignore-unknown --ignore-path ../.prettierignore --write "${files[@]}"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 helm/**/templates/**/*.yaml
 *.env
 .github/ISSUE_TEMPLATE/
+app/schema/schema.graphql


### PR DESCRIPTION
- feat: add graphql schema to prettierignore
- fix: add prettierignore path to pre-commit command

<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # \<issue number\>

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
