### PR TITLE
sow spinner and success toast should not show when SOW validation has failed

### DIFF
--- a/app/components/Analyst/Project/ProjectInformation/ProjectInformationForm.tsx
+++ b/app/components/Analyst/Project/ProjectInformation/ProjectInformationForm.tsx
@@ -325,7 +325,6 @@ const ProjectInformationForm = ({ application }) => {
   };
 
   const isOriginalSowUpload = projectInformation?.jsonData;
-
   return (
     <StyledProjectForm
       additionalContext={{
@@ -378,8 +377,14 @@ const ProjectInformationForm = ({ application }) => {
       onSubmit={handleSubmit}
       saveBtnText={hasSowValidationErrors ? 'Save' : 'Save & Import Data'}
       setFormData={setFormData}
-      submitting={isFormSubmitting}
       submittingText="Importing Statement of Work. Please wait."
+      submitting={
+        !hasSowValidationErrors &&
+        !hasFormErrors &&
+        sowFile &&
+        formData.statementOfWorkUpload &&
+        isFormSubmitting
+      }
       saveBtnDisabled={isFormSubmitting}
       setIsFormEditMode={(boolean) => {
         setShowToast(false);

--- a/app/tests/pages/analyst/application/[applicationId]/project.test.tsx
+++ b/app/tests/pages/analyst/application/[applicationId]/project.test.tsx
@@ -1137,6 +1137,11 @@ describe('The Project page', () => {
     pageTestingHelper.loadQuery(mockProjectDataQueryPayload);
     pageTestingHelper.renderPage();
 
+    // @ts-ignore
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ status: 200, json: () => {} })
+    );
+
     // Click on the edit button to open the form
     const editButton = screen.getAllByTestId('project-form-edit-button');
     await act(async () => {
@@ -1147,7 +1152,44 @@ describe('The Project page', () => {
 
     expect(hasFundingAggreementBeenSigned).toBeChecked();
 
-    const saveButton = screen.getByText('Save');
+    const file = new File([new ArrayBuffer(1)], 'file.xls', {
+      type: 'application/vnd.ms-excel',
+    });
+
+    const inputFile = screen.getAllByTestId('file-test');
+
+    await act(async () => {
+      fireEvent.change(inputFile[1], { target: { files: [file] } });
+    });
+
+    pageTestingHelper.expectMutationToBeCalled('createAttachmentMutation', {
+      input: {
+        attachment: {
+          file,
+          fileName: 'file.xls',
+          fileSize: '1 Bytes',
+          fileType: 'application/vnd.ms-excel',
+          applicationId: 1,
+        },
+      },
+    });
+
+    expect(screen.getByLabelText('loading')).toBeInTheDocument();
+
+    act(() => {
+      pageTestingHelper.environment.mock.resolveMostRecentOperation({
+        data: {
+          createAttachment: {
+            attachment: {
+              rowId: 1,
+              file: 'string',
+            },
+          },
+        },
+      });
+    });
+
+    const saveButton = screen.getByText('Save & Import Data');
 
     expect(saveButton).not.toBeDisabled();
 
@@ -1187,6 +1229,11 @@ describe('The Project page', () => {
     pageTestingHelper.loadQuery(mockProjectDataQueryPayload);
     pageTestingHelper.renderPage();
 
+    // @ts-ignore
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ status: 200, json: () => {} })
+    );
+
     // Click on the edit button to open the form
     const editButton = screen.getAllByTestId('project-form-edit-button');
     await act(async () => {
@@ -1197,7 +1244,44 @@ describe('The Project page', () => {
 
     expect(hasFundingAggreementBeenSigned).toBeChecked();
 
-    const saveButton = screen.getByText('Save');
+    const file = new File([new ArrayBuffer(1)], 'file.xls', {
+      type: 'application/vnd.ms-excel',
+    });
+
+    const inputFile = screen.getAllByTestId('file-test');
+
+    await act(async () => {
+      fireEvent.change(inputFile[1], { target: { files: [file] } });
+    });
+
+    pageTestingHelper.expectMutationToBeCalled('createAttachmentMutation', {
+      input: {
+        attachment: {
+          file,
+          fileName: 'file.xls',
+          fileSize: '1 Bytes',
+          fileType: 'application/vnd.ms-excel',
+          applicationId: 1,
+        },
+      },
+    });
+
+    expect(screen.getByLabelText('loading')).toBeInTheDocument();
+
+    act(() => {
+      pageTestingHelper.environment.mock.resolveMostRecentOperation({
+        data: {
+          createAttachment: {
+            attachment: {
+              rowId: 1,
+              file: 'string',
+            },
+          },
+        },
+      });
+    });
+
+    const saveButton = screen.getByText('Save & Import Data');
 
     expect(saveButton).not.toBeDisabled();
 


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # 1939

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
