### PR TITLE
fix: do not show self project number on announcement list

### DIFF
--- a/app/components/Analyst/Project/Announcements/Announcement.tsx
+++ b/app/components/Analyst/Project/Announcements/Announcement.tsx
@@ -107,6 +107,7 @@ const Announcement = ({
   setAnnouncementData,
   setFormData,
   setIsFormEditMode,
+  currentCCBCNumber,
 }) => {
   const {
     jsonData: { announcementTitle, announcementDate, announcementUrl },
@@ -143,7 +144,7 @@ const Announcement = ({
         </div>
         <div>
           {announcement.jsonData.otherProjectsInAnnouncement?.map((project) => {
-            return (
+            return project.ccbcNumber === currentCCBCNumber ? null : (
               <div key={project.id}>
                 <StyledLink
                   href={`/analyst/application/${project.rowId}`}

--- a/app/components/Analyst/Project/Announcements/ViewAnnouncements.tsx
+++ b/app/components/Analyst/Project/Announcements/ViewAnnouncements.tsx
@@ -144,6 +144,7 @@ const ViewAnnouncements: React.FC<Props> = ({
               setAnnouncementData={setAnnouncementData}
               setFormData={setFormData}
               setIsFormEditMode={setIsFormEditMode}
+              currentCCBCNumber={ccbcNumber}
             />
           );
         })
@@ -163,6 +164,7 @@ const ViewAnnouncements: React.FC<Props> = ({
               setAnnouncementData={setAnnouncementData}
               setFormData={setFormData}
               setIsFormEditMode={setIsFormEditMode}
+              currentCCBCNumber={ccbcNumber}
             />
           );
         })


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # 1726

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
