### PR TITLE
feat: add new hook to cancel operations on hook change

### DIFF
--- a/app/lib/helpers/useDisposeOnRouteChange.tsx
+++ b/app/lib/helpers/useDisposeOnRouteChange.tsx
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { Disposable } from 'relay-runtime';
+
+/**
+ * Custom hook that takes an initial disposable from relay-runtime and ensures
+ * that the .dispose() method is called when the URL changes due to client-side
+ * routing in Next.js.
+ *
+ * @param {Disposable | null} initialDisposable - Initial disposable from relay-runtime.
+ * @return {(disposable: Disposable) => void} - Function to set the disposable.
+ */
+const useDisposeOnRouteChange = (
+  initialDisposable: Disposable | null = null
+) => {
+  const [disposable, setDisposable] = useState<Disposable | null>(
+    initialDisposable
+  );
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleDispose = () => {
+      if (disposable?.dispose) {
+        disposable.dispose();
+      }
+    };
+
+    router.events.on('routeChangeStart', handleDispose);
+
+    return () => {
+      router.events.off('routeChangeStart', handleDispose);
+    };
+  }, [disposable, router.events]);
+
+  return setDisposable;
+};
+
+export default useDisposeOnRouteChange;

--- a/app/lib/theme/widgets/FileWidget.tsx
+++ b/app/lib/theme/widgets/FileWidget.tsx
@@ -11,6 +11,7 @@ import { useCreateAttachment } from 'schema/mutations/attachment/createAttachmen
 import { useDeleteAttachment } from 'schema/mutations/attachment/deleteAttachment';
 import bytesToSize from 'utils/bytesToText';
 import FileComponent from 'lib/theme/components/FileComponent';
+import useDisposeOnRouteChange from 'lib/helpers/useDisposeOnRouteChange';
 
 type File = {
   id: string | number;
@@ -38,6 +39,7 @@ const FileWidget: React.FC<FileWidgetProps> = ({
   const router = useRouter();
   const [createAttachment, isCreatingAttachment] = useCreateAttachment();
   const [deleteAttachment, isDeletingAttachment] = useDeleteAttachment();
+  const setDisposable = useDisposeOnRouteChange();
   const wrap = uiSchema['ui:options']?.wrap ?? false;
   const allowMultipleFiles =
     (uiSchema['ui:options']?.allowMultipleFiles as boolean) ?? false;
@@ -99,7 +101,7 @@ const FileWidget: React.FC<FileWidgetProps> = ({
       },
     };
 
-    createAttachment({
+    const disposableEvent = createAttachment({
       variables,
       onError: () => {
         setError('uploadFailed');
@@ -131,6 +133,8 @@ const FileWidget: React.FC<FileWidgetProps> = ({
         transaction.finish();
       },
     });
+
+    setDisposable(disposableEvent);
 
     e.target.value = '';
   };

--- a/app/package.json
+++ b/app/package.json
@@ -102,6 +102,7 @@
     "@testing-library/cypress": "^8.0.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.4.3",
     "@types/archiver": "^5.3.1",
     "@types/connect-pg-simple": "^7.0.0",

--- a/app/tests/lib/helpers/useDisposeOnRouteChange.test.tsx
+++ b/app/tests/lib/helpers/useDisposeOnRouteChange.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook, act } from '@testing-library/react-hooks/dom';
+import useDisposeOnRouteChange from 'lib/helpers/useDisposeOnRouteChange';
+import { useRouter } from 'next/router';
+// Mock the Next.js router
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('useDisposeOnRouteChange', () => {
+  let setDisposable;
+  let mockRouter;
+  let onMapper = {};
+
+  beforeEach(() => {
+    onMapper = {};
+    // Mock router events
+    mockRouter = {
+      events: {
+        on: jest.fn().mockImplementation((eventName, func) => {
+          onMapper[eventName] = func;
+        }),
+        off: jest.fn(),
+      },
+    };
+
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+
+    // Render the hook
+    const { result } = renderHook(() => useDisposeOnRouteChange());
+    setDisposable = result.current;
+  });
+
+  it('should set up an event listener on routeChangeStart', () => {
+    expect(mockRouter.events.on).toHaveBeenCalledWith(
+      'routeChangeStart',
+      expect.any(Function)
+    );
+  });
+
+  it('should remove the event listener on unmount', () => {
+    act(() => {
+      setDisposable({
+        dispose: jest.fn(),
+      });
+    });
+
+    expect(mockRouter.events.off).toHaveBeenCalledWith(
+      'routeChangeStart',
+      expect.any(Function)
+    );
+  });
+
+  it('should call dispose method on route change', () => {
+    const dispose = jest.fn();
+
+    // Set disposable
+    act(() => {
+      setDisposable({
+        dispose,
+      });
+    });
+
+    // Simulate routeChangeStart event
+    const handler = onMapper['routeChangeStart'];
+    if (handler) {
+      handler();
+    }
+
+    expect(dispose).toHaveBeenCalled();
+  });
+});

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3693,6 +3693,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^13.2.0":
   version "13.2.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.2.0.tgz#2db00bc94d71c4e90e5c25582e90a650ae2925bf"
@@ -10841,6 +10849,13 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-fast-compare@^3.0.1:
   version "3.2.0"


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # 1652

I've added a reusable hook to be able to dispose of requests made to graphql (and thus cancelling the onComplete that initiates once it ends) on a route change.
<!--
Add detailed description of the changes if the PR title isn't enough
 -->
