### PR TITLE
Update depreciated actions

### DIFF
--- a/.github/actions/dev-env-setup/action.yml
+++ b/.github/actions/dev-env-setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: asdf setup
-      uses: asdf-vm/actions/setup@v1
+      uses: asdf-vm/actions/setup@v2
     - uses: shogo82148/actions-setup-perl@v1
     - name: install pg perl library
       run: sudo apt-get install -y libpq-dev libdbd-pg-perl

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,15 +30,15 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           install: true
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ matrix.image }}
           tags: |
@@ -46,7 +46,7 @@ jobs:
             latest
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -61,7 +61,7 @@ jobs:
             ${{ runner.os }}-buildx-${{ matrix.name }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ${{ matrix.context }}
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: development
-      url: 'https://ccbc-dev.apps.silver.devops.gov.bc.ca'
+      # url: 'https://ccbc-dev.apps.silver.devops.gov.bc.ca'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Deploy
         uses: ./.github/actions/app
         with:
@@ -74,7 +74,7 @@ jobs:
     needs: [is-tagged-release]
     if: contains(needs.is-tagged-release.outputs.tagVersion, 'v')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: ./.bin/sqitch-last-change-is-tag.sh db
 
   deploy-to-openshift-test:
@@ -91,7 +91,7 @@ jobs:
       url: 'https://ccbc-test.apps.silver.devops.gov.bc.ca'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Deploy
         uses: ./.github/actions/app
         with:
@@ -128,7 +128,7 @@ jobs:
       url: 'https://ccbc.apps.silver.devops.gov.bc.ca'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Deploy
         uses: ./.github/actions/app
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,7 +37,7 @@ jobs:
         id: tagVersion
         # Check if one of the commits is associated with a tag
         run: |
-          echo ::set-output name=tagVersion::$( git tag --merged ${{ github.sha  }} --no-merged ${{ github.event.before }} | grep v*)
+          echo "tagVersion=$( git tag --merged ${{ github.sha  }} --no-merged ${{ github.event.before }} | grep v*)" >>$GITHUB_OUTPUT
 
   deploy-to-openshift-development:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_load_test.yaml
+++ b/.github/workflows/deploy_load_test.yaml
@@ -13,7 +13,7 @@ jobs:
       url: 'https://dev.connectingcommunitiesbc.ca'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Deploy
         uses: ./.github/actions/app
         with:

--- a/.github/workflows/deploy_tools_chart.yaml
+++ b/.github/workflows/deploy_tools_chart.yaml
@@ -13,7 +13,7 @@ jobs:
       name: tools
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Authenticate, set context and run deploy script
         uses: redhat-actions/oc-login@v1
         with:

--- a/.github/workflows/schemaspy.yaml
+++ b/.github/workflows/schemaspy.yaml
@@ -14,7 +14,7 @@ jobs:
   install-test-env:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - run: make install_dev_tools
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - name: deploy db migrations

--- a/.github/workflows/test-code.yaml
+++ b/.github/workflows/test-code.yaml
@@ -17,7 +17,7 @@ jobs:
   install-test-env:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - run: make install_dev_tools
@@ -59,7 +59,7 @@ jobs:
         os: ['linux']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
@@ -100,7 +100,7 @@ jobs:
     needs: [install-test-env]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
@@ -120,7 +120,7 @@ jobs:
     needs: [install-test-env]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - run: yarn run eslint -f @microsoft/eslint-formatter-sarif -o results.sarif . || true
@@ -133,7 +133,7 @@ jobs:
     needs: [install-test-env]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - name: deploy db migrations
@@ -147,7 +147,7 @@ jobs:
     needs: [install-test-env]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: dev env setup
@@ -171,7 +171,7 @@ jobs:
       name: tools
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Authenticate to OpenShift Linter namespace
         uses: redhat-actions/oc-login@v1
         with:

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -20,7 +20,7 @@ jobs:
   yarn-test-e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - name: run app locally
@@ -37,7 +37,7 @@ jobs:
   zap-owasp-full:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: dev env setup
         uses: ./.github/actions/dev-env-setup
       - name: run app locally


### PR DESCRIPTION
Fixed all of the `set-state`, `set-output` and `node 12` being depreciated warnings in our workflows except for the `zaproxy` warning. Supposedly it has been fixed though I don't see a release since that was merged and all the rest of the notification have disappeared. Something to keep an eye on anyways, I created a new issue to track it: #1502 

https://github.com/zaproxy/action-full-scan/issues/61

Fixed our singluar usage of `set-output` and updated a lot of our actions. 

Full scan completed with warning removed (except for zaproxy):

https://github.com/bcgov/CONN-CCBC-portal/actions/runs/4812941028

