### PR TITLE
feat: add word break on read-only component

### DIFF
--- a/app/components/Analyst/Project/ConditionalApproval/widgets/ReadOnlyFileWidget.tsx
+++ b/app/components/Analyst/Project/ConditionalApproval/widgets/ReadOnlyFileWidget.tsx
@@ -21,6 +21,7 @@ const StyledFileDiv = styled('div')`
 const StyledLink = styled.button`
   color: ${(props) => props.theme.color.links};
   text-decoration-line: underline;
+  word-break: break-word;
 `;
 
 const handleDownload = async (uuid, fileName) => {


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # 1370 
Fix for read only view

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
