### PR TITLE
2055 suppress aws logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ AWS_S3_SECRET_KEY
 AWS_ROLE_ARN
 ```
 
+To enable logging in the development console set the `ENABLE_AWS_LOGS` environment variable to `true`.
+
 ### Release Process
 
 Before releasing our application to our `test` and `prod` environments, an essential step is to add a tag to our sqitch plan, to identify which database changes are released to prod and should be immutable.

--- a/app/backend/lib/awsCommon.ts
+++ b/app/backend/lib/awsCommon.ts
@@ -10,6 +10,7 @@ import CustomHttpsAgent from './CustomHttpsAgent';
 
 const AWS_S3_REGION = config.get('AWS_S3_REGION');
 const AWS_ROLE_ARN = config.get('AWS_ROLE_ARN');
+const ENABLE_AWS_LOGS = config.get('ENABLE_AWS_LOGS');
 
 const httpsAgent = new CustomHttpsAgent();
 const httpAgent = new http.Agent({
@@ -25,7 +26,7 @@ const nodeHandler = new NodeHttpHandler({
 
 const awsConfig: S3ClientConfig = {
   region: AWS_S3_REGION,
-  logger: console,
+  logger: ENABLE_AWS_LOGS && console,
   requestHandler: nodeHandler,
   credentials: fromTemporaryCredentials({
     masterCredentials: fromEnv(),

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -182,6 +182,12 @@ const config = convict({
     default: 'arn:aws:sns:ca-central-1:780887525069:ccbc-export-files',
     env: 'ARCHIVE_REQUEST_TOPIC_ARN',
   },
+  ENABLE_AWS_LOGS: {
+    doc: 'Enable AWS logging in the console console',
+    format: Boolean,
+    default: false,
+    env: 'ENABLE_AWS_LOGS',
+  },
   ENABLE_MOCK_TIME: {
     doc: 'Enable Mock Time',
     format: Boolean,

--- a/app/config/prod.json
+++ b/app/config/prod.json
@@ -2,5 +2,6 @@
   "AUTH_SERVER_URL": "https://loginproxy.gov.bc.ca/auth/realms/standard",
   "SITEMINDER_LOGOUT_URL": "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi",
   "ARCHIVE_REQUEST_TOPIC_ARN": "arn:aws:sns:ca-central-1:443109034040:ccbc-export-files",
-  "SENTRY_ENVIRONMENT": "prod"
+  "SENTRY_ENVIRONMENT": "prod",
+  "ENABLE_AWS_LOGS": "true"
 }

--- a/app/config/prod.json
+++ b/app/config/prod.json
@@ -3,5 +3,5 @@
   "SITEMINDER_LOGOUT_URL": "https://logon7.gov.bc.ca/clp-cgi/logoff.cgi",
   "ARCHIVE_REQUEST_TOPIC_ARN": "arn:aws:sns:ca-central-1:443109034040:ccbc-export-files",
   "SENTRY_ENVIRONMENT": "prod",
-  "ENABLE_AWS_LOGS": "true"
+  "ENABLE_AWS_LOGS": true
 }

--- a/app/config/test.json
+++ b/app/config/test.json
@@ -4,5 +4,6 @@
   "ARCHIVE_REQUEST_TOPIC_ARN": "arn:aws:sns:ca-central-1:634534882587:ccbc-export-files",
   "ENABLE_MOCK_TIME": true,
   "ENABLE_MOCK_COOKIES": true,
-  "SENTRY_ENVIRONMENT": "test"
+  "SENTRY_ENVIRONMENT": "test",
+  "ENABLE_AWS_LOGS": "true"
 }

--- a/app/config/test.json
+++ b/app/config/test.json
@@ -5,5 +5,5 @@
   "ENABLE_MOCK_TIME": true,
   "ENABLE_MOCK_COOKIES": true,
   "SENTRY_ENVIRONMENT": "test",
-  "ENABLE_AWS_LOGS": "true"
+  "ENABLE_AWS_LOGS": true
 }


### PR DESCRIPTION
Adds a new env var called `ENABLE_AWS_LOGS` which is set to true by default in `test` and `prod`.

Implements #255

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
