### PR TITLE
fix: sow validate query param boolean bug

### DIFF
--- a/app/backend/lib/sow_import/summary_tab.ts
+++ b/app/backend/lib/sow_import/summary_tab.ts
@@ -196,7 +196,8 @@ const ValidateData = (data) => {
 
 const LoadSummaryData = async (wb, sheet_name, req) => {
   const { applicationId, ccbcNumber, amendmentNumber } = req.params;
-  const { validate = false } = req.query || {};
+  const validate = req.query?.validate === 'true';
+
   const data = await readSummary(
     wb,
     sheet_name,

--- a/app/tests/backend/lib/summary_tab.test.ts
+++ b/app/tests/backend/lib/summary_tab.test.ts
@@ -161,11 +161,12 @@ describe('sow_summary parsing tests', () => {
 
     const wb = XLSX.read(null);
     const req = { ...request };
-    req.query = { validate: true };
+    req.query = { validate: 'true' };
     req.params = {
       applicationId: 1,
       ccbcNumber: 'CCBC-020118',
       amendmentNumber: 0,
+      validate: 'true',
     };
 
     const data = await LoadSummaryData(wb, 'Summary_Sommaire', req);


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements #1829

This must have slipped by in a validation ticket. Since query params are all strings this made `validation = true` all the time so it wouldn't save in the database. 
