### PR TITLE
feat: do not include the ccbc id of your own application

### DIFF
--- a/app/components/Analyst/Project/widgets/CcbcIdWidget.tsx
+++ b/app/components/Analyst/Project/widgets/CcbcIdWidget.tsx
@@ -18,9 +18,16 @@ const StyledAutocomplete = styled(Autocomplete)`
   }
 `;
 
-export const renderTags = (tagValue: any[], getTagProps: (any) => any) => {
+export const renderTags = (
+  tagValue: any[],
+  getTagProps: (any) => any,
+  preSelectedCcbcNumber: string
+) => {
   return tagValue.map((option: any, index) => {
     const { ccbcNumber, rowId } = option;
+    if (preSelectedCcbcNumber === ccbcNumber) {
+      return null;
+    }
     return (
       <Chip
         key={ccbcNumber}
@@ -45,7 +52,7 @@ const UrlWidget: React.FC<WidgetProps> = ({
   onChange,
   value,
 }) => {
-  const { ccbcIdList } = formContext;
+  const { ccbcIdList, ccbcNumber, rowId } = formContext;
   const isValue = value && value.length > 0;
 
   const styles = {
@@ -76,14 +83,16 @@ const UrlWidget: React.FC<WidgetProps> = ({
       onChange={(e, val) => {
         if (e) onChange(val);
       }}
-      value={value ?? []}
+      value={value ?? [{ ccbcNumber, rowId }]}
       data-testid={id}
       options={ccbcIdList}
       // To prevent a warning when comparing the previous value to the current
       isOptionEqualToValue={optionChecker}
       getOptionLabel={(option: any) => option.ccbcNumber}
       filterSelectedOptions
-      renderTags={renderTags}
+      renderTags={(val, getTagProps) =>
+        renderTags(val, getTagProps, ccbcNumber)
+      }
       renderInput={(params) => (
         <TextField {...params} sx={styles} placeholder="Search by CCBC ID" />
       )}

--- a/app/tests/components/Analyst/CcbcIdWidget.test.tsx
+++ b/app/tests/components/Analyst/CcbcIdWidget.test.tsx
@@ -5,6 +5,26 @@ import {
 } from 'components/Analyst/Project/widgets/CcbcIdWidget';
 
 describe('UrlWidget', () => {
+  it('should not render tag if ccbcNumber matches', () => {
+    // Sample tag data
+    const tagValue = [
+      { ccbcNumber: '123', rowId: '1' },
+      { ccbcNumber: '456', rowId: '2' },
+    ];
+
+    // Sample getTagProps function
+    const getTagProps = ({ index }) => ({ 'data-testid': `tag-${index}` });
+
+    // Render tags using the extracted renderTags function
+    const { getByTestId, queryByTestId } = render(
+      <div>{renderTags(tagValue, getTagProps, '123')}</div>
+    );
+
+    // Assert the tags are rendered
+    expect(queryByTestId('tag-0')).not.toBeInTheDocument();
+    expect(getByTestId('tag-1')).toHaveTextContent('456');
+  });
+
   it('renders tags and handles click events', () => {
     // Mock the window.open function
     const windowOpenSpy = jest
@@ -22,7 +42,7 @@ describe('UrlWidget', () => {
 
     // Render tags using the extracted renderTags function
     const { getByTestId } = render(
-      <div>{renderTags(tagValue, getTagProps)}</div>
+      <div>{renderTags(tagValue, getTagProps, '')}</div>
     );
 
     // Assert the tags are rendered


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

I noticed a quirk in the announcements form. Right now, if you've added a project to an announcement (so in the dev data, if you're on CCBC-010001 and you've added CCBC-010003) you'll see the added project in its own project. 

I've changed it so that it always adds its own ccbcNumber as the value, and additionally removes the reference to itself in the success toast and in the autocomplete. 

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
