### PR TITLE
temp fix: disable all previews

### DIFF
--- a/app/backend/lib/linkPreview.ts
+++ b/app/backend/lib/linkPreview.ts
@@ -8,13 +8,7 @@ const limiter = RateLimit({
   max: 2000,
 });
 
-const allowedHostnames = [
-  'news.gov.bc.ca',
-  'gov.bc.ca',
-  'canada.ca',
-  'www.canada.ca',
-  'www2.gov.bc.ca',
-];
+const allowedHostnames = [];
 
 const linkPreview = Router();
 

--- a/app/tests/backend/lib/linkPreview.test.ts
+++ b/app/tests/backend/lib/linkPreview.test.ts
@@ -46,6 +46,7 @@ describe('The Link Preview', () => {
     expect(response.status).toBe(404);
   });
 
+  /*
   it('should return preview for allowed hostname with gov image', async () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -162,6 +163,7 @@ describe('The Link Preview', () => {
     expect(response.body.image).toBe('/images/noPreview.png');
     expect(response.status).toBe(200);
   });
+  */
   it('should return no preview for non allowed hostname', async () => {
     mocked(getAuthRole).mockImplementation(() => {
       return {


### PR DESCRIPTION
Temporarily remove all allowed hostnames so no previews are fetched making linkPreview respond immediately.

<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # \<issue number\>

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
