### PR TITLE
fix: handle links without protocol

### DIFF
--- a/app/backend/lib/linkPreview.ts
+++ b/app/backend/lib/linkPreview.ts
@@ -28,7 +28,16 @@ linkPreview.post('/api/announcement/linkPreview', limiter, (req, res) => {
   const { url } = req.body;
   let urlObj;
   try {
-    urlObj = new URL(url);
+    // attempt to fix url if it doesn't have http or https
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      urlObj = new URL(`https://${url}`);
+    } else {
+      urlObj = new URL(url);
+    }
+    // check if URL has a domain
+    if (!urlObj.hostname.includes('.')) {
+      return res.status(400).json({ error: 'Invalid URL' }).end();
+    }
   } catch (e) {
     return res.status(400).json({ error: 'Invalid URL' }).end();
   }

--- a/app/components/Analyst/Project/Announcements/ViewAnnouncements.tsx
+++ b/app/components/Analyst/Project/Announcements/ViewAnnouncements.tsx
@@ -69,6 +69,17 @@ const ViewAnnouncements: React.FC<Props> = ({
               signal,
             });
             const preview = await response.json();
+            // set fallback in case preview request fails
+            if (preview.error) {
+              return {
+                ...announcement,
+                preview: {
+                  image: '/images/noPreview.png',
+                  title: null,
+                  description: 'No preview available',
+                },
+              };
+            }
             return { ...announcement, preview };
           })
         );


### PR DESCRIPTION
Bug fix for announcements link previews.
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # \<issue number\>

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
