### PR TITLE
fix: link preview increase rate, set timeout

### DIFF
--- a/app/backend/lib/linkPreview.ts
+++ b/app/backend/lib/linkPreview.ts
@@ -5,7 +5,7 @@ import getAuthRole from '../../utils/getAuthRole';
 
 const limiter = RateLimit({
   windowMs: 1 * 60 * 1000, // 1 minute
-  max: 100,
+  max: 2000,
 });
 
 const allowedHostnames = [

--- a/app/utils/getLinkPreview.ts
+++ b/app/utils/getLinkPreview.ts
@@ -32,7 +32,12 @@ async function getLinkPreview(
       image: '/images/noPreview.png',
     };
   }
-  const res = await fetch(`https://${urlObj.hostname}${urlObj.pathname}`);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
+  const res = await fetch(`https://${urlObj.hostname}${urlObj.pathname}`, {
+    signal: controller.signal,
+  });
+  clearTimeout(timeoutId);
   const html = await res.text();
   const $ = cheerio.load(html);
   const title =


### PR DESCRIPTION
The link previews were infinitely waiting due to the rate limiter and/or response from the fetch when getting the preview. This change should allow enough requests in a minute, or abort the fetch if it's taking longer than 10 seconds since we fetch the preview each time the user visits/refreshes the page, adds or deletes an announcement.
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # \<issue number\>

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
