### PR TITLE
feat: cosmetic changes for sow

### DIFF
--- a/app/components/Analyst/Project/ProjectInformation/ProjectInformationForm.tsx
+++ b/app/components/Analyst/Project/ProjectInformation/ProjectInformationForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 import ProjectForm from 'components/Analyst/Project/ProjectForm';
@@ -12,65 +12,6 @@ import ProjectTheme from 'components/Analyst/Project/ProjectTheme';
 import MetabaseLink from 'components/Analyst/Project/ProjectInformation/MetabaseLink';
 import Toast from 'components/Toast';
 import validateFormData from '@rjsf/core/dist/cjs/validate';
-import { Alert } from '@button-inc/bcgov-theme';
-
-const StyledAlert = styled(Alert)`
-  margin-bottom: 8px;
-  margin-top: 8px;
-`;
-
-export const displaySowUploadErrors = (err) => {
-  const { level: errorType, error: errorMessage } = err;
-  let title =
-    'An unknown error has occured while validating the Statement of Work data';
-  if (errorType?.includes('tab')) {
-    title = `There was an error importing the Statement of Work data at ${errorType}`;
-  }
-  if (errorType === 'summary') {
-    title =
-      'There was an error importing the Statement of Work data at the Summary tab';
-  }
-
-  if (errorType === 'database') {
-    title = 'An error occured when validating the Statement of Work data';
-  }
-
-  if (errorType === 'workbook') {
-    title =
-      'The Statement of Work sheet does not appear to contain the correct tabs.';
-  }
-  // for cell level errors
-  if (typeof errorMessage !== 'string') {
-    return errorMessage.map(({ error: message }) => {
-      return (
-        <StyledAlert
-          key={message}
-          variant="danger"
-          closable={false}
-          content={
-            <>
-              <div> {title}</div>
-              <div>{message}</div>
-            </>
-          }
-        />
-      );
-    });
-  }
-  return (
-    <StyledAlert
-      key={errorMessage}
-      variant="danger"
-      closable={false}
-      content={
-        <>
-          <div> {title}</div>
-          <div>{errorMessage}</div>
-        </>
-      }
-    />
-  );
-};
 
 const StyledProjectForm = styled(ProjectForm)`
   .datepicker-widget {
@@ -100,7 +41,6 @@ const ProjectInformationForm = ({ application }) => {
   const [archiveApplicationSow] = useArchiveApplicationSowMutation();
   const [formData, setFormData] = useState(projectInformation?.jsonData);
   const [showToast, setShowToast] = useState(false);
-  const [sowValidationErrors, setSowValidationErrors] = useState([]);
   const [isFormEditMode, setIsFormEditMode] = useState(
     !projectInformation?.jsonData
   );
@@ -127,27 +67,6 @@ const ProjectInformationForm = ({ application }) => {
     const isFormValid = filteredErrors.length <= 0;
     return !isFormValid;
   }, [formData]);
-
-  const validateSow = useCallback(
-    async (file) => {
-      const sowFileFormData = new FormData();
-      sowFileFormData.append('file', file);
-
-      const response = await fetch(`/api/analyst/sow/${rowId}/${ccbcNumber}`, {
-        method: 'POST',
-        body: sowFileFormData,
-      });
-
-      const sowErrorList = await response.json();
-      if (Array.isArray(sowErrorList) && sowErrorList.length > 0) {
-        setSowValidationErrors(sowErrorList);
-      } else {
-        setSowValidationErrors([]);
-      }
-      return response;
-    },
-    [setSowValidationErrors, ccbcNumber, rowId]
-  );
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -196,7 +115,7 @@ const ProjectInformationForm = ({ application }) => {
       additionalContext={{
         applicationId: rowId,
         ccbcNumber,
-        validateSow,
+        rowId,
       }}
       formData={formData}
       handleChange={(e) => {
@@ -225,14 +144,18 @@ const ProjectInformationForm = ({ application }) => {
       setIsFormEditMode={(boolean) => setIsFormEditMode(boolean)}
       hiddenSubmitRef={hiddenSubmitRef}
     >
-      {!isFormEditMode && <MetabaseLink href='#' text='View project data in Metabase' width={326} />}
+      {!isFormEditMode && (
+        <MetabaseLink
+          href="#"
+          text="View project data in Metabase"
+          width={326}
+        />
+      )}
       {showToast && (
         <Toast timeout={100000000}>
           Statement of work successfully imported
         </Toast>
       )}
-      {sowValidationErrors?.length > 0 &&
-        sowValidationErrors.flatMap(displaySowUploadErrors)}
     </StyledProjectForm>
   );
 };

--- a/app/components/Analyst/Project/ProjectInformation/widgets/SowImportFileWidget.tsx
+++ b/app/components/Analyst/Project/ProjectInformation/widgets/SowImportFileWidget.tsx
@@ -35,14 +35,13 @@ const ellipsisAnimation = keyframes`
 
 const Loading = styled.div`
   color: #1a5a96;
-
+  width: 10rem;
   &:after {
     overflow: hidden;
     display: inline-block;
     vertical-align: bottom;
     animation: ${ellipsisAnimation} steps(4, end) 900ms infinite;
     content: '\\2026'; /* ascii code for the ellipsis character */
-    width: 0px;
   }
 `;
 

