### PR TITLE
fix: add cy.wait before analyst dashboard happo screenshot

### DIFF
--- a/app/cypress/integration/analyst/dashboard.spec.js
+++ b/app/cypress/integration/analyst/dashboard.spec.js
@@ -29,6 +29,9 @@ describe('The analyst dashboard', () => {
     cy.wait(2000);
     cy.get('tr > th').first().click();
     cy.url().should('include', 'orderBy');
+
+    // add wait to prevent happo diff from taking a screenshot before the sort is complete
+    cy.wait(2000);
     cy.get('body').happoScreenshot({ component: 'Sorted Analyst Dashboard' });
   });
 });

--- a/app/cypress/integration/analyst/dashboard.spec.js
+++ b/app/cypress/integration/analyst/dashboard.spec.js
@@ -32,6 +32,9 @@ describe('The analyst dashboard', () => {
 
     // add wait to prevent happo diff from taking a screenshot before the sort is complete
     cy.wait(2000);
+
+    cy.contains('button', 'Clear sorting');
+
     cy.get('body').happoScreenshot({ component: 'Sorted Analyst Dashboard' });
   });
 });


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements #1331 

This should fix that happo dashboard diff we regularly get. Looks like the screenshot just gets taken before the sorting completes sometimes.

