### PR TITLE
feat: use object-fit: contain on announcement image preview

### DIFF
--- a/app/components/Analyst/Project/Announcements/Announcement.tsx
+++ b/app/components/Analyst/Project/Announcements/Announcement.tsx
@@ -31,6 +31,7 @@ const StyledPreview = styled.div`
   & img {
     border-radius: 8px;
     padding: 1px;
+    object-fit: contain;
   }
 `;
 


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements #1727 

After some discussion we decided to use `object-fit: contain` which will display the full image while maintaining aspect ratio
![Screenshot 2023-06-29 at 2 55 24 PM](https://github.com/bcgov/CONN-CCBC-portal/assets/14259474/95d021cc-a227-4ea5-9544-a1950cb87917)

