### PR TITLE
1691 enable change requests mvp

### DIFF
--- a/app/components/Analyst/Project/AddButton.tsx
+++ b/app/components/Analyst/Project/AddButton.tsx
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+
+interface EditProps {
+  isFormEditMode: boolean;
+}
+
+const StyledAddButton = styled.button<EditProps>`
+  display: flex;
+  align-items: center;
+  color: ${(props) => props.theme.color.links};
+  margin-bottom: ${(props) => (props.isFormEditMode ? '0px' : '16px')};
+  overflow: hidden;
+  max-height: ${(props) => (props.isFormEditMode ? '0px' : '30px')};
+  transition: max-height 0.5s;
+
+  & svg {
+    margin-left: 16px;
+  }
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;
+
+interface Props {
+  isFormEditMode: boolean;
+  onClick?: () => void;
+  title: string;
+}
+
+const AddButton: React.FC<Props> = ({ isFormEditMode, onClick, title }) => {
+  return (
+    <StyledAddButton onClick={onClick} isFormEditMode={isFormEditMode}>
+      <span>{title}</span>
+      <FontAwesomeIcon icon={faPlus} />
+    </StyledAddButton>
+  );
+};
+
+export default AddButton;

--- a/app/components/Analyst/Project/Announcements/AnnouncementsForm.tsx
+++ b/app/components/Analyst/Project/Announcements/AnnouncementsForm.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useMemo, useRef, useState, ReactNode } from 'react';
 import { ConnectionHandler, graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
-import { ProjectForm } from 'components/Analyst/Project';
+import { AddButton, ProjectForm } from 'components/Analyst/Project';
 import validateFormData from '@rjsf/core/dist/cjs/validate';
 import validator from 'validator';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import ViewAnnouncements from 'components/Analyst/Project/Announcements/ViewAnnouncements';
 import announcementsSchema from 'formSchema/analyst/announcements';
 import announcementsUiSchema from 'formSchema/uiSchema/analyst/announcementsUiSchema';
@@ -15,24 +13,6 @@ import Link from 'next/link';
 import Toast from 'components/Toast';
 import { Tooltip } from 'components';
 import ProjectTheme from '../ProjectTheme';
-
-const StyledAddButton = styled.button<EditProps>`
-  display: flex;
-  align-items: center;
-  color: ${(props) => props.theme.color.links};
-  margin-bottom: ${(props) => (props.isFormEditMode ? '0px' : '16px')};
-  overflow: hidden;
-  max-height: ${(props) => (props.isFormEditMode ? '0px' : '30px')};
-  transition: max-height 0.5s;
-
-  & svg {
-    margin-left: 16px;
-  }
-
-  &:hover {
-    opacity: 0.7;
-  }
-`;
 
 interface EditProps {
   isFormEditMode: boolean;
@@ -291,13 +271,11 @@ const AnnouncementsForm = ({ query }) => {
   return (
     <StyledProjectForm
       before={
-        <StyledAddButton
+        <AddButton
           isFormEditMode={isFormEditMode}
           onClick={() => setIsFormEditMode(true)}
-        >
-          <span>Add announcement</span>
-          <FontAwesomeIcon icon={faPlus} />
-        </StyledAddButton>
+          title="Add announcement"
+        />
       }
       overflow={overflow}
       additionalContext={{ ccbcIdList, ccbcNumber, rowId }}

--- a/app/components/Analyst/Project/Announcements/AnnouncementsForm.tsx
+++ b/app/components/Analyst/Project/Announcements/AnnouncementsForm.tsx
@@ -255,6 +255,7 @@ const AnnouncementsForm = ({ query }) => {
         setFormData({ ...e.formData });
       }}
       hiddenSubmitRef={hiddenSubmitRef}
+      formAnimationHeight={400}
       isFormAnimated
       isFormEditMode={isFormEditMode}
       showEditBtn={false}

--- a/app/components/Analyst/Project/Announcements/AnnouncementsForm.tsx
+++ b/app/components/Analyst/Project/Announcements/AnnouncementsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState, ReactNode } from 'react';
+import React, { useMemo, useRef, useState, ReactNode } from 'react';
 import { ConnectionHandler, graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 import { AddButton, ProjectForm } from 'components/Analyst/Project';
@@ -23,14 +23,6 @@ interface EditProps {
 const StyledProjectForm = styled(ProjectForm)<EditProps>`
   .pg-card-content {
     min-height: 0;
-  }
-
-  .project-form {
-    position: relative;
-    z-index: ${(props) => (props.isFormEditMode ? 100 : 1)};
-    overflow: ${(props) => props.overflow};
-    max-height: ${(props) => (props.isFormEditMode ? '400px' : '30px')};
-    transition: max-height 0.7s;
   }
 `;
 
@@ -248,26 +240,6 @@ const AnnouncementsForm = ({ query }) => {
   // Filter out this application CCBC ID
   const ccbcIdList = queryFragment.allApplications.nodes;
 
-  // Overflow hidden is needed for animated edit transition though
-  // visible is needed for the datepicker so we needed to set it on a
-  // timeout to prevent buggy visual transition
-  const [overflow, setOverflow] = useState(
-    isFormEditMode ? 'visible' : 'hidden'
-  );
-  const [isFirstRender, setIsFirstRender] = useState(true);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      if (isFormEditMode && !isFirstRender) {
-        setOverflow('visible');
-      } else {
-        setOverflow('hidden');
-      }
-      setIsFirstRender(false);
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [isFormEditMode]);
-
   return (
     <StyledProjectForm
       before={
@@ -277,13 +249,13 @@ const AnnouncementsForm = ({ query }) => {
           title="Add announcement"
         />
       }
-      overflow={overflow}
       additionalContext={{ ccbcIdList, ccbcNumber, rowId }}
       formData={formData}
       handleChange={(e) => {
         setFormData({ ...e.formData });
       }}
       hiddenSubmitRef={hiddenSubmitRef}
+      isFormAnimated
       isFormEditMode={isFormEditMode}
       showEditBtn={false}
       title="Announcements"

--- a/app/components/Analyst/Project/ChangeRequest/ChangeRequestCard.tsx
+++ b/app/components/Analyst/Project/ChangeRequest/ChangeRequestCard.tsx
@@ -11,6 +11,7 @@ const StyledCard = styled.div`
   display: flex;
   flex-direction: column;
   position: relative;
