### PR TITLE
1524 edit announcements

### DIFF
--- a/app/components/Analyst/Project/Announcements/AnnouncementsForm.tsx
+++ b/app/components/Analyst/Project/Announcements/AnnouncementsForm.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { ConnectionHandler, graphql, useFragment } from 'react-relay';
-// import { ConnectionHandler } from 'relay-runtime';
 import styled from 'styled-components';
 import { ProjectForm } from 'components/Analyst/Project';
 import validateFormData from '@rjsf/core/dist/cjs/validate';
@@ -231,6 +230,7 @@ const AnnouncementsForm = ({ query }) => {
       resetFormData={handleResetFormData}
       onSubmit={handleSubmit}
       setIsFormEditMode={(boolean) => setIsFormEditMode(boolean)}
+      saveDataTestId="save-announcement"
     >
       <ViewAnnouncements
         announcements={announcementsList}

--- a/app/components/Analyst/Project/Announcements/AnnouncementsForm.tsx
+++ b/app/components/Analyst/Project/Announcements/AnnouncementsForm.tsx
@@ -83,11 +83,12 @@ const AnnouncementsForm = ({ query }) => {
   } = queryFragment;
 
   const announcementsList = announcements.edges.map((announcement) => {
-    return announcement.node.jsonData;
+    return announcement.node;
   });
 
   const [formData, setFormData] = useState({} as any);
   const [isFormEditMode, setIsFormEditMode] = useState(false);
+  const [announcementId, setAnnouncementId] = useState(null);
 
   const [createAnnouncement] = useCreateAnnouncementMutation();
   const hiddenSubmitRef = useRef<HTMLButtonElement>(null);
@@ -199,6 +200,10 @@ const AnnouncementsForm = ({ query }) => {
     >
       <ViewAnnouncements
         announcements={announcementsList}
+        isFormEditMode={isFormEditMode}
+        setAnnouncementId={setAnnouncementId}
+        setFormData={setFormData}
+        setIsFormEditMode={setIsFormEditMode}
         style={{
           zIndex: isFormEditMode ? -1 : 1,
         }}

--- a/app/components/Analyst/Project/Announcements/ViewAnnouncements.tsx
+++ b/app/components/Analyst/Project/Announcements/ViewAnnouncements.tsx
@@ -43,7 +43,7 @@ const StyledIconBtn = styled.button`
 const Announcement = ({
   announcement,
   isFormEditMode,
-  setAnnouncementId,
+  setAnnouncementData,
   setFormData,
   setIsFormEditMode,
 }) => {
@@ -58,7 +58,10 @@ const Announcement = ({
         <StyledIconBtn
           onClick={() => {
             setIsFormEditMode(true);
-            setAnnouncementId(announcement.id);
+            setAnnouncementData({
+              id: announcement.id,
+              rowId: announcement.rowId,
+            });
             setFormData(announcement.jsonData);
           }}
           data-testid="project-form-edit-button"
@@ -74,7 +77,7 @@ interface Props {
   announcements: any;
   style?: any;
   isFormEditMode: boolean;
-  setAnnouncementId: (announcementId: string) => void;
+  setAnnouncementData: (announcementId: string) => void;
   setFormData: (formData: JSONSchema7) => void;
   setIsFormEditMode: (isFormEditMode: boolean) => void;
 }
@@ -82,7 +85,7 @@ interface Props {
 const ViewAnnouncements: React.FC<Props> = ({
   announcements,
   isFormEditMode,
-  setAnnouncementId,
+  setAnnouncementData,
   setFormData,
   setIsFormEditMode,
   style,
@@ -108,7 +111,7 @@ const ViewAnnouncements: React.FC<Props> = ({
               key={announcement.id}
               announcement={announcement}
               isFormEditMode={isFormEditMode}
-              setAnnouncementId={setAnnouncementId}
+              setAnnouncementData={setAnnouncementData}
               setFormData={setFormData}
               setIsFormEditMode={setIsFormEditMode}
             />
@@ -125,7 +128,7 @@ const ViewAnnouncements: React.FC<Props> = ({
               key={announcement.id}
               announcement={announcement}
               isFormEditMode={isFormEditMode}
-              setAnnouncementId={setAnnouncementId}
+              setAnnouncementData={setAnnouncementData}
               setFormData={setFormData}
               setIsFormEditMode={setIsFormEditMode}
             />

--- a/app/components/Analyst/Project/Announcements/ViewAnnouncements.tsx
+++ b/app/components/Analyst/Project/Announcements/ViewAnnouncements.tsx
@@ -64,6 +64,7 @@ const Announcement = ({
             });
             setFormData(announcement.jsonData);
           }}
+          aria-label="Edit announcement"
           data-testid="project-form-edit-button"
         >
           <FontAwesomeIcon icon={faPen} size="xs" />

--- a/app/components/Analyst/Project/Announcements/ViewAnnouncements.tsx
+++ b/app/components/Analyst/Project/Announcements/ViewAnnouncements.tsx
@@ -1,4 +1,7 @@
 import styled from 'styled-components';
+import { JSONSchema7 } from 'json-schema';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPen } from '@fortawesome/free-solid-svg-icons';
 import AnnouncementsHeader from './AnnouncementsHeader';
 
 const StyledEmpty = styled.div`
@@ -25,11 +28,44 @@ const StyledAnnouncement = styled.div`
 }
 `;
 
-const Announcement = ({ announcement }) => {
+const StyledIconBtn = styled.button`
+  margin-left: 8px;
+
+  & svg {
+    color: ${(props) => props.theme.color.links};
+  }
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;
+
+const Announcement = ({
+  announcement,
+  isFormEditMode,
+  setAnnouncementId,
+  setFormData,
+  setIsFormEditMode,
+}) => {
+  const {
+    jsonData: { announcementUrl, announcementDate },
+  } = announcement;
   return (
     <StyledAnnouncement>
-      <div>{announcement.announcementUrl}</div>
-      <div>{announcement.announcementDate}</div>
+      <div>{announcementUrl}</div>
+      <div>{announcementDate}</div>
+      {!isFormEditMode && (
+        <StyledIconBtn
+          onClick={() => {
+            setIsFormEditMode(true);
+            setAnnouncementId(announcement.id);
+            setFormData(announcement.jsonData);
+          }}
+          data-testid="project-form-edit-button"
+        >
+          <FontAwesomeIcon icon={faPen} size="xs" />
+        </StyledIconBtn>
+      )}
     </StyledAnnouncement>
   );
 };
@@ -37,15 +73,26 @@ const Announcement = ({ announcement }) => {
 interface Props {
   announcements: any;
   style?: any;
+  isFormEditMode: boolean;
+  setAnnouncementId: (announcementId: string) => void;
+  setFormData: (formData: JSONSchema7) => void;
+  setIsFormEditMode: (isFormEditMode: boolean) => void;
 }
 
-const ViewAnnouncements: React.FC<Props> = ({ announcements, style }) => {
+const ViewAnnouncements: React.FC<Props> = ({
+  announcements,
+  isFormEditMode,
+  setAnnouncementId,
+  setFormData,
+  setIsFormEditMode,
+  style,
+}) => {
   const primaryAnnouncements = announcements.filter(
-    (announcement) => announcement.announcementType === 'Primary'
+    (announcement) => announcement.jsonData.announcementType === 'Primary'
   );
 
   const secondaryAnnouncements = announcements.filter(
-    (announcement) => announcement.announcementType === 'Secondary'
+    (announcement) => announcement.jsonData.announcementType === 'Secondary'
   );
 
   const isPrimary = primaryAnnouncements.length > 0;
@@ -57,7 +104,14 @@ const ViewAnnouncements: React.FC<Props> = ({ announcements, style }) => {
       {isPrimary ? (
         primaryAnnouncements.map((announcement) => {
           return (
-            <Announcement key={announcement.id} announcement={announcement} />
+            <Announcement
+              key={announcement.id}
+              announcement={announcement}
+              isFormEditMode={isFormEditMode}
+              setAnnouncementId={setAnnouncementId}
+              setFormData={setFormData}
+              setIsFormEditMode={setIsFormEditMode}
+            />
           );
         })
       ) : (
@@ -67,7 +121,14 @@ const ViewAnnouncements: React.FC<Props> = ({ announcements, style }) => {
       {isSecondary ? (
         secondaryAnnouncements.map((announcement) => {
           return (
-            <Announcement key={announcement.id} announcement={announcement} />
+            <Announcement
+              key={announcement.id}
+              announcement={announcement}
+              isFormEditMode={isFormEditMode}
+              setAnnouncementId={setAnnouncementId}
+              setFormData={setFormData}
+              setIsFormEditMode={setIsFormEditMode}
+            />
           );
         })
       ) : (

--- a/app/components/Analyst/Project/ProjectForm.tsx
+++ b/app/components/Analyst/Project/ProjectForm.tsx
@@ -81,6 +81,7 @@ interface Props {
   theme?: any;
   title: string;
   uiSchema?: any;
+  saveDataTestId?: string;
 }
 
 const ProjectForm: React.FC<Props> = ({
@@ -99,6 +100,7 @@ const ProjectForm: React.FC<Props> = ({
   theme,
   title,
   uiSchema,
+  saveDataTestId = 'save',
   ...rest
 }) => {
   return (
@@ -108,7 +110,11 @@ const ProjectForm: React.FC<Props> = ({
         <StyledToggleRight>
           {isFormEditMode ? (
             <>
-              <StyledBtn size="small" onClick={onSubmit}>
+              <StyledBtn
+                data-testid={saveDataTestId}
+                size="small"
+                onClick={onSubmit}
+              >
                 Save
               </StyledBtn>
               <StyledBtn

--- a/app/components/Analyst/Project/widgets/CcbcIdWidget.tsx
+++ b/app/components/Analyst/Project/widgets/CcbcIdWidget.tsx
@@ -18,7 +18,24 @@ const StyledAutocomplete = styled(Autocomplete)`
   }
 `;
 
-const optionChecker = (option: any, val: any) => {
+export const renderTags = (tagValue: any[], getTagProps: (any) => any) => {
+  return tagValue.map((option: any, index) => {
+    const { ccbcNumber, rowId } = option;
+    return (
+      <Chip
+        key={ccbcNumber}
+        label={ccbcNumber}
+        clickable
+        onClick={() => {
+          window.open(`/analyst/application/${rowId}/project`, '_blank');
+        }}
+        {...getTagProps({ index })}
+      />
+    );
+  });
+};
+
+export const optionChecker = (option: any, val: any) => {
   return option.rowId === val.rowId && option.ccbcNumber === val.ccbcNumber;
 };
 
@@ -66,22 +83,7 @@ const UrlWidget: React.FC<WidgetProps> = ({
       isOptionEqualToValue={optionChecker}
       getOptionLabel={(option: any) => option.ccbcNumber}
       filterSelectedOptions
-      renderTags={(tagValue, getTagProps) =>
-        tagValue.map((option: any, index) => {
-          const { ccbcNumber, rowId } = option;
-          return (
-            <Chip
-              key={ccbcNumber}
-              label={ccbcNumber}
-              clickable
-              onClick={() => {
-                window.open(`/analyst/application/${rowId}/project`, '_blank');
-              }}
-              {...getTagProps({ index })}
-            />
-          );
-        })
-      }
+      renderTags={renderTags}
       renderInput={(params) => (
         <TextField {...params} sx={styles} placeholder="Search by CCBC ID" />
       )}

--- a/app/components/Analyst/Project/widgets/CcbcIdWidget.tsx
+++ b/app/components/Analyst/Project/widgets/CcbcIdWidget.tsx
@@ -18,6 +18,10 @@ const StyledAutocomplete = styled(Autocomplete)`
   }
 `;
 
+const optionChecker = (option: any, val: any) => {
+  return option.rowId === val.rowId && option.ccbcNumber === val.ccbcNumber;
+};
+
 const UrlWidget: React.FC<WidgetProps> = ({
   id,
   formContext,
@@ -55,8 +59,11 @@ const UrlWidget: React.FC<WidgetProps> = ({
       onChange={(e, val) => {
         if (e) onChange(val);
       }}
+      value={value ?? []}
       data-testid={id}
       options={ccbcIdList}
+      // To prevent a warning when comparing the previous value to the current
+      isOptionEqualToValue={optionChecker}
       getOptionLabel={(option: any) => option.ccbcNumber}
       filterSelectedOptions
       renderTags={(tagValue, getTagProps) =>

--- a/app/schema/mutations/project/updateAnnouncement.ts
+++ b/app/schema/mutations/project/updateAnnouncement.ts
@@ -1,0 +1,23 @@
+import { graphql } from 'react-relay';
+import { updateAnnouncementMutation } from '__generated__/updateAnnouncementMutation.graphql';
+import useMutationWithErrorMessage from '../useMutationWithErrorMessage';
+
+const mutation = graphql`
+  mutation updateAnnouncementMutation($input: UpdateAnnouncementInput!) {
+    updateAnnouncement(input: $input) {
+      announcement {
+        id
+        rowId
+        jsonData
+      }
+    }
+  }
+`;
+
+const useUpdateAnnouncementMutation = () =>
+  useMutationWithErrorMessage<updateAnnouncementMutation>(
+    mutation,
+    () => 'An error occured while attempting to create the announcement'
+  );
+
+export { mutation, useUpdateAnnouncementMutation };

--- a/app/tests/components/Analyst/AnnouncementsForm.test.tsx
+++ b/app/tests/components/Analyst/AnnouncementsForm.test.tsx
@@ -1,0 +1,30 @@
+import { concatCCBCNumbers } from 'components/Analyst/Project/Announcements/AnnouncementsForm';
+
+describe('Test pure functions in AnnouncementsForm', () => {
+  it('Test result of concatCCBCNumbers with valid data', () => {
+    const currentCcbcNumber = 'CCBC-010004';
+    const ccbcNumberList = [
+      { ccbcNumber: 'CCBC-010003' },
+      { ccbcNumber: 'CCBC-010002' },
+      { ccbcNumber: 'CCBC-010001' },
+    ];
+    const result = concatCCBCNumbers(currentCcbcNumber, ccbcNumberList);
+    expect(result).toBe('CCBC-010004,CCBC-010003,CCBC-010002,CCBC-010001,');
+  });
+  it('Test result of concatCCBCNumbers with empty array', () => {
+    const currentCcbcNumber = 'CCBC-010003';
+    const ccbcNumberList = [];
+    const result = concatCCBCNumbers(currentCcbcNumber, ccbcNumberList);
+    expect(result).toBe('CCBC-010003');
+  });
+  it('Test result of concatCCBCNumbers with empty currenctCcbcNumber', () => {
+    const currentCcbcNumber = '';
+    const ccbcNumberList = [
+      { ccbcNumber: 'CCBC-010003' },
+      { ccbcNumber: 'CCBC-010002' },
+      { ccbcNumber: 'CCBC-010001' },
+    ];
+    const result = concatCCBCNumbers(currentCcbcNumber, ccbcNumberList);
+    expect(result).toBe(',CCBC-010003,CCBC-010002,CCBC-010001,');
+  });
+});

--- a/app/tests/components/Analyst/CcbcIdWidget.test.tsx
+++ b/app/tests/components/Analyst/CcbcIdWidget.test.tsx
@@ -1,0 +1,72 @@
+import { render, fireEvent } from '@testing-library/react';
+import {
+  optionChecker,
+  renderTags,
+} from 'components/Analyst/Project/widgets/CcbcIdWidget';
+
+describe('UrlWidget', () => {
+  it('renders tags and handles click events', () => {
+    // Mock the window.open function
+    const windowOpenSpy = jest
+      .spyOn(window, 'open')
+      .mockImplementation(() => null);
+
+    // Sample tag data
+    const tagValue = [
+      { ccbcNumber: '123', rowId: '1' },
+      { ccbcNumber: '456', rowId: '2' },
+    ];
+
+    // Sample getTagProps function
+    const getTagProps = ({ index }) => ({ 'data-testid': `tag-${index}` });
+
+    // Render tags using the extracted renderTags function
+    const { getByTestId } = render(
+      <div>{renderTags(tagValue, getTagProps)}</div>
+    );
+
+    // Assert the tags are rendered
+    expect(getByTestId('tag-0')).toHaveTextContent('123');
+    expect(getByTestId('tag-1')).toHaveTextContent('456');
+
+    // Fire click event on the first tag
+    fireEvent.click(getByTestId('tag-0'));
+
+    // Assert window.open is called with the correct URL
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      '/analyst/application/1/project',
+      '_blank'
+    );
+
+    // Clean up the window.open mock
+    windowOpenSpy.mockRestore();
+  });
+
+  it('returns true when the rowId and ccbcNumber properties match', () => {
+    const option1 = { rowId: '1', ccbcNumber: '123' };
+    const option2 = { rowId: '1', ccbcNumber: '123' };
+
+    expect(optionChecker(option1, option2)).toBe(true);
+  });
+
+  it('returns false when the rowId property does not match', () => {
+    const option1 = { rowId: '1', ccbcNumber: '123' };
+    const option2 = { rowId: '2', ccbcNumber: '123' };
+
+    expect(optionChecker(option1, option2)).toBe(false);
+  });
+
+  it('returns false when the ccbcNumber property does not match', () => {
+    const option1 = { rowId: '1', ccbcNumber: '123' };
+    const option2 = { rowId: '1', ccbcNumber: '456' };
+
+    expect(optionChecker(option1, option2)).toBe(false);
+  });
+
+  it('returns false when both rowId and ccbcNumber properties do not match', () => {
+    const option1 = { rowId: '1', ccbcNumber: '123' };
+    const option2 = { rowId: '2', ccbcNumber: '456' };
+
+    expect(optionChecker(option1, option2)).toBe(false);
+  });
+});

--- a/app/tests/pages/analyst/application/[applicationId]/project.test.tsx
+++ b/app/tests/pages/analyst/application/[applicationId]/project.test.tsx
@@ -57,6 +57,7 @@ const mockJsonDataQueryPayload = {
                   announcementDate: '2023-05-01',
                   announcementType: 'Primary',
                 },
+                rowId: 1,
               },
             },
             {
@@ -67,6 +68,7 @@ const mockJsonDataQueryPayload = {
                   announcementDate: '2023-05-02',
                   announcementType: 'Secondary',
                 },
+                rowId: 2,
               },
             },
           ],
@@ -507,5 +509,45 @@ describe('The Project page', () => {
     expect(announcementUrl).toHaveStyle('border: 2px solid #E71F1F;');
     expect(announcementType).toHaveStyle('border: 2px solid #E71F1F;');
     expect(announcementDate).toHaveStyle('border: 2px solid #E71F1F;');
+  });
+
+  it('should send the updateAnnouncement mutation instead of createAnnouncement when updating an existing announcement', async () => {
+    pageTestingHelper.loadQuery(mockJsonDataQueryPayload);
+    pageTestingHelper.renderPage();
+
+    // Click on the edit button to open the form for the first announcement
+    const editButton = screen.getAllByTestId('project-form-edit-button')[1];
+    await act(async () => {
+      fireEvent.click(editButton);
+    });
+
+    // Change the announcement URL
+    const announcementUrl = screen.getByTestId('root_announcementUrl');
+    await act(async () => {
+      fireEvent.change(announcementUrl, {
+        target: { value: 'https://www.bc.com' },
+      });
+    });
+
+    // Save the announcement
+    const saveButton = screen.getByTestId('save-announcement');
+
+    await act(async () => {
+      fireEvent.click(saveButton);
+    });
+
+    // Check if the updateAnnouncement mutation has been sent instead of createAnnouncement
+    pageTestingHelper.expectMutationToBeCalled('updateAnnouncementMutation', {
+      input: {
+        // Add the expected input parameters for the updateAnnouncement mutation
+        jsonData: {
+          announcementUrl: 'https://www.bc.com',
+          announcementDate: '2023-05-01',
+          announcementType: 'Primary',
+        },
+        oldRowId: 1,
+        projectNumbers: 'CCBC-010003',
+      },
+    });
   });
 });


### PR DESCRIPTION
This is working aside from the Relay store update, so you can only see changes on refresh and also only edit an announcement once without refresh due to stale id. I had some issues trying to get the store to update and also tried removing/adding a node using the [connection handler](https://relay.dev/docs/v13.0.0/guided-tour/list-data/updating-connections/).

Anyways leaving this up here in case someone needs it or wants to give it a go, if not I can figure it out when I get back thanks.