### PR TITLE
chore: allow project information save only with date signed set

### DIFF
--- a/app/formSchema/analyst/projectInformation.ts
+++ b/app/formSchema/analyst/projectInformation.ts
@@ -4,7 +4,7 @@ const projectInformation: JSONSchema7 = {
   title: 'Project information',
   description: '',
   type: 'object',
-  required: ['dateFundingAgreementSigned', 'fundingAgreementUpload'],
+  required: ['dateFundingAgreementSigned'],
   properties: {
     hasFundingAgreementBeenSigned: {
       title: 'Has the funding agreement been signed?',


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements #1823 

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
