### PR TITLE
fix: set the sequence value to match what is set on override

### DIFF
--- a/db/data/dev/001_intake.sql
+++ b/db/data/dev/001_intake.sql
@@ -31,4 +31,6 @@ open_timestamp = excluded.open_timestamp,
 close_timestamp = excluded.close_timestamp,
 ccbc_intake_number = excluded.ccbc_intake_number;
 
+select setval('ccbc_public.intake_id_seq', 2, true);
+
 commit;

--- a/db/data/dev/001_intake.sql
+++ b/db/data/dev/001_intake.sql
@@ -32,5 +32,7 @@ close_timestamp = excluded.close_timestamp,
 ccbc_intake_number = excluded.ccbc_intake_number;
 
 select setval('ccbc_public.intake_id_seq', 2, true);
+select setval('ccbc_public.gapless_counter_id_seq', 2, true);
+
 
 commit;


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements fix where creating an intake produces an error in deev data. @marcellmueller 

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
