### PR TITLE
fix: session timeout

### DIFF
--- a/app/components/SessionExpiryHandler.tsx
+++ b/app/components/SessionExpiryHandler.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { graphql, fetchQuery, useRelayEnvironment } from 'react-relay';
-import config from 'config';
 import { SessionTimeoutHandler } from '@bcgov-cas/sso-react';
 import type { SessionExpiryHandlerQuery } from '../__generated__/SessionExpiryHandlerQuery.graphql';
 
@@ -33,15 +32,11 @@ const SessionExpiryHandler: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const getLogOutUrl = () => {
-    const logoutUrl = config.get('SITEMINDER_LOGOUT_URL');
-    const localRedirectURL = `${window.location.origin}/${router.asPath}`;
-    return `${logoutUrl}?returl=${localRedirectURL}&retnow=1`;
-  };
-
   const handleSessionExpired = () => {
     setHasSession(false);
-    const logOutURL = getLogOutUrl();
+    // change to use backend logout
+    // as it will clear both SM and KC sessions
+    const logOutURL = '/logout';
 
     if (!logOutURL) {
       router.push({
@@ -65,7 +60,7 @@ const SessionExpiryHandler: React.FC = () => {
           resetOnChange={[router]}
           extendSessionOnEvents={{
             enabled: true,
-            throttleTime: 200000,
+            throttleTime: 60000,
             events: ['keydown', 'mousedown', 'scroll'],
           }}
         />

--- a/app/patches/@bcgov-cas+sso-express+3.2.0.patch
+++ b/app/patches/@bcgov-cas+sso-express+3.2.0.patch
@@ -1,0 +1,101 @@
+diff --git a/node_modules/@bcgov-cas/sso-express/dist/controllers.d.ts b/node_modules/@bcgov-cas/sso-express/dist/controllers.d.ts
+index fed3a24..b66860b 100644
+--- a/node_modules/@bcgov-cas/sso-express/dist/controllers.d.ts
++++ b/node_modules/@bcgov-cas/sso-express/dist/controllers.d.ts
+@@ -2,7 +2,7 @@ import type { Request, Response, NextFunction } from "express";
+ import { BaseClient } from "openid-client";
+ import { SSOExpressOptions } from "./index";
+ export declare const logoutController: (client: BaseClient, options: SSOExpressOptions) => (req: Request, res: Response) => void;
+-export declare const tokenSetController: (client: BaseClient, _options: SSOExpressOptions) => (req: Request, _res: Response, next: NextFunction) => Promise<void>;
++export declare const tokenSetController: (client: BaseClient, _options: SSOExpressOptions, idleRemainingRoute?: string) => (req: Request, _res: Response, next: NextFunction) => Promise<void>;
+ export declare const sessionIdleRemainingTimeController: (_client: BaseClient, options: SSOExpressOptions) => (req: Request, res: Response) => Response<any, Record<string, any>>;
+ export declare const loginController: (client: BaseClient, options: SSOExpressOptions) => (req: Request, res: Response) => void;
+ export declare const authCallbackController: (client: BaseClient, options: SSOExpressOptions) => (req: Request, res: Response) => Promise<void>;
+diff --git a/node_modules/@bcgov-cas/sso-express/dist/controllers.js b/node_modules/@bcgov-cas/sso-express/dist/controllers.js
+index 86b2152..429f9f6 100644
+--- a/node_modules/@bcgov-cas/sso-express/dist/controllers.js
++++ b/node_modules/@bcgov-cas/sso-express/dist/controllers.js
+@@ -77,18 +77,20 @@ var logoutController = function (client, options) {
+     };
+ };
+ exports.logoutController = logoutController;
+-var tokenSetController = function (client, _options) {
++var tokenSetController = function (client, _options, idleRemainingRoute) {
++    if (idleRemainingRoute === void 0) { idleRemainingRoute = '/session-idle-remaining-time'; }
+     return function (req, _res, next) { return __awaiter(void 0, void 0, void 0, function () {
+-        var tokenSet, err_1;
++        var extend, tokenSet, err_1;
+         return __generator(this, function (_a) {
+             switch (_a.label) {
+                 case 0:
+                     if (!(0, helpers_1.isAuthenticated)(req)) return [3 /*break*/, 5];
++                    extend = req.url !== idleRemainingRoute;
+                     tokenSet = new openid_client_1.TokenSet(req.session.tokenSet);
+                     _a.label = 1;
+                 case 1:
+                     _a.trys.push([1, 4, , 5]);
+-                    if (!tokenSet.expired()) return [3 /*break*/, 3];
++                    if (!(extend && tokenSet.expired())) return [3 /*break*/, 3];
+                     return [4 /*yield*/, client.refresh(tokenSet)];
+                 case 2:
+                     // If so, use the refresh token to get a new access token
+diff --git a/node_modules/@bcgov-cas/sso-express/dist/index.d.ts b/node_modules/@bcgov-cas/sso-express/dist/index.d.ts
+index 7a29a48..ef5549b 100644
+--- a/node_modules/@bcgov-cas/sso-express/dist/index.d.ts
++++ b/node_modules/@bcgov-cas/sso-express/dist/index.d.ts
+@@ -52,6 +52,7 @@ export interface SSOExpressOptions {
+         logout?: string;
+         sessionIdleRemainingTime?: string;
+         authCallback?: string;
++        extendSession?: string;
+     };
+     authorizationUrlParams?: Record<string, string> | ((req: Request) => Record<string, string>);
+     /**
+diff --git a/node_modules/@bcgov-cas/sso-express/dist/index.js b/node_modules/@bcgov-cas/sso-express/dist/index.js
+index 66d1457..dbb4762 100644
+--- a/node_modules/@bcgov-cas/sso-express/dist/index.js
++++ b/node_modules/@bcgov-cas/sso-express/dist/index.js
+@@ -68,12 +68,13 @@ var defaultOptions = {
+         logout: "/logout",
+         sessionIdleRemainingTime: "/session-idle-remaining-time",
+         authCallback: "/auth-callback",
++        extendSession: '/extend-session',
+     },
+     authorizationUrlParams: {},
+ };
+ function ssoExpress(opts) {
+     return __awaiter(this, void 0, void 0, function () {
+-        var options, _a, clientId, clientSecret, baseUrl, oidcIssuer, _b, authCallback, login, logout, sessionIdleRemainingTime, issuer, Client, client, middleware;
++        var options, _a, clientId, clientSecret, baseUrl, oidcIssuer, _b, authCallback, login, logout, sessionIdleRemainingTime, extendSession, issuer, Client, client, middleware;
+         return __generator(this, function (_c) {
+             switch (_c.label) {
+                 case 0:
+@@ -81,7 +82,7 @@ function ssoExpress(opts) {
+                         throw new Error("sso-express: oidcConfig key not provided in options");
+                     options = __assign(__assign(__assign({}, defaultOptions), opts), { routes: __assign(__assign({}, defaultOptions.routes), opts.routes) });
+                     _a = options.oidcConfig, clientId = _a.clientId, clientSecret = _a.clientSecret, baseUrl = _a.baseUrl, oidcIssuer = _a.oidcIssuer;
+-                    _b = options.routes, authCallback = _b.authCallback, login = _b.login, logout = _b.logout, sessionIdleRemainingTime = _b.sessionIdleRemainingTime;
++                    _b = options.routes, authCallback = _b.authCallback, login = _b.login, logout = _b.logout, sessionIdleRemainingTime = _b.sessionIdleRemainingTime, extendSession = _b.extendSession;
+                     return [4 /*yield*/, openid_client_1.Issuer.discover(oidcIssuer)];
+                 case 1:
+                     issuer = _c.sent();
+@@ -94,14 +95,18 @@ function ssoExpress(opts) {
+                         token_endpoint_auth_method: clientSecret ? "client_secret_basic" : "none",
+                     });
+                     middleware = (0, express_1.Router)();
++                    //also create a get logout to be used by the onSessionExpired callbaack
++                    middleware.get(logout, (0, controllers_1.logoutController)(client, options));
+                     middleware.post(logout, (0, controllers_1.logoutController)(client, options));
+-                    middleware.use((0, controllers_1.tokenSetController)(client, options));
++                    middleware.use((0, controllers_1.tokenSetController)(client, options, sessionIdleRemainingTime));
+                     // Session Idle Remaining Time
+                     // Returns, in seconds, the amount of time left in the session
+                     if (sessionIdleRemainingTime)
+                         middleware.get(sessionIdleRemainingTime, (0, controllers_1.sessionIdleRemainingTimeController)(client, options));
+                     middleware.post(login, (0, controllers_1.loginController)(client, options));
+                     middleware.get(authCallback, (0, controllers_1.authCallbackController)(client, options));
++                    // create a separate extend-session callback
++                    middleware.get(extendSession, (0, controllers_1.sessionIdleRemainingTimeController)(client, options));
+                     return [2 /*return*/, middleware];
+             }
+         });

--- a/app/patches/@bcgov-cas+sso-react+2.0.0.patch
+++ b/app/patches/@bcgov-cas+sso-react+2.0.0.patch
@@ -1,8 +1,16 @@
 diff --git a/node_modules/@bcgov-cas/sso-react/dist/SessionTimeoutHandler.js b/node_modules/@bcgov-cas/sso-react/dist/SessionTimeoutHandler.js
-index 43e6190..586eb4e 100644
+index 43e6190..de717d8 100644
 --- a/node_modules/@bcgov-cas/sso-react/dist/SessionTimeoutHandler.js
 +++ b/node_modules/@bcgov-cas/sso-react/dist/SessionTimeoutHandler.js
-@@ -82,7 +82,7 @@ var SessionTimeoutHandler = function (_a) {
+@@ -76,13 +76,14 @@ var SERVER_DELAY_SECONDS = 2;
+ var SessionTimeoutHandler = function (_a) {
+     var _b = _a.modalDisplaySecondsBeforeLogout, modalDisplaySecondsBeforeLogout = _b === void 0 ? 120 : _b, _c = _a.sessionRemainingTimePath, sessionRemainingTimePath = _c === void 0 ? "/session-idle-remaining-time" : _c, _d = _a.logoutPath, logoutPath = _d === void 0 ? "/logout" : _d, _e = _a.onSessionExpired, onSessionExpired = _e === void 0 ? function () { } : _e, _f = _a.resetOnChange, resetOnChange = _f === void 0 ? [] : _f, renderModal = _a.renderModal, extendSessionOnEvents = _a.extendSessionOnEvents;
+     var _g = (0, react_1.useState)(false), showModal = _g[0], setShowModal = _g[1];
++    var _h = (0, react_1.useState)(false), sessionExtendedToggle = _h[0], setSessionExtendedToggle = _h[1];
+     // UNIX epoch (ms)
+-    var _h = (0, react_1.useState)(Infinity), sessionExpiresOn = _h[0], setSessionExpiresOn = _h[1];
++    var _j = (0, react_1.useState)(Infinity), sessionExpiresOn = _j[0], setSessionExpiresOn = _j[1];
+     var extendSession = function () { return __awaiter(void 0, void 0, void 0, function () {
          var response, timeout, _a;
          return __generator(this, function (_b) {
              switch (_b.label) {
@@ -11,3 +19,20 @@ index 43e6190..586eb4e 100644
                  case 1:
                      response = _b.sent();
                      if (!response.ok) return [3 /*break*/, 3];
+@@ -94,6 +95,7 @@ var SessionTimeoutHandler = function (_a) {
+                         setShowModal(false);
+                     }
+                     setSessionExpiresOn(timeout * 1000 + Date.now());
++                    setSessionExtendedToggle(function (sessionExtendedToggle) { return !sessionExtendedToggle; });
+                     _b.label = 3;
+                 case 3: return [2 /*return*/];
+             }
+@@ -153,7 +155,7 @@ var SessionTimeoutHandler = function (_a) {
+             clearTimeout(modalDisplayTimeoutId);
+             clearTimeout(sessionTimeoutId);
+         };
+-    }, __spreadArray([], resetOnChange, true));
++    }, __spreadArray(__spreadArray([], resetOnChange, true), [sessionExtendedToggle], false));
+     return (react_1.default.createElement(react_1.default.Fragment, null, showModal && (react_1.default.createElement(LogoutWarningModal_1.default, { expiresOn: sessionExpiresOn, onExtendSession: extendSession, logoutPath: logoutPath, renderModal: renderModal }))));
+ };
+ exports.default = SessionTimeoutHandler;

--- a/app/patches/@bcgov-cas+sso-react+2.0.0.patch
+++ b/app/patches/@bcgov-cas+sso-react+2.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@bcgov-cas/sso-react/dist/SessionTimeoutHandler.js b/node_modules/@bcgov-cas/sso-react/dist/SessionTimeoutHandler.js
+index 43e6190..586eb4e 100644
+--- a/node_modules/@bcgov-cas/sso-react/dist/SessionTimeoutHandler.js
++++ b/node_modules/@bcgov-cas/sso-react/dist/SessionTimeoutHandler.js
+@@ -82,7 +82,7 @@ var SessionTimeoutHandler = function (_a) {
+         var response, timeout, _a;
+         return __generator(this, function (_b) {
+             switch (_b.label) {
+-                case 0: return [4 /*yield*/, fetch(sessionRemainingTimePath)];
++                case 0: return [4 /*yield*/, fetch('/extend-session')];
+                 case 1:
+                     response = _b.sent();
+                     if (!response.ok) return [3 /*break*/, 3];


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # 1690

- Updated logout for inactivity to be handled by sso-express
- Separate session-idle-remaining and extend into their own endpoints
- session-idle will no longer refresh token to prevent countdown from 1700+
- Refresh the timeout when session is extended

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
