### PR TITLE
chore: update crunchy postgres images

### DIFF
--- a/helm/app/templates/PostgresCluster.yaml
+++ b/helm/app/templates/PostgresCluster.yaml
@@ -10,7 +10,8 @@ spec:
     pgmonitor:
       # this stuff is for the "exporter" container in the "hippo-ha-pgha1" set of pods
       exporter:
-        image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-exporter:ubi8-5.0.4-0
+        image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-exporter:ubi8-5.3.1-0
+
         resources:
           requests:
             cpu: {{ .Values.exporter.requests.cpu }}
@@ -18,7 +19,7 @@ spec:
           limits:
             cpu: {{ .Values.exporter.limits.cpu }}
             memory: {{ .Values.exporter.limits.memory }}
-  image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres:centos8-14.1-0
+  image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres:ubi8-14.7-0
   postgresVersion: 14
   instances:
     - name: {{ .Values.instances.name }}
@@ -71,7 +72,7 @@ spec:
     pgbackrest:
       global:
         repo1-retention-full: {{ .Values.pgbackrest.retention | quote }}
-      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest:centos8-2.36-0
+      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest:ubi8-2.41-4
       repos:
         - name: repo1
           schedules:
@@ -122,7 +123,7 @@ spec:
       config:
         global:
           client_tls_sslmode: disable
-      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer:centos8-1.16-0
+      image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer:ubi8-1.18-0
       replicas: {{ .Values.pgBouncer.replicas }}
       # these resources are for the "pgbouncer" container in the "hippo-ha-pgbouncer" set of pods
       # there is a sidecar in these pods which are not mentioned here, but the requests/limits are teeny weeny by default so no worries there.


### PR DESCRIPTION
Updating crunchy images to prepare for upcoming PGO 5.3 upgrade. Successful deployment to dev: 

https://github.com/bcgov/CONN-CCBC-portal/actions/runs/4993774729/jobs/8943986428