--- a/app/components/Analyst/Project/ProjectInformation/widgets/SowImportFileWidget.tsx
+++ b/app/components/Analyst/Project/ProjectInformation/widgets/SowImportFileWidget.tsx
@@ -252,32 +252,32 @@ const SowImportFileWidget: React.FC<SowImportFileWidgetProps> = ({
     }
 
     const { status } = response;
-    if (status === 200) {
-      createAttachment({
-        variables,
-        onError: () => {
-          setError('uploadFailed');
-        },
-        onCompleted: (res) => {
-          const uuid = res?.createAttachment?.attachment?.file;
-          const attachmentRowId = res?.createAttachment?.attachment?.rowId;
+    createAttachment({
+      variables,
+      onError: () => {
+        setError('uploadFailed');
+      },
+      onCompleted: (res) => {
+        const uuid = res?.createAttachment?.attachment?.file;
+        const attachmentRowId = res?.createAttachment?.attachment?.rowId;
 
-          const fileDetails = {
-            id: attachmentRowId,
-            uuid,
-            name,
-            size,
-            type,
-          };
-          onChange([fileDetails]);
-          setIsImporting(false);
-          setIsValidSow(true);
-        },
-      });
-    } else {
+        const fileDetails = {
+          id: attachmentRowId,
+          uuid,
+          name,
+          size,
+          type,
+        };
+        onChange([fileDetails]);
+        setIsImporting(false);
+      },
+    });
+    if (status !== 200) {
       setError('sowImportFailed');
       setIsImporting(false);
       setIsValidSow(false);
+    } else {
+      setIsValidSow(true);
     }
   };
 

--- a/app/components/Analyst/Project/ProjectInformation/widgets/SowImportFileWidget.tsx
+++ b/app/components/Analyst/Project/ProjectInformation/widgets/SowImportFileWidget.tsx
@@ -12,6 +12,12 @@ import FileComponent from 'lib/theme/components/FileComponent';
 import styled, { keyframes } from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
+import { Alert } from '@button-inc/bcgov-theme';
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: 8px;
+  margin-top: 8px;
+`;
 
 const ellipsisAnimation = keyframes`
   0% {
@@ -85,6 +91,59 @@ export const Success = () => (
   </SuccessContainer>
 );
 
+export const displaySowUploadErrors = (err) => {
+  const { level: errorType, error: errorMessage } = err;
+  let title =
+    'An unknown error has occured while validating the Statement of Work data';
+  if (errorType?.includes('tab')) {
+    title = `There was an error importing the Statement of Work data at ${errorType}`;
+  }
+  if (errorType === 'summary') {
+    title =
+      'There was an error importing the Statement of Work data at the Summary tab';
+  }
+
+  if (errorType === 'database') {
+    title = 'An error occured when validating the Statement of Work data';
+  }
+
+  if (errorType === 'workbook') {
+    title =
+      'The Statement of Work sheet does not appear to contain the correct tabs.';
+  }
+  // for cell level errors
+  if (typeof errorMessage !== 'string') {
+    return errorMessage.map(({ error: message }) => {
+      return (
+        <StyledAlert
+          key={message}
+          variant="danger"
+          closable={false}
+          content={
+            <>
+              <div> {title}</div>
+              <div>{message}</div>
+            </>
+          }
+        />
+      );
+    });
+  }
+  return (
+    <StyledAlert
+      key={errorMessage}
+      variant="danger"
+      closable={false}
+      content={
+        <>
+          <div> {title}</div>
+          <div>{errorMessage}</div>
+        </>
+      }
+    />
+  );
+};
+
 export const renderStatusLabel = (
   loading: boolean,
   success: boolean
@@ -126,6 +185,7 @@ const SowImportFileWidget: React.FC<SowImportFileWidgetProps> = ({
   const [error, setError] = useState('');
   const [createAttachment, isCreatingAttachment] = useCreateAttachment();
   const [deleteAttachment, isDeletingAttachment] = useDeleteAttachment();
+  const [sowValidationErrors, setSowValidationErrors] = useState([]);
   const [isImporting, setIsImporting] = useState(false);
   const [isValidSow, setIsValidSow] = useState(false);
   const isFiles = value?.length > 0;
@@ -143,7 +203,7 @@ const SowImportFileWidget: React.FC<SowImportFileWidgetProps> = ({
     if (loading) return;
     setError('');
 
-    const { applicationId, validateSow } = formContext;
+    const { applicationId, rowId, ccbcNumber } = formContext;
     const file = e.target.files?.[0];
 
     const { isValid, error: newError } = validateFile(
@@ -176,57 +236,75 @@ const SowImportFileWidget: React.FC<SowImportFileWidgetProps> = ({
       },
     };
 
-    await validateSow(file).then((response) => {
-      const { status } = response;
-      if (status === 200) {
-        createAttachment({
-          variables,
-          onError: () => {
-            setError('uploadFailed');
-          },
-          onCompleted: (res) => {
-            const uuid = res?.createAttachment?.attachment?.file;
-            const attachmentRowId = res?.createAttachment?.attachment?.rowId;
+    setSowValidationErrors([]);
+    const sowFileFormData = new FormData();
+    sowFileFormData.append('file', file);
 
-            const fileDetails = {
-              id: attachmentRowId,
-              uuid,
-              name,
-              size,
-              type,
-            };
-            onChange([fileDetails]);
-            setIsImporting(false);
-            setIsValidSow(true);
-          },
-        });
-      } else {
-        setError('sowImportFailed');
-        setIsImporting(false);
-        setIsValidSow(false);
-      }
+    const response = await fetch(`/api/analyst/sow/${rowId}/${ccbcNumber}`, {
+      method: 'POST',
+      body: sowFileFormData,
     });
+
+    const sowErrorList = await response.json();
+    if (Array.isArray(sowErrorList) && sowErrorList.length > 0) {
+      setSowValidationErrors(sowErrorList);
+    } else {
+      setSowValidationErrors([]);
+    }
+
+    const { status } = response;
+    if (status === 200) {
+      createAttachment({
+        variables,
+        onError: () => {
+          setError('uploadFailed');
+        },
+        onCompleted: (res) => {
+          const uuid = res?.createAttachment?.attachment?.file;
+          const attachmentRowId = res?.createAttachment?.attachment?.rowId;
+
+          const fileDetails = {
+            id: attachmentRowId,
+            uuid,
+            name,
+            size,
+            type,
+          };
+          onChange([fileDetails]);
+          setIsImporting(false);
+          setIsValidSow(true);
+        },
+      });
+    } else {
+      setError('sowImportFailed');
+      setIsImporting(false);
+      setIsValidSow(false);
+    }
   };
 
   return (
-    <FileComponent
-      loading={loading}
-      error={error}
-      handleDelete={() =>
-        handleDelete(fileId, deleteAttachment, setError, value, onChange)
-      }
-      handleDownload={handleDownload}
-      onChange={(e) => {
-        // eslint-disable-next-line no-void
-        void (() => handleChange(e))();
-      }}
-      fileTypes={acceptedFileTypes}
-      id={id}
-      label={label}
-      statusLabel={renderStatusLabel(isImporting, isValidSow)}
-      required={required}
-      value={value}
-    />
+    <>
+      <FileComponent
+        loading={loading}
+        error={error}
+        handleDelete={() =>
+          handleDelete(fileId, deleteAttachment, setError, value, onChange)
+        }
+        handleDownload={handleDownload}
+        onChange={(e) => {
+          // eslint-disable-next-line no-void
+          void (() => handleChange(e))();
+        }}
+        fileTypes={acceptedFileTypes}
+        id={id}
+        label={label}
+        statusLabel={renderStatusLabel(isImporting, isValidSow)}
+        required={required}
+        value={value}
+      />
+      {sowValidationErrors?.length > 0 &&
+        sowValidationErrors.flatMap(displaySowUploadErrors)}
+    </>
   );
 };
 

--- a/app/tests/components/Analyst/Project/ProjectInformation/ProjectInfomrationForm.test.ts
+++ b/app/tests/components/Analyst/Project/ProjectInformation/ProjectInfomrationForm.test.ts
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { displaySowUploadErrors } from 'components/Analyst/Project/ProjectInformation/ProjectInformationForm';
+import { displaySowUploadErrors } from 'components/Analyst/Project/ProjectInformation/widgets/SowImportFileWidget';
 
 describe('displaySowUploadErrors', () => {
   it('should display the default error message when the error type is unknown', () => {


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # 1617
1. Moved messages to appear right below sow upload field
2. "Checking the data..." is now a fixed width to prevent it from sliding
3. The moment you upload a new file, the errors disappear rather than waiting for the vlidation to occur
4. Even if errors occur, the onChange is committed to allow for the form to still be required *and* for that file to not be valid

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
