### PR TITLE
fix: radio focus border and label spacing

### DIFF
--- a/app/lib/theme/widgets/RadioWidget.tsx
+++ b/app/lib/theme/widgets/RadioWidget.tsx
@@ -6,6 +6,14 @@ import React from 'react';
 const StyledContainer = styled('div')`
   margin-top: 16px;
   margin-bottom: 32px;
+
+  label:focus-within {
+    border-radius: 99px;
+  }
+
+  .pg-radio-label {
+    padding-left: 1em;
+  }
 `;
 
 const StyledDiv = styled('div')`
@@ -15,6 +23,9 @@ const StyledDiv = styled('div')`
   align-items: center;
 `;
 
+const StyledLabel = styled.label`
+  padding-left: 8px;
+`;
 const RadioWidget: React.FC<WidgetProps> = ({
   onChange,
   id,
@@ -50,7 +61,7 @@ const RadioWidget: React.FC<WidgetProps> = ({
               required={required}
               disabled={disabled}
             />
-            <label htmlFor={`${id}-${i}`}>{option.label}</label>
+            <StyledLabel htmlFor={`${id}-${i}`}>{option.label}</StyledLabel>
           </StyledDiv>
         )
       )}


### PR DESCRIPTION
Pushing up a small fix I did when I was doing the radio button spike #1775 

Before:
<img width="241" alt="Screenshot 2023-07-11 at 2 58 04 PM" src="https://github.com/bcgov/CONN-CCBC-portal/assets/14259474/3ea8c438-3d17-42ae-9fc8-165a92638e2d">

After:
<img width="241" alt="Screenshot 2023-07-11 at 2 57 54 PM" src="https://github.com/bcgov/CONN-CCBC-portal/assets/14259474/71f8a530-0171-472e-a358-341537556af3">