+  z-index: 1;
 
   h3 {
     margin-bottom: 8px;

--- a/app/components/Analyst/Project/ChangeRequest/ChangeRequestCard.tsx
+++ b/app/components/Analyst/Project/ChangeRequest/ChangeRequestCard.tsx
@@ -4,7 +4,7 @@ import DownloadLink from 'components/DownloadLink';
 
 const StyledCard = styled.div`
   padding: 8px 12px;
-  margin: 8px 0;
+  margin: 16px 0;
   background: ${(props) => props.theme.color.navigationLightGrey};
   border-radius: 8px;
   width: 100%;

--- a/app/components/Analyst/Project/ChangeRequest/ChangeRequestCard.tsx
+++ b/app/components/Analyst/Project/ChangeRequest/ChangeRequestCard.tsx
@@ -1,0 +1,58 @@
+import styled from 'styled-components';
+import { DateTime } from 'luxon';
+import DownloadLink from 'components/DownloadLink';
+
+const StyledCard = styled.div`
+  padding: 8px 12px;
+  margin: 8px 0;
+  background: ${(props) => props.theme.color.navigationLightGrey};
+  border-radius: 8px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+
+  h3 {
+    margin-bottom: 8px;
+  }
+`;
+
+const StyledSubheader = styled.span`
+  color: #757575;
+  margin-bottom: 8px;
+`;
+
+const StyledFlex = styled.span`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+interface CardProps {
+  changeRequestNumber: number;
+  fileData: any;
+  date: string;
+}
+
+const ChangeRequestCard: React.FC<CardProps> = ({
+  changeRequestNumber,
+  fileData,
+  date,
+}) => {
+  const formattedDate = DateTime.fromISO(date).toLocaleString(
+    DateTime.DATE_MED
+  );
+
+  return (
+    <StyledCard>
+      <StyledFlex>
+        <h3>Change request #{changeRequestNumber}</h3>
+        <span>{formattedDate}</span>
+      </StyledFlex>
+      <StyledSubheader>Updated Statement of Work Excel file</StyledSubheader>
+      <DownloadLink fileName={fileData?.name} uuid={fileData?.uuid} />
+    </StyledCard>
+  );
+};
+
+export default ChangeRequestCard;

--- a/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
+++ b/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
@@ -124,6 +124,7 @@ const ChangeRequestForm = ({ application }) => {
       handleChange={(e) => {
         setFormData({ ...e.formData });
       }}
+      formAnimationHeight={200}
       isFormAnimated
       isFormEditMode={isFormEditMode}
       onSubmit={handleSubmit}

--- a/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
+++ b/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
@@ -135,7 +135,7 @@ const ChangeRequestForm = ({ application }) => {
       showEditBtn={false}
       theme={ProjectTheme}
       title="Change request"
-      schema={changeRequestSchema}
+      schema={isOriginalSowUpload ? changeRequestSchema : {}}
       uiSchema={changeRequestUiSchema}
     >
       {changeRequestData?.map((changeRequest) => {

--- a/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
+++ b/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
@@ -99,16 +99,18 @@ const ChangeRequestForm = ({ application }) => {
       handleChange={(e) => {
         setFormData({ ...e.formData });
       }}
+      isFormAnimated
       isFormEditMode={isFormEditMode}
-      title="Change request"
-      schema={isFormEditMode ? changeRequestSchema : {}}
-      theme={ProjectTheme}
-      uiSchema={changeRequestUiSchema}
-      resetFormData={handleResetFormData}
       onSubmit={handleSubmit}
+      resetFormData={handleResetFormData}
       saveBtnDisabled={!isStatementOfWorkUpload}
       saveBtnText="Save & Import Data"
       setIsFormEditMode={(boolean) => setIsFormEditMode(boolean)}
+      showEditBtn={false}
+      theme={ProjectTheme}
+      title="Change request"
+      schema={isFormEditMode ? changeRequestSchema : {}}
+      uiSchema={changeRequestUiSchema}
     >
       {showToast && (
         <Toast timeout={100000000}>

--- a/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
+++ b/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import styled from 'styled-components';
 import { AddButton, ProjectForm } from 'components/Analyst/Project';
 import changeRequestSchema from 'formSchema/analyst/changeRequest';
 import changeRequestUiSchema from 'formSchema/uiSchema/analyst/changeRequestUiSchema';
@@ -8,12 +7,6 @@ import { useCreateChangeRequestMutation } from 'schema/mutations/project/createC
 import ProjectTheme from 'components/Analyst/Project/ProjectTheme';
 import Toast from 'components/Toast';
 import ChangeRequestCard from './ChangeRequestCard';
-
-const StyledProjectForm = styled(ProjectForm)`
-  .datepicker-widget {
-    max-width: 200px;
-  }
-`;
 
 const ChangeRequestForm = ({ application }) => {
   const queryFragment = useFragment(
@@ -96,7 +89,7 @@ const ChangeRequestForm = ({ application }) => {
   };
 
   return (
-    <StyledProjectForm
+    <ProjectForm
       additionalContext={{
         applicationId: rowId,
         ccbcNumber,
@@ -156,7 +149,7 @@ const ChangeRequestForm = ({ application }) => {
           Statement of work successfully imported
         </Toast>
       )}
-    </StyledProjectForm>
+    </ProjectForm>
   );
 };
 

--- a/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
+++ b/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
@@ -7,6 +7,7 @@ import changeRequestUiSchema from 'formSchema/uiSchema/analyst/changeRequestUiSc
 import { useCreateChangeRequestMutation } from 'schema/mutations/project/createChangeRequest';
 import ProjectTheme from 'components/Analyst/Project/ProjectTheme';
 import Toast from 'components/Toast';
+import ChangeRequestCard from './ChangeRequestCard';
 
 const StyledProjectForm = styled(ProjectForm)`
   .datepicker-widget {
@@ -33,7 +34,10 @@ const ChangeRequestForm = ({ application }) => {
           edges {
             node {
               id
+              changeRequestNumber
+              createdAt
               jsonData
+              updatedAt
             }
           }
         }
@@ -47,7 +51,7 @@ const ChangeRequestForm = ({ application }) => {
   const changeRequestData = changeRequestDataByApplicationId?.edges;
 
   const connectionId = changeRequestDataByApplicationId?.__id;
-  const changeRequestNumber = changeRequestData.length + 1;
+  const newChangeRequestNumber = changeRequestData.length + 1;
 
   const [createChangeRequest] = useCreateChangeRequestMutation();
   const [formData, setFormData] = useState({} as any);
@@ -64,7 +68,7 @@ const ChangeRequestForm = ({ application }) => {
         connections: [connectionId],
         input: {
           _applicationId: rowId,
-          _changeRequestNumber: changeRequestNumber,
+          _changeRequestNumber: newChangeRequestNumber,
           _jsonData: formData,
         },
       },
@@ -112,6 +116,20 @@ const ChangeRequestForm = ({ application }) => {
       schema={isFormEditMode ? changeRequestSchema : {}}
       uiSchema={changeRequestUiSchema}
     >
+      {changeRequestData?.map((changeRequest) => {
+        const { id, changeRequestNumber, createdAt, jsonData, updatedAt } =
+          changeRequest.node;
+        const sowUpload = jsonData?.statementOfWorkUpload?.[0];
+        console.log(changeRequest);
+        return (
+          <ChangeRequestCard
+            key={id}
+            changeRequestNumber={changeRequestNumber}
+            fileData={sowUpload}
+            date={updatedAt || createdAt}
+          />
+        );
+      })}
       {showToast && (
         <Toast timeout={100000000}>
           Statement of work successfully imported

--- a/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
+++ b/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
@@ -22,6 +22,9 @@ const ChangeRequestForm = ({ application }) => {
         id
         rowId
         ccbcNumber
+        projectInformation {
+          jsonData
+        }
         changeRequestDataByApplicationId(
           filter: { archivedAt: { isNull: true } }
           orderBy: CHANGE_REQUEST_NUMBER_ASC
@@ -46,11 +49,18 @@ const ChangeRequestForm = ({ application }) => {
     application
   );
 
-  const { ccbcNumber, rowId, changeRequestDataByApplicationId } = queryFragment;
+  const {
+    ccbcNumber,
+    rowId,
+    changeRequestDataByApplicationId,
+    projectInformation,
+  } = queryFragment;
 
   const changeRequestData = changeRequestDataByApplicationId?.edges;
   const connectionId = changeRequestDataByApplicationId?.__id;
   const newChangeRequestNumber = changeRequestData.length + 1;
+  const isOriginalSowUpload =
+    projectInformation?.jsonData?.main?.upload?.statementOfWorkUpload?.[0];
 
   const [createChangeRequest] = useCreateChangeRequestMutation();
   const [formData, setFormData] = useState({} as any);
@@ -92,11 +102,23 @@ const ChangeRequestForm = ({ application }) => {
         ccbcNumber,
       }}
       before={
-        <AddButton
-          isFormEditMode={isFormEditMode}
-          onClick={() => setIsFormEditMode(true)}
-          title="Add change request"
-        />
+        <>
+          {isOriginalSowUpload ? (
+            <AddButton
+              isFormEditMode={isFormEditMode}
+              onClick={() => {
+                setShowToast(false);
+                setIsFormEditMode(true);
+              }}
+              title="Add change request"
+            />
+          ) : (
+            <div>
+              Change requests will be available after a funding agreement has
+              been signed.
+            </div>
+          )}
+        </>
       }
       formData={formData}
       handleChange={(e) => {

--- a/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
+++ b/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
@@ -24,7 +24,7 @@ const ChangeRequestForm = ({ application }) => {
         ccbcNumber
         changeRequestDataByApplicationId(
           filter: { archivedAt: { isNull: true } }
-          orderBy: CREATED_AT_DESC
+          orderBy: CHANGE_REQUEST_NUMBER_ASC
           first: 999
         )
           @connection(
@@ -49,7 +49,6 @@ const ChangeRequestForm = ({ application }) => {
   const { ccbcNumber, rowId, changeRequestDataByApplicationId } = queryFragment;
 
   const changeRequestData = changeRequestDataByApplicationId?.edges;
-
   const connectionId = changeRequestDataByApplicationId?.__id;
   const newChangeRequestNumber = changeRequestData.length + 1;
 
@@ -74,7 +73,7 @@ const ChangeRequestForm = ({ application }) => {
       },
       onCompleted: () => {
         setIsFormEditMode(false);
-
+        setFormData({});
         // May need to change when the toast is shown when we add validation
         setShowToast(true);
       },
@@ -120,7 +119,6 @@ const ChangeRequestForm = ({ application }) => {
         const { id, changeRequestNumber, createdAt, jsonData, updatedAt } =
           changeRequest.node;
         const sowUpload = jsonData?.statementOfWorkUpload?.[0];
-        console.log(changeRequest);
         return (
           <ChangeRequestCard
             key={id}

--- a/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
+++ b/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+import { AddButton, ProjectForm } from 'components/Analyst/Project';
+import changeRequestSchema from 'formSchema/analyst/changeRequest';
+import changeRequestUiSchema from 'formSchema/uiSchema/analyst/changeRequestUiSchema';
+import { useCreateChangeRequestMutation } from 'schema/mutations/project/createChangeRequest';
+import ProjectTheme from 'components/Analyst/Project/ProjectTheme';
+import Toast from 'components/Toast';
+
+const StyledProjectForm = styled(ProjectForm)`
+  .datepicker-widget {
+    max-width: 200px;
+  }
+`;
+
+const ChangeRequestForm = ({ application }) => {
+  const queryFragment = useFragment(
+    graphql`
+      fragment ChangeRequestForm_application on Application {
+        id
+        rowId
+        ccbcNumber
+        changeRequestDataByApplicationId(
+          filter: { archivedAt: { isNull: true } }
+          orderBy: CREATED_AT_DESC
+          first: 1
+        )
+          @connection(
+            key: "ChangeRequestForm_changeRequestDataByApplicationId"
+          ) {
+          __id
+          edges {
+            node {
+              id
+              jsonData
+            }
+          }
+        }
+      }
+    `,
+    application
+  );
+
+  const { ccbcNumber, id, rowId, changeRequestDataByApplicationId } =
+    queryFragment;
+
+  const changeRequestData = changeRequestDataByApplicationId?.edges?.[0]?.node;
+
+  const [createChangeRequest] = useCreateChangeRequestMutation();
+  const [formData, setFormData] = useState(changeRequestData?.jsonData || {});
+  const [showToast, setShowToast] = useState(false);
+  const [isFormEditMode, setIsFormEditMode] = useState(
+    !changeRequestData?.jsonData
+  );
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    createChangeRequest({
+      variables: {
+        input: { _applicationId: rowId, _jsonData: formData },
+      },
+      onCompleted: () => {
+        setIsFormEditMode(false);
+
+        // May need to change when the toast is shown when we add validation
+        setShowToast(true);
+      },
+      updater: (store, data) => {
+        store
+          .get(id)
+          .setLinkedRecord(
+            store.get(data.createChangeRequest.changeRequestData.id),
+            'changeRequest'
+          );
+      },
+    });
+  };
+
+  const handleResetFormData = () => {
+    setFormData({});
+    setShowToast(false);
+  };
+
+  return (
+    <StyledProjectForm
+      additionalContext={{
+        applicationId: rowId,
+        ccbcNumber,
+      }}
+      before={
+        <AddButton
+          isFormEditMode={isFormEditMode}
+          onClick={() => setIsFormEditMode(true)}
+          title="Add change request"
+        />
+      }
+      formData={formData}
+      handleChange={(e) => {
+        setFormData({ ...e.formData });
+      }}
+      isFormEditMode={isFormEditMode}
+      title="Change request"
+      schema={changeRequestSchema}
+      theme={ProjectTheme}
+      uiSchema={changeRequestUiSchema}
+      resetFormData={handleResetFormData}
+      onSubmit={handleSubmit}
+      saveBtnText="Save & Import Data"
+      setIsFormEditMode={(boolean) => setIsFormEditMode(boolean)}
+    >
+      {showToast && (
+        <Toast timeout={100000000}>
+          Statement of work successfully imported
+        </Toast>
+      )}
+    </StyledProjectForm>
+  );
+};
+
+export default ChangeRequestForm;

--- a/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
+++ b/app/components/Analyst/Project/ChangeRequest/ChangeRequestForm.tsx
@@ -134,7 +134,7 @@ const ChangeRequestForm = ({ application }) => {
       showEditBtn={false}
       theme={ProjectTheme}
       title="Change request"
-      schema={isFormEditMode ? changeRequestSchema : {}}
+      schema={changeRequestSchema}
       uiSchema={changeRequestUiSchema}
     >
       {changeRequestData?.map((changeRequest) => {

--- a/app/components/Analyst/Project/ChangeRequest/index.ts
+++ b/app/components/Analyst/Project/ChangeRequest/index.ts
@@ -1,0 +1,2 @@
+export { default as ChangeRequestCard } from './ChangeRequestCard';
+export { default as ChangeRequestForm } from './ChangeRequestForm';

--- a/app/components/Analyst/Project/ProjectForm.tsx
+++ b/app/components/Analyst/Project/ProjectForm.tsx
@@ -79,6 +79,7 @@ interface Props {
   onSubmit: any;
   resetFormData: any;
   saveBtnText?: string;
+  saveBtnDisabled?: boolean;
   schema: JSONSchema7;
   setIsFormEditMode: any;
   theme?: any;
@@ -98,6 +99,7 @@ const ProjectForm: React.FC<Props> = ({
   isFormEditMode,
   onSubmit,
   resetFormData,
+  saveBtnDisabled,
   saveBtnText,
   schema,
   setIsFormEditMode,
@@ -117,6 +119,7 @@ const ProjectForm: React.FC<Props> = ({
               <StyledBtn
                 data-testid={saveDataTestId}
                 size="small"
+                disabled={saveBtnDisabled}
                 onClick={onSubmit}
               >
                 {saveBtnText || 'Save'}

--- a/app/components/Analyst/Project/ProjectForm.tsx
+++ b/app/components/Analyst/Project/ProjectForm.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Button from '@button-inc/bcgov-theme/Button';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -65,6 +66,25 @@ const StyledBtn = styled(Button)`
   padding: 8px 16px;
 `;
 
+interface AnimateFormProps {
+  isAnimated: boolean;
+  isFormExpanded: boolean;
+  overflow: string;
+  onClick?: () => void;
+}
+
+const StyledAnimateForm = styled.div<AnimateFormProps>`
+  ${({ isAnimated, isFormExpanded, overflow }) =>
+    isAnimated &&
+    `
+    position: relative;
+    z-index: ${isFormExpanded ? 100 : 1};
+    overflow: ${overflow};
+    max-height: ${isFormExpanded ? '400px' : '30px'};
+    transition: max-height 0.7s;
+  `}
+`;
+
 interface Props {
   additionalContext?: any;
   before?: React.ReactNode;
@@ -76,6 +96,7 @@ interface Props {
    *  (the red-outline we see on widgets) */
   hiddenSubmitRef?: any;
   isFormEditMode: boolean;
+  isFormAnimated?: boolean;
   onSubmit: any;
   resetFormData: any;
   saveBtnText?: string;
@@ -96,6 +117,7 @@ const ProjectForm: React.FC<Props> = ({
   handleChange,
   hiddenSubmitRef,
   showEditBtn = true,
+  isFormAnimated,
   isFormEditMode,
   onSubmit,
   resetFormData,
@@ -109,6 +131,26 @@ const ProjectForm: React.FC<Props> = ({
   saveDataTestId = 'save',
   ...rest
 }) => {
+  // Overflow hidden is needed for animated edit transition though
+  // visible is needed for the datepicker so we needed to set it on a
+  // timeout to prevent buggy visual transition
+  const [overflow, setOverflow] = useState(
+    isFormEditMode ? 'visible' : 'hidden'
+  );
+  const [isFirstRender, setIsFirstRender] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (isFormEditMode && !isFirstRender) {
+        setOverflow('visible');
+      } else {
+        setOverflow('hidden');
+      }
+      setIsFirstRender(false);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [isFormEditMode]);
+
   return (
     <StyledBaseAccordion onToggle={() => {}} {...rest} defaultToggled>
       <StyledHeader>
@@ -156,7 +198,11 @@ const ProjectForm: React.FC<Props> = ({
         </StyledToggleRight>
       </StyledHeader>
       <BaseAccordion.Content>
-        <div className="project-form">
+        <StyledAnimateForm
+          isAnimated={isFormAnimated}
+          isFormExpanded={isFormEditMode}
+          overflow={overflow}
+        >
           {before}
           <FormBase
             // setting a key here will reset the form
@@ -181,7 +227,7 @@ const ProjectForm: React.FC<Props> = ({
               true
             )}
           </FormBase>
-        </div>
+        </StyledAnimateForm>
         {children}
       </BaseAccordion.Content>
     </StyledBaseAccordion>

--- a/app/components/Analyst/Project/ProjectForm.tsx
+++ b/app/components/Analyst/Project/ProjectForm.tsx
@@ -155,6 +155,7 @@ const ProjectForm: React.FC<Props> = ({
       setIsFirstRender(false);
     }, 300);
     return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFormEditMode]);
 
   return (

--- a/app/components/Analyst/Project/ProjectForm.tsx
+++ b/app/components/Analyst/Project/ProjectForm.tsx
@@ -67,20 +67,24 @@ const StyledBtn = styled(Button)`
 `;
 
 interface AnimateFormProps {
+  formAnimationHeight: number;
   isAnimated: boolean;
   isFormExpanded: boolean;
   overflow: string;
   onClick?: () => void;
 }
 
+// form animation height is the height of the form when it is expanded.
+// The children of the form (eg the ViewAnnouncements or ChangeRequestCard)
+// may need a z-index of 1 to prevent visual glitches while expanding/retracting
 const StyledAnimateForm = styled.div<AnimateFormProps>`
-  ${({ isAnimated, isFormExpanded, overflow }) =>
+  ${({ formAnimationHeight, isAnimated, isFormExpanded, overflow }) =>
     isAnimated &&
     `
     position: relative;
     z-index: ${isFormExpanded ? 100 : 1};
     overflow: ${overflow};
-    max-height: ${isFormExpanded ? '400px' : '30px'};
+    max-height: ${isFormExpanded ? `${formAnimationHeight}px` : '30px'};
     transition: max-height 0.7s;
   `}
 `;
@@ -89,6 +93,7 @@ interface Props {
   additionalContext?: any;
   before?: React.ReactNode;
   children?: React.ReactNode;
+  formAnimationHeight?: number;
   formData: any;
   handleChange: any;
   showEditBtn?: boolean;
@@ -117,6 +122,7 @@ const ProjectForm: React.FC<Props> = ({
   handleChange,
   hiddenSubmitRef,
   showEditBtn = true,
+  formAnimationHeight = 300,
   isFormAnimated,
   isFormEditMode,
   onSubmit,
@@ -199,6 +205,7 @@ const ProjectForm: React.FC<Props> = ({
       </StyledHeader>
       <BaseAccordion.Content>
         <StyledAnimateForm
+          formAnimationHeight={formAnimationHeight}
           isAnimated={isFormAnimated}
           isFormExpanded={isFormEditMode}
           overflow={overflow}

--- a/app/components/Analyst/Project/index.ts
+++ b/app/components/Analyst/Project/index.ts
@@ -1,2 +1,3 @@
+export { default as AddButton } from './AddButton';
 export { default as ProjectForm } from './ProjectForm';
 export { default as ProjectTheme } from './ProjectTheme';

--- a/app/components/DownloadLink.tsx
+++ b/app/components/DownloadLink.tsx
@@ -5,6 +5,7 @@ const StyledLink = styled.button`
   color: ${(props) => props.theme.color.links};
   text-decoration-line: underline;
   word-break: break-word;
+  width: fit-content;
 `;
 
 const handleDownload = async (uuid, fileName) => {

--- a/app/formSchema/analyst/changeRequest.ts
+++ b/app/formSchema/analyst/changeRequest.ts
@@ -1,0 +1,15 @@
+import { JSONSchema7 } from 'json-schema';
+
+const changeRequest: JSONSchema7 = {
+  description: '',
+  type: 'object',
+  required: ['statementOfWorkUpload'],
+  properties: {
+    statementOfWorkUpload: {
+      title: 'Upload the completed statement of work Excel file',
+      type: 'string',
+    },
+  },
+};
+
+export default changeRequest;

--- a/app/formSchema/uiSchema/analyst/changeRequestUiSchema.ts
+++ b/app/formSchema/uiSchema/analyst/changeRequestUiSchema.ts
@@ -2,7 +2,8 @@ const changeRequestUiSchema = {
   statementOfWorkUpload: {
     'ui:title':
       'After pressing Import, key information will be extracted from the Statement of Work Tables to the database such as Dates, Communities & households, and Project costing & funding',
-    'ui:widget': 'SowImportFileWidget',
+    /*   'ui:widget': 'SowImportFileWidget', */
+    'ui:widget': 'FileWidget',
   },
 };
 

--- a/app/formSchema/uiSchema/analyst/changeRequestUiSchema.ts
+++ b/app/formSchema/uiSchema/analyst/changeRequestUiSchema.ts
@@ -1,0 +1,9 @@
+const changeRequestUiSchema = {
+  statementOfWorkUpload: {
+    'ui:title':
+      'After pressing Import, key information will be extracted from the Statement of Work Tables to the database such as Dates, Communities & households, and Project costing & funding',
+    'ui:widget': 'SowImportFileWidget',
+  },
+};
+
+export default changeRequestUiSchema;

--- a/app/pages/analyst/application/[applicationId]/project.tsx
+++ b/app/pages/analyst/application/[applicationId]/project.tsx
@@ -19,6 +19,7 @@ const getProjectQuery = graphql`
     applicationByRowId(rowId: $rowId) {
       ...ConditionalApprovalForm_application
       ...ProjectInformationForm_application
+      ...ChangeRequestForm_application
     }
     ...AnalystLayout_query
     ...AnnouncementsForm_query

--- a/app/pages/analyst/application/[applicationId]/project.tsx
+++ b/app/pages/analyst/application/[applicationId]/project.tsx
@@ -9,6 +9,7 @@ import { useFeature } from '@growthbook/growthbook-react';
 import ConditionalApprovalForm from 'components/Analyst/Project/ConditionalApproval/ConditionalApprovalForm';
 import AnnouncementsForm from 'components/Analyst/Project/Announcements/AnnouncementsForm';
 import ProjectInformationForm from 'components/Analyst/Project/ProjectInformation/ProjectInformationForm';
+import ChangeRequestForm from 'components/Analyst/Project/ChangeRequest/ChangeRequestForm';
 
 const getProjectQuery = graphql`
   query projectQuery($rowId: Int!) {
@@ -33,6 +34,7 @@ const Project = ({
   const showConditionalApproval = useFeature('show_conditional_approval').value;
   const showAnnouncement = useFeature('show_announcement').value;
   const showProjectInformation = useFeature('show_project_information').value;
+  const showChangeRequest = useFeature('show_change_request').value;
 
   return (
     <Layout session={session} title="Connecting Communities BC">
@@ -43,6 +45,9 @@ const Project = ({
         {showAnnouncement && <AnnouncementsForm query={query} />}
         {showProjectInformation && (
           <ProjectInformationForm application={applicationByRowId} />
+        )}
+        {showChangeRequest && (
+          <ChangeRequestForm application={applicationByRowId} />
         )}
       </AnalystLayout>
     </Layout>

--- a/app/schema/mutations/project/createChangeRequest.ts
+++ b/app/schema/mutations/project/createChangeRequest.ts
@@ -1,0 +1,29 @@
+import { graphql } from 'react-relay';
+import { createChangeRequestMutation } from '__generated__/createConditionalApprovalMutation.graphql';
+import useMutationWithErrorMessage from '../useMutationWithErrorMessage';
+
+const mutation = graphql`
+  mutation createChangeRequestMutation(
+    $connections: [ID!]!
+    $input: CreateChangeRequestInput!
+  ) {
+    createChangeRequest(input: $input) {
+      changeRequestDataEdge @appendEdge(connections: $connections) {
+        cursor
+        node {
+          id
+          jsonData
+          rowId
+        }
+      }
+    }
+  }
+`;
+
+const useCreateChangeRequestMutation = () =>
+  useMutationWithErrorMessage<createChangeRequestMutation>(
+    mutation,
+    () => 'An error occured while attempting to create the conditional approval'
+  );
+
+export { mutation, useCreateChangeRequestMutation };

--- a/app/schema/mutations/project/createChangeRequest.ts
+++ b/app/schema/mutations/project/createChangeRequest.ts
@@ -1,5 +1,5 @@
 import { graphql } from 'react-relay';
-import { createChangeRequestMutation } from '__generated__/createConditionalApprovalMutation.graphql';
+import { createChangeRequestMutation } from '__generated__/createChangeRequestMutation.graphql';
 import useMutationWithErrorMessage from '../useMutationWithErrorMessage';
 
 const mutation = graphql`

--- a/app/schema/mutations/project/createChangeRequest.ts
+++ b/app/schema/mutations/project/createChangeRequest.ts
@@ -12,6 +12,9 @@ const mutation = graphql`
         cursor
         node {
           id
+          changeRequestNumber
+          createdAt
+          updatedAt
           jsonData
           rowId
         }

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -601,6 +601,40 @@ type Query implements Node {
     filter: CcbcUserFilter
   ): CcbcUsersConnection
 
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  allChangeRequestData(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection
+
   """
   Reads and enables pagination through a set of `ConditionalApprovalData`.
   """
@@ -1200,6 +1234,7 @@ type Query implements Node {
   assessmentTypeByName(name: String!): AssessmentType
   attachmentByRowId(rowId: Int!): Attachment
   ccbcUserByRowId(rowId: Int!): CcbcUser
+  changeRequestDataByRowId(rowId: Int!): ChangeRequestData
   conditionalApprovalDataByRowId(rowId: Int!): ConditionalApprovalData
   formByRowId(rowId: Int!): Form
   formBySlug(slug: String!): Form
@@ -1392,6 +1427,14 @@ type Query implements Node {
     """The globally unique `ID` to be used in selecting a single `CcbcUser`."""
     id: ID!
   ): CcbcUser
+
+  """Reads a single `ChangeRequestData` using its globally unique `ID`."""
+  changeRequestData(
+    """
+    The globally unique `ID` to be used in selecting a single `ChangeRequestData`.
+    """
+    id: ID!
+  ): ChangeRequestData
 
   """
   Reads a single `ConditionalApprovalData` using its globally unique `ID`.
@@ -4111,6 +4154,108 @@ type CcbcUser implements Node {
     """
     filter: SowTab8Filter
   ): SowTab8SConnection!
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
 
   """Reads and enables pagination through a set of `CcbcUser`."""
   ccbcUsersByCcbcUserCreatedByAndUpdatedBy(
@@ -11149,6 +11294,312 @@ type CcbcUser implements Node {
     """
     filter: CcbcUserFilter
   ): CcbcUserCcbcUsersBySowTab8ArchivedByAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `Application`."""
+  applicationsByChangeRequestDataCreatedByAndApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Application`."""
+    orderBy: [ApplicationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationFilter
+  ): CcbcUserApplicationsByChangeRequestDataCreatedByAndApplicationIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByChangeRequestDataCreatedByAndUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByChangeRequestDataCreatedByAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByChangeRequestDataCreatedByAndArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByChangeRequestDataCreatedByAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `Application`."""
+  applicationsByChangeRequestDataUpdatedByAndApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Application`."""
+    orderBy: [ApplicationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationFilter
+  ): CcbcUserApplicationsByChangeRequestDataUpdatedByAndApplicationIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByChangeRequestDataUpdatedByAndCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByChangeRequestDataUpdatedByAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByChangeRequestDataUpdatedByAndArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByChangeRequestDataUpdatedByAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `Application`."""
+  applicationsByChangeRequestDataArchivedByAndApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Application`."""
+    orderBy: [ApplicationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationFilter
+  ): CcbcUserApplicationsByChangeRequestDataArchivedByAndApplicationIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByChangeRequestDataArchivedByAndCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByChangeRequestDataArchivedByAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByChangeRequestDataArchivedByAndUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByChangeRequestDataArchivedByAndUpdatedByManyToManyConnection!
 }
 
 """A connection to a list of `CcbcUser` values."""
@@ -11711,6 +12162,24 @@ input CcbcUserFilter {
 
   """Some related `sowTab8SByArchivedBy` exist."""
   sowTab8SByArchivedByExist: Boolean
+
+  """Filter by the object’s `changeRequestDataByCreatedBy` relation."""
+  changeRequestDataByCreatedBy: CcbcUserToManyChangeRequestDataFilter
+
+  """Some related `changeRequestDataByCreatedBy` exist."""
+  changeRequestDataByCreatedByExist: Boolean
+
+  """Filter by the object’s `changeRequestDataByUpdatedBy` relation."""
+  changeRequestDataByUpdatedBy: CcbcUserToManyChangeRequestDataFilter
+
+  """Some related `changeRequestDataByUpdatedBy` exist."""
+  changeRequestDataByUpdatedByExist: Boolean
+
+  """Filter by the object’s `changeRequestDataByArchivedBy` relation."""
+  changeRequestDataByArchivedBy: CcbcUserToManyChangeRequestDataFilter
+
+  """Some related `changeRequestDataByArchivedBy` exist."""
+  changeRequestDataByArchivedByExist: Boolean
 
   """Filter by the object’s `keycloakJwtsBySub` relation."""
   keycloakJwtsBySub: CcbcUserToManyKeycloakJwtFilter
@@ -12298,6 +12767,12 @@ input ApplicationFilter {
 
   """Some related `projectInformationDataByApplicationId` exist."""
   projectInformationDataByApplicationIdExist: Boolean
+
+  """Filter by the object’s `changeRequestDataByApplicationId` relation."""
+  changeRequestDataByApplicationId: ApplicationToManyChangeRequestDataFilter
+
+  """Some related `changeRequestDataByApplicationId` exist."""
+  changeRequestDataByApplicationIdExist: Boolean
 
   """Filter by the object’s `intakeByIntakeId` relation."""
   intakeByIntakeId: IntakeFilter
@@ -14683,6 +15158,91 @@ input ProjectInformationDataFilter {
 }
 
 """
+A filter to be used against many `ChangeRequestData` object types. All fields are combined with a logical ‘and.’
+"""
+input ApplicationToManyChangeRequestDataFilter {
+  """
+  Every related `ChangeRequestData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  every: ChangeRequestDataFilter
+
+  """
+  Some related `ChangeRequestData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  some: ChangeRequestDataFilter
+
+  """
+  No related `ChangeRequestData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  none: ChangeRequestDataFilter
+}
+
+"""
+A filter to be used against `ChangeRequestData` object types. All fields are combined with a logical ‘and.’
+"""
+input ChangeRequestDataFilter {
+  """Filter by the object’s `rowId` field."""
+  rowId: IntFilter
+
+  """Filter by the object’s `applicationId` field."""
+  applicationId: IntFilter
+
+  """Filter by the object’s `jsonData` field."""
+  jsonData: JSONFilter
+
+  """Filter by the object’s `createdBy` field."""
+  createdBy: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedBy` field."""
+  updatedBy: IntFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `archivedBy` field."""
+  archivedBy: IntFilter
+
+  """Filter by the object’s `archivedAt` field."""
+  archivedAt: DatetimeFilter
+
+  """Filter by the object’s `applicationByApplicationId` relation."""
+  applicationByApplicationId: ApplicationFilter
+
+  """A related `applicationByApplicationId` exists."""
+  applicationByApplicationIdExists: Boolean
+
+  """Filter by the object’s `ccbcUserByCreatedBy` relation."""
+  ccbcUserByCreatedBy: CcbcUserFilter
+
+  """A related `ccbcUserByCreatedBy` exists."""
+  ccbcUserByCreatedByExists: Boolean
+
+  """Filter by the object’s `ccbcUserByUpdatedBy` relation."""
+  ccbcUserByUpdatedBy: CcbcUserFilter
+
+  """A related `ccbcUserByUpdatedBy` exists."""
+  ccbcUserByUpdatedByExists: Boolean
+
+  """Filter by the object’s `ccbcUserByArchivedBy` relation."""
+  ccbcUserByArchivedBy: CcbcUserFilter
+
+  """A related `ccbcUserByArchivedBy` exists."""
+  ccbcUserByArchivedByExists: Boolean
+
+  """Checks for all expressions in this list."""
+  and: [ChangeRequestDataFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ChangeRequestDataFilter!]
+
+  """Negates the expression."""
+  not: ChangeRequestDataFilter
+}
+
+"""
 A filter to be used against `GaplessCounter` object types. All fields are combined with a logical ‘and.’
 """
 input GaplessCounterFilter {
@@ -15347,6 +15907,26 @@ input CcbcUserToManySowTab8Filter {
   No related `SowTab8` matches the filter criteria. All fields are combined with a logical ‘and.’
   """
   none: SowTab8Filter
+}
+
+"""
+A filter to be used against many `ChangeRequestData` object types. All fields are combined with a logical ‘and.’
+"""
+input CcbcUserToManyChangeRequestDataFilter {
+  """
+  Every related `ChangeRequestData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  every: ChangeRequestDataFilter
+
+  """
+  Some related `ChangeRequestData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  some: ChangeRequestDataFilter
+
+  """
+  No related `ChangeRequestData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  none: ChangeRequestDataFilter
 }
 
 """
@@ -16655,6 +17235,40 @@ type Application implements Node {
     """
     filter: ProjectInformationDataFilter
   ): ProjectInformationDataConnection!
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
 
   """Reads and enables pagination through a set of `AssessmentData`."""
   allAssessments(
@@ -18079,6 +18693,108 @@ type Application implements Node {
     """
     filter: CcbcUserFilter
   ): ApplicationCcbcUsersByProjectInformationDataApplicationIdAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByChangeRequestDataApplicationIdAndCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): ApplicationCcbcUsersByChangeRequestDataApplicationIdAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByChangeRequestDataApplicationIdAndUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): ApplicationCcbcUsersByChangeRequestDataApplicationIdAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByChangeRequestDataApplicationIdAndArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): ApplicationCcbcUsersByChangeRequestDataApplicationIdAndArchivedByManyToManyConnection!
 }
 
 """A connection to a list of `ApplicationStatus` values."""
@@ -25696,6 +26412,141 @@ input ProjectInformationDataCondition {
   archivedAt: Datetime
 }
 
+"""A connection to a list of `ChangeRequestData` values."""
+type ChangeRequestDataConnection {
+  """A list of `ChangeRequestData` objects."""
+  nodes: [ChangeRequestData]!
+
+  """
+  A list of edges which contains the `ChangeRequestData` and cursor to aid in pagination.
+  """
+  edges: [ChangeRequestDataEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ChangeRequestData` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""Table to store change request data"""
+type ChangeRequestData implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  id: ID!
+
+  """Unique id for the row"""
+  rowId: Int!
+
+  """The foreign key of an application"""
+  applicationId: Int
+
+  """The json form data of the change request form"""
+  jsonData: JSON!
+
+  """created by user id"""
+  createdBy: Int
+
+  """created at timestamp"""
+  createdAt: Datetime!
+
+  """updated by user id"""
+  updatedBy: Int
+
+  """updated at timestamp"""
+  updatedAt: Datetime!
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """archived at timestamp"""
+  archivedAt: Datetime
+
+  """
+  Reads a single `Application` that is related to this `ChangeRequestData`.
+  """
+  applicationByApplicationId: Application
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByCreatedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByArchivedBy: CcbcUser
+}
+
+"""A `ChangeRequestData` edge in the connection."""
+type ChangeRequestDataEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ChangeRequestData` at the end of the edge."""
+  node: ChangeRequestData
+}
+
+"""Methods to use when ordering `ChangeRequestData`."""
+enum ChangeRequestDataOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  APPLICATION_ID_ASC
+  APPLICATION_ID_DESC
+  JSON_DATA_ASC
+  JSON_DATA_DESC
+  CREATED_BY_ASC
+  CREATED_BY_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_BY_ASC
+  UPDATED_BY_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  ARCHIVED_BY_ASC
+  ARCHIVED_BY_DESC
+  ARCHIVED_AT_ASC
+  ARCHIVED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `ChangeRequestData` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input ChangeRequestDataCondition {
+  """Checks for equality with the object’s `rowId` field."""
+  rowId: Int
+
+  """Checks for equality with the object’s `applicationId` field."""
+  applicationId: Int
+
+  """Checks for equality with the object’s `jsonData` field."""
+  jsonData: JSON
+
+  """Checks for equality with the object’s `createdBy` field."""
+  createdBy: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedBy` field."""
+  updatedBy: Int
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `archivedBy` field."""
+  archivedBy: Int
+
+  """Checks for equality with the object’s `archivedAt` field."""
+  archivedAt: Datetime
+}
+
 """A connection to a list of `Announcement` values."""
 type AnnouncementsConnection {
   """A list of `Announcement` objects."""
@@ -28441,6 +29292,198 @@ type ApplicationCcbcUsersByProjectInformationDataApplicationIdAndArchivedByManyT
     """
     filter: ProjectInformationDataFilter
   ): ProjectInformationDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ChangeRequestData`.
+"""
+type ApplicationCcbcUsersByChangeRequestDataApplicationIdAndCreatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ChangeRequestData`, and the cursor to aid in pagination.
+  """
+  edges: [ApplicationCcbcUsersByChangeRequestDataApplicationIdAndCreatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ChangeRequestData`.
+"""
+type ApplicationCcbcUsersByChangeRequestDataApplicationIdAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ChangeRequestData`.
+"""
+type ApplicationCcbcUsersByChangeRequestDataApplicationIdAndUpdatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ChangeRequestData`, and the cursor to aid in pagination.
+  """
+  edges: [ApplicationCcbcUsersByChangeRequestDataApplicationIdAndUpdatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ChangeRequestData`.
+"""
+type ApplicationCcbcUsersByChangeRequestDataApplicationIdAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ChangeRequestData`.
+"""
+type ApplicationCcbcUsersByChangeRequestDataApplicationIdAndArchivedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ChangeRequestData`, and the cursor to aid in pagination.
+  """
+  edges: [ApplicationCcbcUsersByChangeRequestDataApplicationIdAndArchivedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ChangeRequestData`.
+"""
+type ApplicationCcbcUsersByChangeRequestDataApplicationIdAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
 }
 
 """A `Application` edge in the connection."""
@@ -41927,6 +42970,582 @@ type CcbcUserCcbcUsersBySowTab8ArchivedByAndUpdatedByManyToManyEdge {
 }
 
 """
+A connection to a list of `Application` values, with data from `ChangeRequestData`.
+"""
+type CcbcUserApplicationsByChangeRequestDataCreatedByAndApplicationIdManyToManyConnection {
+  """A list of `Application` objects."""
+  nodes: [Application]!
+
+  """
+  A list of edges which contains the `Application`, info from the `ChangeRequestData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserApplicationsByChangeRequestDataCreatedByAndApplicationIdManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Application` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `Application` edge in the connection, with data from `ChangeRequestData`.
+"""
+type CcbcUserApplicationsByChangeRequestDataCreatedByAndApplicationIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Application` at the end of the edge."""
+  node: Application
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ChangeRequestData`.
+"""
+type CcbcUserCcbcUsersByChangeRequestDataCreatedByAndUpdatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ChangeRequestData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByChangeRequestDataCreatedByAndUpdatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ChangeRequestData`.
+"""
+type CcbcUserCcbcUsersByChangeRequestDataCreatedByAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ChangeRequestData`.
+"""
+type CcbcUserCcbcUsersByChangeRequestDataCreatedByAndArchivedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ChangeRequestData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByChangeRequestDataCreatedByAndArchivedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ChangeRequestData`.
+"""
+type CcbcUserCcbcUsersByChangeRequestDataCreatedByAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+}
+
+"""
+A connection to a list of `Application` values, with data from `ChangeRequestData`.
+"""
+type CcbcUserApplicationsByChangeRequestDataUpdatedByAndApplicationIdManyToManyConnection {
+  """A list of `Application` objects."""
+  nodes: [Application]!
+
+  """
+  A list of edges which contains the `Application`, info from the `ChangeRequestData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserApplicationsByChangeRequestDataUpdatedByAndApplicationIdManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Application` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `Application` edge in the connection, with data from `ChangeRequestData`.
+"""
+type CcbcUserApplicationsByChangeRequestDataUpdatedByAndApplicationIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Application` at the end of the edge."""
+  node: Application
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ChangeRequestData`.
+"""
+type CcbcUserCcbcUsersByChangeRequestDataUpdatedByAndCreatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ChangeRequestData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByChangeRequestDataUpdatedByAndCreatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ChangeRequestData`.
+"""
+type CcbcUserCcbcUsersByChangeRequestDataUpdatedByAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ChangeRequestData`.
+"""
+type CcbcUserCcbcUsersByChangeRequestDataUpdatedByAndArchivedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ChangeRequestData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByChangeRequestDataUpdatedByAndArchivedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ChangeRequestData`.
+"""
+type CcbcUserCcbcUsersByChangeRequestDataUpdatedByAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+}
+
+"""
+A connection to a list of `Application` values, with data from `ChangeRequestData`.
+"""
+type CcbcUserApplicationsByChangeRequestDataArchivedByAndApplicationIdManyToManyConnection {
+  """A list of `Application` objects."""
+  nodes: [Application]!
+
+  """
+  A list of edges which contains the `Application`, info from the `ChangeRequestData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserApplicationsByChangeRequestDataArchivedByAndApplicationIdManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Application` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `Application` edge in the connection, with data from `ChangeRequestData`.
+"""
+type CcbcUserApplicationsByChangeRequestDataArchivedByAndApplicationIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Application` at the end of the edge."""
+  node: Application
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ChangeRequestData`.
+"""
+type CcbcUserCcbcUsersByChangeRequestDataArchivedByAndCreatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ChangeRequestData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByChangeRequestDataArchivedByAndCreatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ChangeRequestData`.
+"""
+type CcbcUserCcbcUsersByChangeRequestDataArchivedByAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ChangeRequestData`.
+"""
+type CcbcUserCcbcUsersByChangeRequestDataArchivedByAndUpdatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ChangeRequestData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByChangeRequestDataArchivedByAndUpdatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ChangeRequestData`.
+"""
+type CcbcUserCcbcUsersByChangeRequestDataArchivedByAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ChangeRequestData`."""
+  changeRequestDataByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ChangeRequestDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ChangeRequestDataFilter
+  ): ChangeRequestDataConnection!
+}
+
+"""
 A connection to a list of `Application` values, with data from `ApplicationAnalystLead`.
 """
 type AnalystApplicationsByApplicationAnalystLeadAnalystIdAndApplicationIdManyToManyConnection {
@@ -42818,6 +44437,14 @@ type Mutation {
     input: CreateCcbcUserInput!
   ): CreateCcbcUserPayload
 
+  """Creates a single `ChangeRequestData`."""
+  createChangeRequestData(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateChangeRequestDataInput!
+  ): CreateChangeRequestDataPayload
+
   """Creates a single `ConditionalApprovalData`."""
   createConditionalApprovalData(
     """
@@ -43247,6 +44874,24 @@ type Mutation {
     """
     input: UpdateCcbcUserByRowIdInput!
   ): UpdateCcbcUserPayload
+
+  """
+  Updates a single `ChangeRequestData` using its globally unique id and a patch.
+  """
+  updateChangeRequestData(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateChangeRequestDataInput!
+  ): UpdateChangeRequestDataPayload
+
+  """Updates a single `ChangeRequestData` using a unique key and a patch."""
+  updateChangeRequestDataByRowId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateChangeRequestDataByRowIdInput!
+  ): UpdateChangeRequestDataPayload
 
   """
   Updates a single `ConditionalApprovalData` using its globally unique id and a patch.
@@ -43798,6 +45443,22 @@ type Mutation {
     input: DeleteCcbcUserByRowIdInput!
   ): DeleteCcbcUserPayload
 
+  """Deletes a single `ChangeRequestData` using its globally unique id."""
+  deleteChangeRequestData(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteChangeRequestDataInput!
+  ): DeleteChangeRequestDataPayload
+
+  """Deletes a single `ChangeRequestData` using a unique key."""
+  deleteChangeRequestDataByRowId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteChangeRequestDataByRowIdInput!
+  ): DeleteChangeRequestDataPayload
+
   """
   Deletes a single `ConditionalApprovalData` using its globally unique id.
   """
@@ -44067,6 +45728,12 @@ type Mutation {
     """
     input: CreateAssessmentFormInput!
   ): CreateAssessmentFormPayload
+  createChangeRequest(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateChangeRequestInput!
+  ): CreateChangeRequestPayload
   createConditionalApproval(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -45342,6 +47009,82 @@ input CcbcUserInput {
 
   """User is an external analyst"""
   externalAnalyst: Boolean
+}
+
+"""The output of our create `ChangeRequestData` mutation."""
+type CreateChangeRequestDataPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `ChangeRequestData` that was created by this mutation."""
+  changeRequestData: ChangeRequestData
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Application` that is related to this `ChangeRequestData`.
+  """
+  applicationByApplicationId: Application
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByCreatedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByArchivedBy: CcbcUser
+
+  """An edge for our `ChangeRequestData`. May be used by Relay 1."""
+  changeRequestDataEdge(
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ChangeRequestDataEdge
+}
+
+"""All input for the create `ChangeRequestData` mutation."""
+input CreateChangeRequestDataInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `ChangeRequestData` to be created by this mutation."""
+  changeRequestData: ChangeRequestDataInput!
+}
+
+"""An input for mutations affecting `ChangeRequestData`"""
+input ChangeRequestDataInput {
+  """The foreign key of an application"""
+  applicationId: Int
+
+  """The json form data of the change request form"""
+  jsonData: JSON
+
+  """created by user id"""
+  createdBy: Int
+
+  """created at timestamp"""
+  createdAt: Datetime
+
+  """updated by user id"""
+  updatedBy: Int
+
+  """updated at timestamp"""
+  updatedAt: Datetime
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """archived at timestamp"""
+  archivedAt: Datetime
 }
 
 """The output of our create `ConditionalApprovalData` mutation."""
@@ -47991,6 +49734,108 @@ input UpdateCcbcUserByRowIdInput {
   rowId: Int!
 }
 
+"""The output of our update `ChangeRequestData` mutation."""
+type UpdateChangeRequestDataPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `ChangeRequestData` that was updated by this mutation."""
+  changeRequestData: ChangeRequestData
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Application` that is related to this `ChangeRequestData`.
+  """
+  applicationByApplicationId: Application
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByCreatedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByArchivedBy: CcbcUser
+
+  """An edge for our `ChangeRequestData`. May be used by Relay 1."""
+  changeRequestDataEdge(
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ChangeRequestDataEdge
+}
+
+"""All input for the `updateChangeRequestData` mutation."""
+input UpdateChangeRequestDataInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `ChangeRequestData` to be updated.
+  """
+  id: ID!
+
+  """
+  An object where the defined keys will be set on the `ChangeRequestData` being updated.
+  """
+  changeRequestDataPatch: ChangeRequestDataPatch!
+}
+
+"""
+Represents an update to a `ChangeRequestData`. Fields that are set will be updated.
+"""
+input ChangeRequestDataPatch {
+  """The foreign key of an application"""
+  applicationId: Int
+
+  """The json form data of the change request form"""
+  jsonData: JSON
+
+  """created by user id"""
+  createdBy: Int
+
+  """created at timestamp"""
+  createdAt: Datetime
+
+  """updated by user id"""
+  updatedBy: Int
+
+  """updated at timestamp"""
+  updatedAt: Datetime
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """archived at timestamp"""
+  archivedAt: Datetime
+}
+
+"""All input for the `updateChangeRequestDataByRowId` mutation."""
+input UpdateChangeRequestDataByRowIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `ChangeRequestData` being updated.
+  """
+  changeRequestDataPatch: ChangeRequestDataPatch!
+
+  """Unique id for the row"""
+  rowId: Int!
+}
+
 """The output of our update `ConditionalApprovalData` mutation."""
 type UpdateConditionalApprovalDataPayload {
   """
@@ -50476,6 +52321,70 @@ input DeleteCcbcUserByRowIdInput {
   rowId: Int!
 }
 
+"""The output of our delete `ChangeRequestData` mutation."""
+type DeleteChangeRequestDataPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `ChangeRequestData` that was deleted by this mutation."""
+  changeRequestData: ChangeRequestData
+  deletedChangeRequestDataId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Application` that is related to this `ChangeRequestData`.
+  """
+  applicationByApplicationId: Application
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByCreatedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByArchivedBy: CcbcUser
+
+  """An edge for our `ChangeRequestData`. May be used by Relay 1."""
+  changeRequestDataEdge(
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ChangeRequestDataEdge
+}
+
+"""All input for the `deleteChangeRequestData` mutation."""
+input DeleteChangeRequestDataInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `ChangeRequestData` to be deleted.
+  """
+  id: ID!
+}
+
+"""All input for the `deleteChangeRequestDataByRowId` mutation."""
+input DeleteChangeRequestDataByRowIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """Unique id for the row"""
+  rowId: Int!
+}
+
 """The output of our delete `ConditionalApprovalData` mutation."""
 type DeleteConditionalApprovalDataPayload {
   """
@@ -51493,6 +53402,52 @@ input CreateAssessmentFormInput {
   _assessmentType: String!
   _jsonData: JSON!
   _applicationId: Int!
+}
+
+"""The output of our `createChangeRequest` mutation."""
+type CreateChangeRequestPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  changeRequestData: ChangeRequestData
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Application` that is related to this `ChangeRequestData`.
+  """
+  applicationByApplicationId: Application
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByCreatedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """Reads a single `CcbcUser` that is related to this `ChangeRequestData`."""
+  ccbcUserByArchivedBy: CcbcUser
+
+  """An edge for our `ChangeRequestData`. May be used by Relay 1."""
+  changeRequestDataEdge(
+    """The method to use when ordering `ChangeRequestData`."""
+    orderBy: [ChangeRequestDataOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ChangeRequestDataEdge
+}
+
+"""All input for the `createChangeRequest` mutation."""
+input CreateChangeRequestInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  _applicationId: Int!
+  _jsonData: JSON!
 }
 
 """The output of our `createConditionalApproval` mutation."""

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -15187,6 +15187,9 @@ input ChangeRequestDataFilter {
   """Filter by the object’s `applicationId` field."""
   applicationId: IntFilter
 
+  """Filter by the object’s `changeRequestNumber` field."""
+  changeRequestNumber: IntFilter
+
   """Filter by the object’s `jsonData` field."""
   jsonData: JSONFilter
 
@@ -26444,6 +26447,9 @@ type ChangeRequestData implements Node {
   """The foreign key of an application"""
   applicationId: Int
 
+  """The change request number for that application"""
+  changeRequestNumber: Int!
+
   """The json form data of the change request form"""
   jsonData: JSON!
 
@@ -26496,6 +26502,8 @@ enum ChangeRequestDataOrderBy {
   ID_DESC
   APPLICATION_ID_ASC
   APPLICATION_ID_DESC
+  CHANGE_REQUEST_NUMBER_ASC
+  CHANGE_REQUEST_NUMBER_DESC
   JSON_DATA_ASC
   JSON_DATA_DESC
   CREATED_BY_ASC
@@ -26524,6 +26532,9 @@ input ChangeRequestDataCondition {
 
   """Checks for equality with the object’s `applicationId` field."""
   applicationId: Int
+
+  """Checks for equality with the object’s `changeRequestNumber` field."""
+  changeRequestNumber: Int
 
   """Checks for equality with the object’s `jsonData` field."""
   jsonData: JSON
@@ -47065,6 +47076,9 @@ input ChangeRequestDataInput {
   """The foreign key of an application"""
   applicationId: Int
 
+  """The change request number for that application"""
+  changeRequestNumber: Int!
+
   """The json form data of the change request form"""
   jsonData: JSON
 
@@ -49796,6 +49810,9 @@ Represents an update to a `ChangeRequestData`. Fields that are set will be updat
 input ChangeRequestDataPatch {
   """The foreign key of an application"""
   applicationId: Int
+
+  """The change request number for that application"""
+  changeRequestNumber: Int
 
   """The json form data of the change request form"""
   jsonData: JSON
@@ -53447,6 +53464,7 @@ input CreateChangeRequestInput {
   """
   clientMutationId: String
   _applicationId: Int!
+  _changeRequestNumber: Int!
   _jsonData: JSON!
 }
 

--- a/app/tests/components/Analyst/Project/ChangeRequest/ChangeRequestForm.test.tsx
+++ b/app/tests/components/Analyst/Project/ChangeRequest/ChangeRequestForm.test.tsx
@@ -1,0 +1,188 @@
+import ChangeRequestForm from 'components/Analyst/Project/ChangeRequest/ChangeRequestForm';
+import { graphql } from 'react-relay';
+import compiledQuery, {
+  ChangeRequestFormTestQuery,
+} from '__generated__/ChangeRequestFormTestQuery.graphql';
+import { act, fireEvent, screen } from '@testing-library/react';
+import ComponentTestingHelper from 'tests/utils/componentTestingHelper';
+
+const testQuery = graphql`
+  query ChangeRequestFormTestQuery @relay_test_operation {
+    # Spread the fragment you want to test here
+    applicationByRowId(rowId: 1) {
+      ...ChangeRequestForm_application
+    }
+  }
+`;
+
+const mockQueryPayload = {
+  Application() {
+    return {
+      rowId: 1,
+      ccbcNumber: 'CCBC-010001',
+      projectInformation: {
+        jsonData: {
+          main: {
+            upload: {
+              statementOfWorkUpload: [
+                {
+                  id: 3,
+                  name: 'CCBC-020118 - Statement of Work Tables - 20230517.xlsx',
+                  uuid: '41ecad78-2a39-41bc-b7c6-7faf23f772f4',
+                },
+              ],
+              fundingAgreementUpload: [
+                {
+                  id: 1,
+                  name: 'test.xls',
+                  uuid: '6ea405a8-c3df-4fa8-b6de-e38300e39482',
+                },
+              ],
+            },
+            dateFundingAgreementSigned: '2023-06-13',
+          },
+          hasFundingAgreementBeenSigned: true,
+        },
+      },
+      changeRequestDataByApplicationId: {
+        edges: [],
+      },
+    };
+  },
+};
+
+const mockEmptyQueryPayload = {
+  Application() {
+    return {
+      rowId: 1,
+      ccbcNumber: 'CCBC-010001',
+      projectInformation: null,
+    };
+  },
+};
+const componentTestingHelper =
+  new ComponentTestingHelper<ChangeRequestFormTestQuery>({
+    component: ChangeRequestForm,
+    testQuery,
+    compiledQuery,
+    defaultQueryResolver: mockQueryPayload,
+    getPropsFromTestQuery: (data) => ({
+      application: data.applicationByRowId,
+    }),
+  });
+
+describe('The Change Request form', () => {
+  beforeEach(() => {
+    componentTestingHelper.reinit();
+
+    componentTestingHelper.setMockRouterValues({
+      query: { id: '1' },
+    });
+  });
+
+  it('displays the title', () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent();
+
+    expect(
+      screen.getByRole('heading', { name: 'Change request' })
+    ).toBeVisible();
+  });
+
+  it('displays the empty state if there is no project information SoW upload', () => {
+    componentTestingHelper.loadQuery(mockEmptyQueryPayload);
+    componentTestingHelper.renderComponent();
+
+    expect(
+      screen.getByText(
+        'Change requests will be available after a funding agreement has been signed.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('calls the mutation on save', async () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent();
+
+    const addButton = screen.getByText('Add change request').closest('button');
+
+    await act(async () => {
+      fireEvent.click(addButton);
+    });
+
+    const file = new File([new ArrayBuffer(1)], 'file.xls', {
+      type: 'application/vnd.ms-excel',
+    });
+
+    const inputFile = screen.getAllByTestId('file-test')[0];
+
+    await act(async () => {
+      fireEvent.change(inputFile, { target: { files: [file] } });
+    });
+
+    componentTestingHelper.expectMutationToBeCalled(
+      'createAttachmentMutation',
+      {
+        input: {
+          attachment: {
+            file,
+            fileName: 'file.xls',
+            fileSize: '1 Bytes',
+            fileType: 'application/vnd.ms-excel',
+            applicationId: 1,
+          },
+        },
+      }
+    );
+
+    expect(screen.getByLabelText('loading')).toBeInTheDocument();
+
+    act(() => {
+      componentTestingHelper.environment.mock.resolveMostRecentOperation({
+        data: {
+          createAttachment: {
+            attachment: {
+              rowId: 1,
+              file: 'string',
+            },
+          },
+        },
+      });
+    });
+
+    expect(screen.getByText('Replace')).toBeInTheDocument();
+    expect(screen.getByText('file.xls')).toBeInTheDocument();
+
+    const saveButton = screen.getByRole('button', {
+      name: 'Save & Import Data',
+    });
+
+    await act(async () => {
+      fireEvent.click(saveButton);
+    });
+
+    componentTestingHelper.expectMutationToBeCalled(
+      'createChangeRequestMutation',
+      {
+        connections: [
+          'client:<Application-mock-id-1>:__ChangeRequestForm_changeRequestDataByApplicationId_connection(filter:{"archivedAt":{"isNull":true}},orderBy:"CHANGE_REQUEST_NUMBER_ASC")',
+        ],
+        input: {
+          _applicationId: 1,
+          _changeRequestNumber: 1,
+          _jsonData: {
+            statementOfWorkUpload: [
+              {
+                id: 1,
+                uuid: 'string',
+                name: 'file.xls',
+                size: 1,
+                type: 'application/vnd.ms-excel',
+              },
+            ],
+          },
+        },
+      }
+    );
+  });
+});

--- a/db/deploy/mutations/create_change_request.sql
+++ b/db/deploy/mutations/create_change_request.sql
@@ -1,0 +1,30 @@
+-- Deploy ccbc:mutations/create_change_request to pg
+
+begin;
+
+create or replace function ccbc_public.create_change_request(_application_id int, _json_data jsonb)
+returns ccbc_public.change_request_data as $$
+declare
+new_change_request_id int;
+old_change_request_id int;
+begin
+
+  select cr.id into old_change_request_id from ccbc_public.change_request_data as cr where cr.application_id = _application_id
+  order by cr.id desc limit 1;
+
+  insert into ccbc_public.change_request_data (application_id, json_data)
+    values (_application_id, _json_data) returning id into new_change_request_id;
+
+  if exists (select * from ccbc_public.change_request_data where id = old_change_request_id)
+    then update ccbc_public.change_request_data set archived_at = now() where id = old_change_request_id;
+  end if;
+
+  return (select row(ccbc_public.change_request_data.*) from ccbc_public.change_request_data
+    where id = new_change_request_id);
+end;
+$$ language plpgsql volatile;
+
+grant execute on function ccbc_public.create_change_request to ccbc_analyst;
+grant execute on function ccbc_public.create_change_request to ccbc_admin;
+
+commit;

--- a/db/deploy/tables/change_request_data.sql
+++ b/db/deploy/tables/change_request_data.sql
@@ -1,0 +1,35 @@
+-- Deploy ccbc:tables/change_request_data to pg
+
+begin;
+
+create table ccbc_public.change_request_data(
+  id integer primary key generated always as identity,
+  application_id integer references ccbc_public.application(id),
+  json_data jsonb not null default '{}'::jsonb);
+
+select ccbc_private.upsert_timestamp_columns('ccbc_public', 'change_request_data');
+select audit.enable_tracking('ccbc_public.change_request_data'::regclass);
+
+do
+$grant$
+begin
+
+perform ccbc_private.grant_permissions('select', 'change_request_data', 'ccbc_analyst');
+perform ccbc_private.grant_permissions('insert', 'change_request_data', 'ccbc_analyst');
+perform ccbc_private.grant_permissions('update', 'change_request_data', 'ccbc_analyst');
+perform ccbc_private.grant_permissions('select', 'change_request_data', 'ccbc_admin');
+perform ccbc_private.grant_permissions('insert', 'change_request_data', 'ccbc_admin');
+perform ccbc_private.grant_permissions('update', 'change_request_data', 'ccbc_admin');
+
+end
+$grant$;
+
+comment on table ccbc_public.change_request_data is 'Table to store change request data';
+
+comment on column ccbc_public.change_request_data.id is 'Unique id for the row';
+
+comment on column ccbc_public.change_request_data.application_id is 'The foreign key of an application';
+
+comment on column ccbc_public.change_request_data.json_data is 'The json form data of the change request form';
+
+commit;

--- a/db/deploy/tables/change_request_data.sql
+++ b/db/deploy/tables/change_request_data.sql
@@ -5,6 +5,7 @@ begin;
 create table ccbc_public.change_request_data(
   id integer primary key generated always as identity,
   application_id integer references ccbc_public.application(id),
+  change_request_number integer not null,
   json_data jsonb not null default '{}'::jsonb);
 
 select ccbc_private.upsert_timestamp_columns('ccbc_public', 'change_request_data');
@@ -29,6 +30,8 @@ comment on table ccbc_public.change_request_data is 'Table to store change reque
 comment on column ccbc_public.change_request_data.id is 'Unique id for the row';
 
 comment on column ccbc_public.change_request_data.application_id is 'The foreign key of an application';
+
+comment on column ccbc_public.change_request_data.change_request_number is 'The change request number for that application';
 
 comment on column ccbc_public.change_request_data.json_data is 'The json form data of the change request form';
 

--- a/db/revert/mutations/create_change_request.sql
+++ b/db/revert/mutations/create_change_request.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:mutations/create_change_request from pg
+
+begin;
+
+drop function ccbc_public.create_project_information;
+
+commit;

--- a/db/revert/mutations/create_change_request.sql
+++ b/db/revert/mutations/create_change_request.sql
@@ -2,6 +2,6 @@
 
 begin;
 
-drop function ccbc_public.create_project_information;
+drop function ccbc_public.create_change_request;
 
 commit;

--- a/db/revert/tables/change_request_data.sql
+++ b/db/revert/tables/change_request_data.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:tables/change_request_data from pg
+
+begin;
+
+drop table ccbc_public.change_request_data;
+
+commit;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -333,3 +333,4 @@ computed_columns/application_history [computed_columns/application_history@1.73.
 @1.75.0 2023-06-13T21:48:06Z Anthony Bushara <anthony@button.is> # release v1.75.0
 tables/application_status_type_006_add_new_types 2023-06-12T23:08:53Z Marcel Mueller <marcel@m2> # add new status types
 @1.76.0 2023-06-22T17:20:00Z Anthony Bushara <anthony@button.is> # release v1.76.0
+tables/change_request_data 2023-06-20T20:07:25Z Marcel Mueller <marcel@m2> # add table change request data

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -334,3 +334,4 @@ computed_columns/application_history [computed_columns/application_history@1.73.
 tables/application_status_type_006_add_new_types 2023-06-12T23:08:53Z Marcel Mueller <marcel@m2> # add new status types
 @1.76.0 2023-06-22T17:20:00Z Anthony Bushara <anthony@button.is> # release v1.76.0
 tables/change_request_data 2023-06-20T20:07:25Z Marcel Mueller <marcel@m2> # add table change request data
+mutations/create_change_request 2023-06-20T21:20:49Z Marcel Mueller <marcel@m2> # add mutation create_change_request

--- a/db/test/unit/mutations/create_change_request_test.sql
+++ b/db/test/unit/mutations/create_change_request_test.sql
@@ -1,0 +1,86 @@
+begin;
+
+select plan(5);
+
+truncate table
+  ccbc_public.application,
+  ccbc_public.application_status,
+  ccbc_public.attachment,
+  ccbc_public.form_data,
+  ccbc_public.application_form_data,
+  ccbc_public.intake
+restart identity cascade;
+
+select has_function('ccbc_public', 'create_change_request',
+'Function create_change_request should exist');
+
+insert into ccbc_public.intake(open_timestamp, close_timestamp, ccbc_intake_number)
+values('2022-03-01 09:00:00-07', '2022-05-01 09:00:00-07', 1);
+
+select mocks.set_mocked_time_in_transaction('2022-04-01 09:00:00-07'::timestamptz);
+set jwt.claims.sub to 'testCcbcAuthUser';
+insert into ccbc_public.ccbc_user
+  (given_name, family_name, email_address, session_sub) values
+  ('foo1', 'bar', 'foo1@bar.com', 'testCcbcAuthUser');
+
+set role ccbc_auth_user;
+
+select ccbc_public.create_application();
+
+-- ccbc_guest cannot create change_request
+
+set role ccbc_guest;
+
+select throws_like(
+  $$
+    select ccbc_public.create_change_request(1::int , '{}'::jsonb);
+  $$,
+  'permission denied%',
+  'ccbc_guest cannot create change_request'
+);
+
+-- ccbc_auth_user cannot create change_request
+
+set role ccbc_auth_user;
+
+select throws_like(
+  $$
+    select ccbc_public.create_change_request(1::int , '{}'::jsonb);
+  $$,
+  'permission denied%',
+  'ccbc_auth_user cannot create change_request'
+);
+
+
+
+-- set role to analyst and create change request
+set role ccbc_analyst;
+select ccbc_public.create_change_request(1::int , '{}'::jsonb);
+
+select results_eq(
+  $$
+    select count(*) from ccbc_public.change_request_data where application_id = 1;
+  $$,
+  $$
+    values(1::bigint);
+  $$,
+  'Should see 1 entry in change_request_data for application 1'
+);
+
+-- set role to admin and create change request
+
+set role ccbc_admin;
+select ccbc_public.create_change_request(1::int , '{}'::jsonb);
+
+select results_eq(
+  $$
+    select count(*) from ccbc_public.change_request_data where application_id = 1;
+  $$,
+  $$
+    values(2::bigint);
+  $$,
+  'Should see 2 entries in change_request_data for application 1'
+);
+
+select finish();
+rollback;

--- a/db/test/unit/mutations/create_change_request_test.sql
+++ b/db/test/unit/mutations/create_change_request_test.sql
@@ -1,6 +1,6 @@
 begin;
 
-select plan(5);
+select plan(6);
 
 truncate table
   ccbc_public.application,
@@ -33,7 +33,7 @@ set role ccbc_guest;
 
 select throws_like(
   $$
-    select ccbc_public.create_change_request(1::int , '{}'::jsonb);
+    select ccbc_public.create_change_request(1::int , 1::int, '{}'::jsonb);
   $$,
   'permission denied%',
   'ccbc_guest cannot create change_request'
@@ -45,7 +45,7 @@ set role ccbc_auth_user;
 
 select throws_like(
   $$
-    select ccbc_public.create_change_request(1::int , '{}'::jsonb);
+    select ccbc_public.create_change_request(1::int , 1::int, '{}'::jsonb);
   $$,
   'permission denied%',
   'ccbc_auth_user cannot create change_request'
@@ -55,7 +55,7 @@ select throws_like(
 
 -- set role to analyst and create change request
 set role ccbc_analyst;
-select ccbc_public.create_change_request(1::int , '{}'::jsonb);
+select ccbc_public.create_change_request(1::int , 1::int, '{}'::jsonb);
 
 select results_eq(
   $$
@@ -67,10 +67,21 @@ select results_eq(
   'Should see 1 entry in change_request_data for application 1'
 );
 
+-- throws error if change request number does not match what is expected in db
+
+
+select throws_like(
+  $$
+    select ccbc_public.create_change_request(1::int , 1::int, '{}'::jsonb);
+  $$,
+  'Change request number 1 does not match expected number 2',
+  'ccbc_analyst cannot create change_request'
+);
+
 -- set role to admin and create change request
 
 set role ccbc_admin;
-select ccbc_public.create_change_request(1::int , '{}'::jsonb);
+select ccbc_public.create_change_request(1::int , 2::int, '{}'::jsonb);
 
 select results_eq(
   $$
@@ -81,6 +92,8 @@ select results_eq(
   $$,
   'Should see 2 entries in change_request_data for application 1'
 );
+
+
 
 select finish();
 rollback;

--- a/db/test/unit/tables/change_request_data_test.sql
+++ b/db/test/unit/tables/change_request_data_test.sql
@@ -1,0 +1,61 @@
+begin;
+select plan(7);
+
+select has_table('ccbc_public', 'change_request_data', 'table ccbc_public.project_information_data exists');
+select has_column('ccbc_public', 'change_request_data', 'id', 'table ccbc_public.project_information_data has id column');
+select has_column('ccbc_public', 'change_request_data', 'json_data', 'table ccbc_public.project_information_data has json_data column');
+
+
+-- ccbc_guest
+set role ccbc_guest;
+set jwt.claims.sub to '11111111-1111-1111-1111-111111111111';
+
+select throws_like(
+  $$
+    select application_id from ccbc_public.change_request_data
+  $$,
+  'permission denied%',
+  'ccbc_guest cannot select'
+);
+
+-- ccbc_auth_user
+set role ccbc_auth_user;
+set jwt.claims.sub to '11111111-1111-1111-1111-111111111111';
+
+select throws_like(
+  $$
+    select application_id from ccbc_public.change_request_data
+  $$,
+  'permission denied%',
+  'ccbc_auth_user cannot select'
+);
+
+-- ccbc_admin
+set role ccbc_admin;
+set jwt.claims.sub to '11111111-1111-1111-1111-111111111111';
+
+select results_eq(
+  $$
+    select count(*) from ccbc_public.change_request_data;
+  $$,
+  $$
+    values (0::bigint)
+  $$,
+  'ccbc_admin can select'
+);
+
+-- ccbc_analyst
+set role ccbc_analyst;
+set jwt.claims.sub to '11111111-1111-1111-1111-111111111111';
+
+select results_eq(
+  $$
+    select count(*) from ccbc_public.change_request_data;
+  $$,
+  $$
+    values (0::bigint)
+  $$,
+  'ccbc_analyst can select'
+);
+select finish();
+rollback;

--- a/db/test/unit/tables/change_request_data_test.sql
+++ b/db/test/unit/tables/change_request_data_test.sql
@@ -1,10 +1,10 @@
 begin;
-select plan(7);
+select plan(8);
 
-select has_table('ccbc_public', 'change_request_data', 'table ccbc_public.project_information_data exists');
-select has_column('ccbc_public', 'change_request_data', 'id', 'table ccbc_public.project_information_data has id column');
-select has_column('ccbc_public', 'change_request_data', 'json_data', 'table ccbc_public.project_information_data has json_data column');
-
+select has_table('ccbc_public', 'change_request_data', 'table ccbc_public.change_request_data exists');
+select has_column('ccbc_public', 'change_request_data', 'id', 'table ccbc_public.change_request_data has id column');
+select has_column('ccbc_public', 'change_request_data', 'change_request_number', 'table ccbc_public.change_request_data has json_data column');
+select has_column('ccbc_public', 'change_request_data', 'json_data', 'table ccbc_public.change_request_data has json_data column');
 
 -- ccbc_guest
 set role ccbc_guest;


### PR DESCRIPTION
- feat: add change_request_data table
- feat: add postgres mutation create_change_request
- feat: add change request json form schema and ui schema
- chore: update graphql schema
- feat: add createChangeRequest graphql mutation
- refactor: move add button to separate component
- feat: update create change request db mutation to check expected number
- chore: update graphql schema
- feat: save change request number with form
- refactor: move form animation to project form for reuse
- feat: add change request card
- feat: order by change request number

<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements #1691 

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
