### PR TITLE
feat/project information feature flag

### DIFF
--- a/app/lib/theme/components/FileComponent.tsx
+++ b/app/lib/theme/components/FileComponent.tsx
@@ -221,7 +221,11 @@ const FileComponent: React.FC<FileComponentProps> = ({
       <input
         data-testid="file-test"
         ref={hiddenFileInput}
-        onChange={onChange}
+        onChange={(e) => {
+          onChange(e);
+          // set target to null to allow for reupload of file with same name
+          e.currentTarget.value = null;
+        }}
         style={{ display: 'none' }}
         type="file"
         required={required}

--- a/app/pages/analyst/application/[applicationId]/project.tsx
+++ b/app/pages/analyst/application/[applicationId]/project.tsx
@@ -32,6 +32,7 @@ const Project = ({
 
   const showConditionalApproval = useFeature('show_conditional_approval').value;
   const showAnnouncement = useFeature('show_announcement').value;
+  const showProjectInformation = useFeature('show_project_information').value;
 
   return (
     <Layout session={session} title="Connecting Communities BC">
@@ -40,7 +41,9 @@ const Project = ({
           <ConditionalApprovalForm application={applicationByRowId} />
         )}
         {showAnnouncement && <AnnouncementsForm query={query} />}
-        <ProjectInformationForm application={applicationByRowId} />
+        {showProjectInformation && (
+          <ProjectInformationForm application={applicationByRowId} />
+        )}
       </AnalystLayout>
     </Layout>
   );


### PR DESCRIPTION
Add a feature flag for project information. 

Also snuck in a small improvement to the file widget which allows a file of the same name to be reuploaded if the upload fails. This has always been a thing with our file widget, or anything using html file input but especially noticeable here if someone was say uploading a SoW excel with the wrong CCBC number.
