### PR TITLE
1504 application history row

### DIFF
--- a/app/pages/analyst/application/[applicationId]/edit/[section].tsx
+++ b/app/pages/analyst/application/[applicationId]/edit/[section].tsx
@@ -62,8 +62,9 @@ const EditApplication = ({
   // Save and update form data in state due to RJSF setState bug
   const [sectionFormData, setSectionFormData] = useState(jsonData[sectionName]);
   const [changeReason, setChangeReason] = useState('');
-
+  const [isFormSaved, setIsFormSaved] = useState(true);
   const handleChange = (e: IChangeEvent) => {
+    setIsFormSaved(false);
     const newFormSectionData = { ...e.formData };
     const calculatedSectionData = calculate(newFormSectionData, sectionName);
     setSectionFormData(calculatedSectionData);
@@ -123,10 +124,12 @@ const EditApplication = ({
           <Button
             onClick={(e: React.MouseEvent<HTMLInputElement>) => {
               e.preventDefault();
-              window.location.hash = '#change-modal';
+              if (!isFormSaved) {
+                window.location.hash = '#change-modal';
+              }
             }}
           >
-            Save
+            {isFormSaved ? 'Saved' : 'Save'}
           </Button>
           <Button
             variant="secondary"

--- a/app/tests/pages/analyst/application/[applicationId]/edit/[section].test.tsx
+++ b/app/tests/pages/analyst/application/[applicationId]/edit/[section].test.tsx
@@ -83,22 +83,22 @@ describe('The analyst edit application page', () => {
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
 
-    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Saved' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 
-  it('should go back on cancel button', async() => {
+  it('should go back on cancel button', async () => {
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
 
-    const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
 
     await act(async () => {
       fireEvent.click(cancelButton);
     });
 
-    expect(window.location.hash).toBe("")
-  })
+    expect(window.location.hash).toBe('');
+  });
 
   it('should calculate values on estimatedProjectEmployment page', async () => {
     pageTestingHelper.setMockRouterValues({
@@ -136,7 +136,7 @@ describe('The analyst edit application page', () => {
     ).toHaveValue('$15');
   });
 
-  it('shows modal on enter key', async() => {
+  it('shows modal on enter key', async () => {
     pageTestingHelper.setMockRouterValues({
       query: { applicationId: '1', section: 'estimatedProjectEmployment' },
     });
@@ -145,16 +145,35 @@ describe('The analyst edit application page', () => {
 
     const people = screen.getAllByLabelText(/Number of people/)[0];
 
-    await userEvent.type(people, '{enter}')
+    await userEvent.type(people, '{enter}');
 
-    expect(window.location.hash).toBe("#change-modal")
+    expect(window.location.hash).toBe('#change-modal');
 
-    window.location.hash = ""
-  })
+    window.location.hash = '';
+  });
+
+  it('changes the save button text on form change', async () => {
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    expect(screen.getByRole('button', { name: 'Saved' })).toBeInTheDocument();
+
+    await userEvent.type(
+      screen.getByTestId('root_projectTitle'),
+      'test project'
+    );
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
 
   it('displays the confirmation modal and calls the mutation on save', async () => {
     pageTestingHelper.loadQuery();
     pageTestingHelper.renderPage();
+
+    await userEvent.type(
+      screen.getByTestId('root_projectTitle'),
+      'test project'
+    );
 
     const formSaveButton = screen.getByRole('button', { name: 'Save' });
 
@@ -176,7 +195,9 @@ describe('The analyst edit application page', () => {
       input: {
         applicationRowId: 1,
         jsonData: {
-          projectInformation: {},
+          projectInformation: {
+            projectTitle: 'test project',
+          },
         },
         reasonForChange: 'test text',
         formSchemaId: 1,


### PR DESCRIPTION
- feat: only allow save when edit application data has changed
- test: add test for edit application save button

<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements #1504 

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
