### PR TITLE
2002 add claims

### DIFF
--- a/app/backend/lib/claims-upload.ts
+++ b/app/backend/lib/claims-upload.ts
@@ -1,0 +1,96 @@
+import { Router } from 'express';
+import formidable from 'formidable';
+import fs from 'fs';
+import RateLimit from 'express-rate-limit';
+import * as XLSX from 'xlsx';
+import getAuthRole from '../../utils/getAuthRole';
+import LoadClaimsData from './excel_import/claims';
+import { ExpressMiddleware, parseForm } from './express-helper';
+
+// see https://docs.sheetjs.com/docs/getting-started/installation/nodejs/#installation
+XLSX.set_fs(fs);
+
+const limiter = RateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 5,
+});
+
+const claimsUpload = Router();
+
+const processClaims: ExpressMiddleware = async (req, res) => {
+  const authRole = getAuthRole(req);
+  const isRoleAuthorized =
+    authRole?.pgRole === 'ccbc_admin' || authRole?.pgRole === 'ccbc_analyst';
+
+  if (!isRoleAuthorized) {
+    return res.status(404).end();
+  }
+
+  const errorList = [];
+  const form = new formidable.IncomingForm({ maxFileSize: 8000000 });
+
+  const files = await parseForm(form, req).catch((err) => {
+    errorList.push({ level: 'file', error: err });
+    return res.status(400).json(errorList).end();
+  });
+
+  const filename = Object.keys(files)[0];
+  const uploaded = files[filename];
+  if (!uploaded) {
+    return res.status(200).end();
+  }
+  const buf = fs.readFileSync(uploaded.filepath);
+  const wb = XLSX.read(buf);
+
+  const sheet = 'Sheet 1';
+
+  // Throw error if sheet is not found
+  if (!wb.SheetNames.includes(sheet)) {
+    errorList.push({
+      level: 'workbook',
+      error: `missing required sheet "${sheet}". Found: ${JSON.stringify(
+        wb.SheetNames
+      )}`,
+    });
+  }
+
+  // other validation stuff here
+
+  if (errorList.length > 0) {
+    return res.status(400).json(errorList).end();
+  }
+
+  const result = await LoadClaimsData(wb, 'Sheet 1', req);
+  // get around typescript complaining
+  if (result['error']) {
+    return res.status(400).json(result['error']).end();
+  }
+
+  if (result) {
+    return res.status(200).json({ result }).end();
+  }
+
+  return res
+    .status(400)
+    .json({ error: 'failed to save claims data in DB' })
+    .end();
+};
+
+// claimsId is optional and used for the previously uploaded claim so we can archive it if replacing with another excel upload.
+claimsUpload.post(
+  '/api/analyst/claims/:applicationId/:claimsId',
+  limiter,
+  (req, res) => {
+    // eslint-disable-next-line no-void
+    void (() => processClaims(req, res, null))();
+  }
+);
+
+export const config = {
+  api: {
+    bodyParser: false,
+    externalResolver: true,
+  },
+};
+
+export default claimsUpload;

--- a/app/backend/lib/excel_import/claims.ts
+++ b/app/backend/lib/excel_import/claims.ts
@@ -15,8 +15,8 @@ const createClaimsMutation = `
 `;
 
 const readSummary = async (wb, sheet_name, applicationId, claimsId) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const ws = wb.Sheets[sheet_name];
-  console.log('ws', ws !== undefined);
 
   // read excel data here
 

--- a/app/backend/lib/excel_import/claims.ts
+++ b/app/backend/lib/excel_import/claims.ts
@@ -1,0 +1,62 @@
+/* import * as XLSX from 'xlsx'; */
+import { performQuery } from '../graphql';
+/* import { convertExcelDateToJSDate } from '../sow_import/util'; */
+
+const createClaimsMutation = `
+  mutation claimsUploadMutation($input: CreateApplicationClaimsExcelDataInput!) {
+    createApplicationClaimsExcelData(input:   $input) {
+        applicationClaimsExcelData {
+        id
+        rowId
+      }
+      clientMutationId
+    }
+  }
+`;
+
+const readSummary = async (wb, sheet_name, applicationId, claimsId) => {
+  const ws = wb.Sheets[sheet_name];
+  console.log('ws', ws !== undefined);
+
+  // read excel data here
+
+  const jsonData = {
+    // excel fields here
+  };
+
+  const claimsData = {
+    _applicationId: parseInt(applicationId, 10),
+    _jsonData: jsonData,
+    _oldId: claimsId ? parseInt(claimsId, 10) : null,
+  };
+
+  return claimsData;
+};
+
+const LoadClaimsData = async (wb, sheet_name, req) => {
+  const { applicationId, claimsId } = req.params;
+  const validate = req.query?.validate === 'true';
+
+  const data = await readSummary(wb, sheet_name, applicationId, claimsId);
+
+  if (validate) {
+    return data;
+  }
+  // time to persist in DB
+  const result = await performQuery(
+    createClaimsMutation,
+    {
+      input: {
+        _applicationId: data._applicationId,
+        _jsonData: data._jsonData,
+      },
+    },
+    req
+  ).catch((e) => {
+    return { error: e };
+  });
+
+  return result;
+};
+
+export default LoadClaimsData;

--- a/app/components/Analyst/Project/Claims/ClaimsForm.tsx
+++ b/app/components/Analyst/Project/Claims/ClaimsForm.tsx
@@ -107,11 +107,11 @@ const ClaimsForm = ({ application }) => {
   const [isFormSubmitting, setIsFormSubmitting] = useState(false);
 
   const claimsConnectionId = claimsData?.__id;
-  const claimsList = claimsData?.edges?.filter((data) => {
-    // filter null nodes from the list caused by relay connection update
-    return data.node !== null;
-  });
-
+  // const claimsList = claimsData?.edges?.filter((data) => {
+  //   // filter null nodes from the list caused by relay connection update
+  //   return data.node !== null;
+  // });
+  //
   const apiPath = `/api/analyst/claims/${applicationRowId}/${currentClaimsData?.rowId}`;
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -138,16 +138,15 @@ const ClaimsForm = ({ application }) => {
 
     validateClaims(excelFile, false).then((res) => {
       // get the excel data row i from the response or the current community progress data
-      const responseExcelDataId =
-        res?.result?.data.createApplicationCommunityReportExcelData
-          ?.applicationCommunityReportExcelData?.rowId;
+      // const responseExcelDataId =
+      //   res?.result?.data.createApplicationCommunityReportExcelData
+      //     ?.applicationCommunityReportExcelData?.rowId;
 
       // get the excel data row id from the current community progress data if it exists
-      const currentExcelDataId = currentClaimsData?.excelDataId;
+      /* const currentExcelDataId = currentClaimsData?.excelDataId; */
 
       // replace the current excel data id if a new excel file was uploaded since the previous data will be archived
-      const excelDataId = responseExcelDataId || currentExcelDataId;
-      console.log(claimsList, excelDataId);
+      /* const excelDataId = responseExcelDataId || currentExcelDataId; */
 
       /// save form data
       createClaims({

--- a/app/components/Analyst/Project/Claims/ClaimsForm.tsx
+++ b/app/components/Analyst/Project/Claims/ClaimsForm.tsx
@@ -5,7 +5,7 @@ import { ConnectionHandler, graphql, useFragment } from 'react-relay';
 import claimsSchema from 'formSchema/analyst/claims';
 import claimsUiSchema from 'formSchema/uiSchema/analyst/claimsUiSchema';
 import { useCreateClaimsMutation } from 'schema/mutations/project/createClaimsData';
-/* import { useArchiveApplicationClaimsMutation as useArchiveCpr } from 'schema/mutations/project/archiveApplicationClaims'; */
+/* import { useArchiveApplicationClaimsMutation as useArchiveClaims } from 'schema/mutations/project/archiveApplicationClaims'; */
 import excelValidateGenerator from 'lib/helpers/excelValidate';
 import Toast from 'components/Toast';
 import Modal from 'components/Modal';
@@ -276,7 +276,7 @@ const ClaimsForm = ({ application }) => {
         }
         saveDataTestId="save-claims data"
       >
-        map view here
+        {/*  map view here */}
       </StyledProjectForm>
     </>
   );

--- a/app/components/Analyst/Project/Claims/ClaimsForm.tsx
+++ b/app/components/Analyst/Project/Claims/ClaimsForm.tsx
@@ -38,6 +38,23 @@ const StyledFlex = styled.div`
   }
 `;
 
+const FormHeader = (
+  <div>
+    <p>
+      Claims & progress reports are submitted by recipients for incurred or paid
+      expenses during the previous quarter(s). While they are due 45 days after
+      that quarter ends, recipients do not always submit claim & progress
+      reports every quarter.{' '}
+    </p>
+    <p>
+      All processing of claims takes place outside of the CCBC portal. After a
+      claim is processed and paid, please upload the finalized and completed
+      claim Excel file here.
+    </p>
+    <b>Claims period</b>
+  </div>
+);
+
 interface FormData {
   claimsFile?: any;
   fromDate?: string;
@@ -224,6 +241,7 @@ const ClaimsForm = ({ application }) => {
         schema={claimsSchema}
         uiSchema={claimsUiSchema}
         formData={formData}
+        formHeader={FormHeader}
         theme={ProjectTheme}
         onSubmit={handleSubmit}
         formAnimationHeight={600}

--- a/app/components/Analyst/Project/Claims/ClaimsForm.tsx
+++ b/app/components/Analyst/Project/Claims/ClaimsForm.tsx
@@ -1,0 +1,267 @@
+import { useCallback, useRef, useState } from 'react';
+import styled from 'styled-components';
+import Button from '@button-inc/bcgov-theme/Button';
+import { ConnectionHandler, graphql, useFragment } from 'react-relay';
+import claimsSchema from 'formSchema/analyst/claims';
+import claimsUiSchema from 'formSchema/uiSchema/analyst/claimsUiSchema';
+import { useCreateClaimsMutation } from 'schema/mutations/project/createClaimsData';
+/* import { useArchiveApplicationClaimsMutation as useArchiveCpr } from 'schema/mutations/project/archiveApplicationClaims'; */
+import excelValidateGenerator from 'lib/helpers/excelValidate';
+import Toast from 'components/Toast';
+import Modal from 'components/Modal';
+import ProjectTheme from '../ProjectTheme';
+import ProjectForm from '../ProjectForm';
+import AddButton from '../AddButton';
+
+const StyledContainer = styled.div`
+  text-align: center;
+  max-width: 400px;
+
+  p {
+    margin-top: 16px;
+  }
+`;
+
+const StyledProjectForm = styled(ProjectForm)`
+  .datepicker-widget {
+    width: 180px;
+    margin-bottom: 0px;
+  }
+`;
+
+const StyledFlex = styled.div`
+  display: flex;
+  justify-content: center;
+
+  button:first-child {
+    margin-right: 16px;
+  }
+`;
+
+interface FormData {
+  claimsFile?: any;
+  fromDate?: string;
+  toDate?: string;
+}
+
+const ClaimsForm = ({ application }) => {
+  const queryFragment = useFragment(
+    graphql`
+      fragment ClaimsForm_application on Application {
+        id
+        rowId
+        applicationClaimsDataByApplicationId(
+          filter: { archivedAt: { isNull: true } }
+          first: 1000
+        ) @connection(key: "ClaimsForm_applicationClaimsDataByApplicationId") {
+          __id
+          edges {
+            node {
+              __id
+              id
+              rowId
+              jsonData
+            }
+          }
+        }
+        ccbcNumber
+      }
+    `,
+    application
+  );
+  const {
+    applicationClaimsDataByApplicationId: claimsData,
+    rowId: applicationRowId,
+  } = queryFragment;
+
+  const [formData, setFormData] = useState({} as FormData);
+  const [showModal, setShowModal] = useState(false);
+  // store the current community progress data node for edit mode so we have access to row id and relay connection
+  const [currentClaimsData, setCurrentClaimsData] = useState(null);
+  const [isFormEditMode, setIsFormEditMode] = useState(false);
+  const [createClaims] = useCreateClaimsMutation();
+  /*   const [archiveClaims] = useArchiveCpr(); */
+  const hiddenSubmitRef = useRef<HTMLButtonElement>(null);
+  // use this to live validate the form after the first submit attempt
+  const [isSubmitAttempted, setIsSubmitAttempted] = useState(false);
+  const [excelFile, setExcelFile] = useState(null);
+  const [showToast, setShowToast] = useState(false);
+  const [claimsValidationErrors, setClaimsValidationErrors] = useState([]);
+  const [isFormSubmitting, setIsFormSubmitting] = useState(false);
+
+  const claimsConnectionId = claimsData?.__id;
+  const claimsList = claimsData?.edges?.filter((data) => {
+    // filter null nodes from the list caused by relay connection update
+    return data.node !== null;
+  });
+
+  const apiPath = `/api/analyst/claims/${applicationRowId}/${currentClaimsData?.rowId}`;
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const validateClaims = useCallback(
+    excelValidateGenerator(apiPath, setExcelFile, setClaimsValidationErrors),
+    [setExcelFile]
+  );
+
+  const handleResetFormData = () => {
+    setIsFormEditMode(false);
+    setFormData({} as FormData);
+    setCurrentClaimsData(null);
+    setIsSubmitAttempted(false);
+    setExcelFile(null);
+    setShowToast(false);
+  };
+
+  const handleSubmit = async (e) => {
+    hiddenSubmitRef.current.click();
+    e.preventDefault();
+    setIsSubmitAttempted(true);
+    /*   if (!formData?.fromDate) return; */
+    setIsFormSubmitting(true);
+
+    validateClaims(excelFile, false).then((res) => {
+      // get the excel data row i from the response or the current community progress data
+      const responseExcelDataId =
+        res?.result?.data.createApplicationCommunityReportExcelData
+          ?.applicationCommunityReportExcelData?.rowId;
+
+      // get the excel data row id from the current community progress data if it exists
+      const currentExcelDataId = currentClaimsData?.excelDataId;
+
+      // replace the current excel data id if a new excel file was uploaded since the previous data will be archived
+      const excelDataId = responseExcelDataId || currentExcelDataId;
+      console.log(claimsList, excelDataId);
+
+      /// save form data
+      createClaims({
+        variables: {
+          connections: [claimsConnectionId],
+          input: {
+            _jsonData: formData,
+            _applicationId: applicationRowId,
+            _oldClaimsId: currentClaimsData?.rowId,
+            /*             _excelDataId: excelDataId, */
+          },
+        },
+        onCompleted: () => {
+          handleResetFormData();
+          setIsFormSubmitting(false);
+
+          if (res?.status === 200) {
+            setShowToast(true);
+          }
+        },
+        onError: () => {
+          setIsFormSubmitting(false);
+        },
+        updater: (store) => {
+          if (currentClaimsData?.id) {
+            const connection = store.get(claimsConnectionId);
+
+            store.delete(currentClaimsData.id);
+            ConnectionHandler.deleteNode(connection, currentClaimsData.id);
+          }
+        },
+      });
+    });
+  };
+
+  const handleDelete = async () => {
+    // archiveClaims({
+    //   variables: {
+    //     input: {
+    //       _claimsId: currentClaimsData?.rowId,
+    //     },
+    //   },
+    //   updater: (store) => {
+    //     const connection = store.get(claimsConnectionId);
+    //     const claimsConnectionId = currentClaimsData?.__id;
+    //
+    //     store.delete(claimsConnectionId);
+    //     ConnectionHandler.deleteNode(connection, claimsConnectionId);
+    //   },
+    //   onCompleted: () => {
+    //     setShowModal(false);
+    //     setCurrentClaimsData(null);
+    //   },
+    // });
+  };
+
+  return (
+    <>
+      {showToast && (
+        <Toast timeout={5000}>
+          Claims & progress report excel data successfully imported
+        </Toast>
+      )}
+      <Modal
+        open={showModal}
+        onClose={() => {
+          setCurrentClaimsData(null);
+          setShowModal(false);
+        }}
+        title="Delete"
+      >
+        <StyledContainer>
+          <p>
+            Are you sure you want to delete this claim and all accompanying
+            data?
+          </p>
+          <StyledFlex>
+            <Button onClick={handleDelete}>Yes, delete</Button>
+            <Button onClick={() => setShowModal(false)} variant="secondary">
+              No, keep
+            </Button>
+          </StyledFlex>
+        </StyledContainer>
+      </Modal>
+      <StyledProjectForm
+        additionalContext={{
+          applicationId: applicationRowId,
+          validateExcel: validateClaims,
+          excelValidationErrors: claimsValidationErrors,
+        }}
+        schema={claimsSchema}
+        uiSchema={claimsUiSchema}
+        formData={formData}
+        theme={ProjectTheme}
+        onSubmit={handleSubmit}
+        formAnimationHeight={600}
+        isFormAnimated
+        hiddenSubmitRef={hiddenSubmitRef}
+        isFormEditMode={isFormEditMode}
+        setIsFormEditMode={(boolean) => setIsFormEditMode(boolean)}
+        saveBtnText={
+          formData?.claimsFile && excelFile ? 'Save & Import' : 'Save'
+        }
+        title="Claims"
+        handleChange={(e) => {
+          setFormData({ ...e.formData });
+        }}
+        submitting={isFormSubmitting}
+        submittingText="Importing claim data. Please wait."
+        showEditBtn={false}
+        saveBtnDisabled={isFormSubmitting}
+        cancelBtnDisabled={isFormSubmitting}
+        resetFormData={handleResetFormData}
+        liveValidate={isSubmitAttempted}
+        setFormData={setFormData}
+        before={
+          <AddButton
+            isFormEditMode={isFormEditMode}
+            onClick={() => {
+              setIsSubmitAttempted(false);
+              setIsFormEditMode(true);
+            }}
+            title="Add claim"
+          />
+        }
+        saveDataTestId="save-claims data"
+      >
+        map view here
+      </StyledProjectForm>
+    </>
+  );
+};
+
+export default ClaimsForm;

--- a/app/components/Analyst/Project/ProjectForm.tsx
+++ b/app/components/Analyst/Project/ProjectForm.tsx
@@ -126,6 +126,7 @@ interface Props {
   formAnimationHeight?: number;
   formAnimationHeightOffset?: number;
   formData: any;
+  formHeader?: string | React.ReactNode | JSX.Element;
   handleChange: any;
   showEditBtn?: boolean;
   /** The hidden submit button's ref, used to enforce validation on the form
@@ -156,6 +157,7 @@ const ProjectForm: React.FC<Props> = ({
   before,
   children,
   formData,
+  formHeader,
   handleChange,
   hiddenSubmitRef,
   showEditBtn = true,
@@ -261,6 +263,7 @@ const ProjectForm: React.FC<Props> = ({
           overflow={overflow}
         >
           {before}
+          {formHeader}
           {submitting ? (
             <LoadingContainer>
               <LoadingItem>

--- a/app/formSchema/analyst/claims.ts
+++ b/app/formSchema/analyst/claims.ts
@@ -1,0 +1,21 @@
+import { JSONSchema7 } from 'json-schema';
+
+const claims: JSONSchema7 = {
+  required: ['dueDate'],
+  properties: {
+    fromDate: {
+      title: 'From',
+      type: 'string',
+    },
+    toDate: {
+      title: 'To',
+      type: 'string',
+    },
+    claimsFile: {
+      title: 'Upload the completed claims & progress report',
+      type: 'string',
+    },
+  },
+};
+
+export default claims;

--- a/app/formSchema/uiSchema/analyst/claimsUiSchema.ts
+++ b/app/formSchema/uiSchema/analyst/claimsUiSchema.ts
@@ -8,8 +8,6 @@ const claimsUiSchema = {
     'ui:widget': 'DatePickerWidget',
   },
   claimsFile: {
-    'ui:title':
-      'Claims & progress reports are submitted by recipients for incurred or paid expenses during the previous quarter(s). While they are due 45 days after that quarter ends, recipients do not always submit claim & progress reports every quarter. \nAll processing of claims takes place outside of the CCBC portal. After a claim is processed and paid, please upload the finalized and completed claim Excel file here.',
     'ui:widget': 'ExcelImportFileWidget',
     'ui:options': {
       excelImport: {

--- a/app/formSchema/uiSchema/analyst/claimsUiSchema.ts
+++ b/app/formSchema/uiSchema/analyst/claimsUiSchema.ts
@@ -1,0 +1,30 @@
+const claimsUiSchema = {
+  fromDate: {
+    'ui:title': 'From',
+    'ui:widget': 'DatePickerWidget',
+  },
+  toDate: {
+    'ui:title': 'To',
+    'ui:widget': 'DatePickerWidget',
+  },
+  claimsFile: {
+    'ui:title':
+      'Claims & progress reports are submitted by recipients for incurred or paid expenses during the previous quarter(s). While they are due 45 days after that quarter ends, recipients do not always submit claim & progress reports every quarter. \nAll processing of claims takes place outside of the CCBC portal. After a claim is processed and paid, please upload the finalized and completed claim Excel file here.',
+    'ui:widget': 'ExcelImportFileWidget',
+    'ui:options': {
+      excelImport: {
+        successHeading: 'Community Progress Report Data table match database',
+        errorType: 'communityProgressImportFailed',
+      },
+    },
+  },
+  'ui:inline': [
+    {
+      columns: 6,
+      fromDate: 1,
+      toDate: 2,
+    },
+  ],
+};
+
+export default claimsUiSchema;

--- a/app/pages/analyst/application/[applicationId]/project.tsx
+++ b/app/pages/analyst/application/[applicationId]/project.tsx
@@ -10,6 +10,7 @@ import ConditionalApprovalForm from 'components/Analyst/Project/ConditionalAppro
 import AnnouncementsForm from 'components/Analyst/Project/Announcements/AnnouncementsForm';
 import ProjectInformationForm from 'components/Analyst/Project/ProjectInformation/ProjectInformationForm';
 import CommunityProgressReportForm from 'components/Analyst/Project/CommunityProgressReport/CommunityProgressReportForm';
+import ClaimsForm from 'components/Analyst/Project/Claims/ClaimsForm';
 
 const getProjectQuery = graphql`
   query projectQuery($rowId: Int!) {
@@ -21,6 +22,7 @@ const getProjectQuery = graphql`
       ...ConditionalApprovalForm_application
       ...ProjectInformationForm_application
       ...CommunityProgressReportForm_application
+      ...ClaimsForm_application
     }
     ...AnalystLayout_query
     ...AnnouncementsForm_query
@@ -39,6 +41,8 @@ const Project = ({
   const showCommunityProgressReport = useFeature(
     'show_community_progress_report'
   ).value;
+  const showClaims = useFeature('show_claims').value;
+  console.log('showClaims', showClaims);
 
   return (
     <Layout session={session} title="Connecting Communities BC">
@@ -53,6 +57,7 @@ const Project = ({
         {showCommunityProgressReport && (
           <CommunityProgressReportForm application={applicationByRowId} />
         )}
+        {showClaims && <ClaimsForm application={applicationByRowId} />}
       </AnalystLayout>
     </Layout>
   );

--- a/app/postgraphile.tags.json5
+++ b/app/postgraphile.tags.json5
@@ -52,6 +52,11 @@
           omit: ['create', 'delete'],
         },
       },
+      'ccbc_public.application_claims_excel_data': {
+        tags: {
+          omit: ['create', 'delete'],
+        },
+      },
     },
     procedure: {
       'ccbc_public.application_analyst_lead': {

--- a/app/postgraphile.tags.json5
+++ b/app/postgraphile.tags.json5
@@ -47,6 +47,11 @@
           omit: ['create', 'delete'],
         },
       },
+      'ccbc_public.application_claims_data': {
+        tags: {
+          omit: ['create', 'delete'],
+        },
+      },
     },
     procedure: {
       'ccbc_public.application_analyst_lead': {

--- a/app/schema/mutations/project/createClaimsData.ts
+++ b/app/schema/mutations/project/createClaimsData.ts
@@ -1,0 +1,28 @@
+import { graphql } from 'react-relay';
+import { createClaimsDataMutation } from '__generated__/createClaimsDataMutation.graphql';
+import useMutationWithErrorMessage from '../useMutationWithErrorMessage';
+
+const mutation = graphql`
+  mutation createClaimsDataMutation(
+    $connections: [ID!]!
+    $input: CreateApplicationClaimsDataInput!
+  ) {
+    createApplicationClaimsData(input: $input) {
+      applicationClaimsDataEdge @appendEdge(connections: $connections) {
+        node {
+          id
+          jsonData
+          rowId
+        }
+      }
+    }
+  }
+`;
+
+const useCreateClaimsMutation = () =>
+  useMutationWithErrorMessage<createClaimsDataMutation>(
+    mutation,
+    () => 'An error occurred while attempting to create the claims'
+  );
+
+export { mutation, useCreateClaimsMutation };

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -226,6 +226,42 @@ type Query implements Node {
   ): ApplicationClaimsDataConnection
 
   """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  allApplicationClaimsExcelData(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection
+
+  """
   Reads and enables pagination through a set of `ApplicationCommunityProgressReportData`.
   """
   allApplicationCommunityProgressReportData(
@@ -1330,6 +1366,7 @@ type Query implements Node {
   applicationAnalystLeadByRowId(rowId: Int!): ApplicationAnalystLead
   applicationAnnouncementByAnnouncementIdAndApplicationId(announcementId: Int!, applicationId: Int!): ApplicationAnnouncement
   applicationClaimsDataByRowId(rowId: Int!): ApplicationClaimsData
+  applicationClaimsExcelDataByRowId(rowId: Int!): ApplicationClaimsExcelData
   applicationCommunityProgressReportDataByRowId(rowId: Int!): ApplicationCommunityProgressReportData
   applicationCommunityReportExcelDataByRowId(rowId: Int!): ApplicationCommunityReportExcelData
   applicationFormDataByFormDataIdAndApplicationId(formDataId: Int!, applicationId: Int!): ApplicationFormData
@@ -1449,6 +1486,16 @@ type Query implements Node {
     """
     id: ID!
   ): ApplicationClaimsData
+
+  """
+  Reads a single `ApplicationClaimsExcelData` using its globally unique `ID`.
+  """
+  applicationClaimsExcelData(
+    """
+    The globally unique `ID` to be used in selecting a single `ApplicationClaimsExcelData`.
+    """
+    id: ID!
+  ): ApplicationClaimsExcelData
 
   """
   Reads a single `ApplicationCommunityProgressReportData` using its globally unique `ID`.
@@ -4720,6 +4767,114 @@ type CcbcUser implements Node {
     """
     filter: ApplicationClaimsDataFilter
   ): ApplicationClaimsDataConnection!
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
 
   """Reads and enables pagination through a set of `CcbcUser`."""
   ccbcUsersByCcbcUserCreatedByAndUpdatedBy(
@@ -12982,6 +13137,312 @@ type CcbcUser implements Node {
     """
     filter: CcbcUserFilter
   ): CcbcUserCcbcUsersByApplicationClaimsDataArchivedByAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `Application`."""
+  applicationsByApplicationClaimsExcelDataCreatedByAndApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Application`."""
+    orderBy: [ApplicationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationFilter
+  ): CcbcUserApplicationsByApplicationClaimsExcelDataCreatedByAndApplicationIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsExcelDataCreatedByAndUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationClaimsExcelDataCreatedByAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsExcelDataCreatedByAndArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationClaimsExcelDataCreatedByAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `Application`."""
+  applicationsByApplicationClaimsExcelDataUpdatedByAndApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Application`."""
+    orderBy: [ApplicationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationFilter
+  ): CcbcUserApplicationsByApplicationClaimsExcelDataUpdatedByAndApplicationIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsExcelDataUpdatedByAndCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationClaimsExcelDataUpdatedByAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsExcelDataUpdatedByAndArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationClaimsExcelDataUpdatedByAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `Application`."""
+  applicationsByApplicationClaimsExcelDataArchivedByAndApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Application`."""
+    orderBy: [ApplicationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationFilter
+  ): CcbcUserApplicationsByApplicationClaimsExcelDataArchivedByAndApplicationIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsExcelDataArchivedByAndCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationClaimsExcelDataArchivedByAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsExcelDataArchivedByAndUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationClaimsExcelDataArchivedByAndUpdatedByManyToManyConnection!
 }
 
 """A connection to a list of `CcbcUser` values."""
@@ -13635,6 +14096,30 @@ input CcbcUserFilter {
   """Some related `applicationClaimsDataByArchivedBy` exist."""
   applicationClaimsDataByArchivedByExist: Boolean
 
+  """
+  Filter by the object’s `applicationClaimsExcelDataByCreatedBy` relation.
+  """
+  applicationClaimsExcelDataByCreatedBy: CcbcUserToManyApplicationClaimsExcelDataFilter
+
+  """Some related `applicationClaimsExcelDataByCreatedBy` exist."""
+  applicationClaimsExcelDataByCreatedByExist: Boolean
+
+  """
+  Filter by the object’s `applicationClaimsExcelDataByUpdatedBy` relation.
+  """
+  applicationClaimsExcelDataByUpdatedBy: CcbcUserToManyApplicationClaimsExcelDataFilter
+
+  """Some related `applicationClaimsExcelDataByUpdatedBy` exist."""
+  applicationClaimsExcelDataByUpdatedByExist: Boolean
+
+  """
+  Filter by the object’s `applicationClaimsExcelDataByArchivedBy` relation.
+  """
+  applicationClaimsExcelDataByArchivedBy: CcbcUserToManyApplicationClaimsExcelDataFilter
+
+  """Some related `applicationClaimsExcelDataByArchivedBy` exist."""
+  applicationClaimsExcelDataByArchivedByExist: Boolean
+
   """Filter by the object’s `keycloakJwtsBySub` relation."""
   keycloakJwtsBySub: CcbcUserToManyKeycloakJwtFilter
 
@@ -14267,6 +14752,14 @@ input ApplicationFilter {
 
   """Some related `applicationClaimsDataByApplicationId` exist."""
   applicationClaimsDataByApplicationIdExist: Boolean
+
+  """
+  Filter by the object’s `applicationClaimsExcelDataByApplicationId` relation.
+  """
+  applicationClaimsExcelDataByApplicationId: ApplicationToManyApplicationClaimsExcelDataFilter
+
+  """Some related `applicationClaimsExcelDataByApplicationId` exist."""
+  applicationClaimsExcelDataByApplicationIdExist: Boolean
 
   """Filter by the object’s `intakeByIntakeId` relation."""
   intakeByIntakeId: IntakeFilter
@@ -17014,6 +17507,9 @@ input ApplicationClaimsDataFilter {
   """Filter by the object’s `jsonData` field."""
   jsonData: JSONFilter
 
+  """Filter by the object’s `excelDataId` field."""
+  excelDataId: IntFilter
+
   """Filter by the object’s `createdBy` field."""
   createdBy: IntFilter
 
@@ -17064,6 +17560,91 @@ input ApplicationClaimsDataFilter {
 
   """Negates the expression."""
   not: ApplicationClaimsDataFilter
+}
+
+"""
+A filter to be used against many `ApplicationClaimsExcelData` object types. All fields are combined with a logical ‘and.’
+"""
+input ApplicationToManyApplicationClaimsExcelDataFilter {
+  """
+  Every related `ApplicationClaimsExcelData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  every: ApplicationClaimsExcelDataFilter
+
+  """
+  Some related `ApplicationClaimsExcelData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  some: ApplicationClaimsExcelDataFilter
+
+  """
+  No related `ApplicationClaimsExcelData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  none: ApplicationClaimsExcelDataFilter
+}
+
+"""
+A filter to be used against `ApplicationClaimsExcelData` object types. All fields are combined with a logical ‘and.’
+"""
+input ApplicationClaimsExcelDataFilter {
+  """Filter by the object’s `rowId` field."""
+  rowId: IntFilter
+
+  """Filter by the object’s `applicationId` field."""
+  applicationId: IntFilter
+
+  """Filter by the object’s `jsonData` field."""
+  jsonData: JSONFilter
+
+  """Filter by the object’s `createdBy` field."""
+  createdBy: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedBy` field."""
+  updatedBy: IntFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `archivedBy` field."""
+  archivedBy: IntFilter
+
+  """Filter by the object’s `archivedAt` field."""
+  archivedAt: DatetimeFilter
+
+  """Filter by the object’s `applicationByApplicationId` relation."""
+  applicationByApplicationId: ApplicationFilter
+
+  """A related `applicationByApplicationId` exists."""
+  applicationByApplicationIdExists: Boolean
+
+  """Filter by the object’s `ccbcUserByCreatedBy` relation."""
+  ccbcUserByCreatedBy: CcbcUserFilter
+
+  """A related `ccbcUserByCreatedBy` exists."""
+  ccbcUserByCreatedByExists: Boolean
+
+  """Filter by the object’s `ccbcUserByUpdatedBy` relation."""
+  ccbcUserByUpdatedBy: CcbcUserFilter
+
+  """A related `ccbcUserByUpdatedBy` exists."""
+  ccbcUserByUpdatedByExists: Boolean
+
+  """Filter by the object’s `ccbcUserByArchivedBy` relation."""
+  ccbcUserByArchivedBy: CcbcUserFilter
+
+  """A related `ccbcUserByArchivedBy` exists."""
+  ccbcUserByArchivedByExists: Boolean
+
+  """Checks for all expressions in this list."""
+  and: [ApplicationClaimsExcelDataFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ApplicationClaimsExcelDataFilter!]
+
+  """Negates the expression."""
+  not: ApplicationClaimsExcelDataFilter
 }
 
 """
@@ -17811,6 +18392,26 @@ input CcbcUserToManyApplicationClaimsDataFilter {
   No related `ApplicationClaimsData` matches the filter criteria. All fields are combined with a logical ‘and.’
   """
   none: ApplicationClaimsDataFilter
+}
+
+"""
+A filter to be used against many `ApplicationClaimsExcelData` object types. All fields are combined with a logical ‘and.’
+"""
+input CcbcUserToManyApplicationClaimsExcelDataFilter {
+  """
+  Every related `ApplicationClaimsExcelData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  every: ApplicationClaimsExcelDataFilter
+
+  """
+  Some related `ApplicationClaimsExcelData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  some: ApplicationClaimsExcelDataFilter
+
+  """
+  No related `ApplicationClaimsExcelData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  none: ApplicationClaimsExcelDataFilter
 }
 
 """
@@ -19273,6 +19874,42 @@ type Application implements Node {
     """
     filter: ApplicationClaimsDataFilter
   ): ApplicationClaimsDataConnection!
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
 
   """Reads and enables pagination through a set of `AssessmentData`."""
   allAssessments(
@@ -21116,6 +21753,108 @@ type Application implements Node {
     """
     filter: CcbcUserFilter
   ): ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsExcelDataApplicationIdAndCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): ApplicationCcbcUsersByApplicationClaimsExcelDataApplicationIdAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsExcelDataApplicationIdAndUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): ApplicationCcbcUsersByApplicationClaimsExcelDataApplicationIdAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsExcelDataApplicationIdAndArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): ApplicationCcbcUsersByApplicationClaimsExcelDataApplicationIdAndArchivedByManyToManyConnection!
 }
 
 """A connection to a list of `ApplicationStatus` values."""
@@ -29305,16 +30044,17 @@ type ApplicationClaimsData implements Node {
   """
   id: ID!
 
-  """Unique ID for the claims"""
+  """Unique id for the claims"""
   rowId: Int!
 
   """Id of the application the claims belongs to"""
   applicationId: Int
 
-  """
-  The due date, date received and the file information of the claims Excel file
-  """
+  """The claims form json data"""
   jsonData: JSON!
+
+  """The id of the excel data that this record is associated with"""
+  excelDataId: Int
 
   """created by user id"""
   createdBy: Int
@@ -29373,6 +30113,8 @@ enum ApplicationClaimsDataOrderBy {
   APPLICATION_ID_DESC
   JSON_DATA_ASC
   JSON_DATA_DESC
+  EXCEL_DATA_ID_ASC
+  EXCEL_DATA_ID_DESC
   CREATED_BY_ASC
   CREATED_BY_DESC
   CREATED_AT_ASC
@@ -29394,6 +30136,150 @@ A condition to be used against `ApplicationClaimsData` object types. All fields
 are tested for equality and combined with a logical ‘and.’
 """
 input ApplicationClaimsDataCondition {
+  """Checks for equality with the object’s `rowId` field."""
+  rowId: Int
+
+  """Checks for equality with the object’s `applicationId` field."""
+  applicationId: Int
+
+  """Checks for equality with the object’s `jsonData` field."""
+  jsonData: JSON
+
+  """Checks for equality with the object’s `excelDataId` field."""
+  excelDataId: Int
+
+  """Checks for equality with the object’s `createdBy` field."""
+  createdBy: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedBy` field."""
+  updatedBy: Int
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `archivedBy` field."""
+  archivedBy: Int
+
+  """Checks for equality with the object’s `archivedAt` field."""
+  archivedAt: Datetime
+}
+
+"""A connection to a list of `ApplicationClaimsExcelData` values."""
+type ApplicationClaimsExcelDataConnection {
+  """A list of `ApplicationClaimsExcelData` objects."""
+  nodes: [ApplicationClaimsExcelData]!
+
+  """
+  A list of edges which contains the `ApplicationClaimsExcelData` and cursor to aid in pagination.
+  """
+  edges: [ApplicationClaimsExcelDataEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ApplicationClaimsExcelData` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""Table containing the claims excel data for the given application"""
+type ApplicationClaimsExcelData implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  id: ID!
+
+  """Unique ID for the claims excel data"""
+  rowId: Int!
+
+  """ID of the application this data belongs to"""
+  applicationId: Int
+
+  """The data imported from the excel filled by the respondent"""
+  jsonData: JSON!
+
+  """created by user id"""
+  createdBy: Int
+
+  """created at timestamp"""
+  createdAt: Datetime!
+
+  """updated by user id"""
+  updatedBy: Int
+
+  """updated at timestamp"""
+  updatedAt: Datetime!
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """archived at timestamp"""
+  archivedAt: Datetime
+
+  """
+  Reads a single `Application` that is related to this `ApplicationClaimsExcelData`.
+  """
+  applicationByApplicationId: Application
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsExcelData`.
+  """
+  ccbcUserByCreatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsExcelData`.
+  """
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsExcelData`.
+  """
+  ccbcUserByArchivedBy: CcbcUser
+}
+
+"""A `ApplicationClaimsExcelData` edge in the connection."""
+type ApplicationClaimsExcelDataEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ApplicationClaimsExcelData` at the end of the edge."""
+  node: ApplicationClaimsExcelData
+}
+
+"""Methods to use when ordering `ApplicationClaimsExcelData`."""
+enum ApplicationClaimsExcelDataOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  APPLICATION_ID_ASC
+  APPLICATION_ID_DESC
+  JSON_DATA_ASC
+  JSON_DATA_DESC
+  CREATED_BY_ASC
+  CREATED_BY_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_BY_ASC
+  UPDATED_BY_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  ARCHIVED_BY_ASC
+  ARCHIVED_BY_DESC
+  ARCHIVED_AT_ASC
+  ARCHIVED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `ApplicationClaimsExcelData` object types. All
+fields are tested for equality and combined with a logical ‘and.’
+"""
+input ApplicationClaimsExcelDataCondition {
   """Checks for equality with the object’s `rowId` field."""
   rowId: Int
 
@@ -32960,6 +33846,204 @@ type ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndArchivedByManyTo
     """
     filter: ApplicationClaimsDataFilter
   ): ApplicationClaimsDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsExcelData`.
+"""
+type ApplicationCcbcUsersByApplicationClaimsExcelDataApplicationIdAndCreatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsExcelData`, and the cursor to aid in pagination.
+  """
+  edges: [ApplicationCcbcUsersByApplicationClaimsExcelDataApplicationIdAndCreatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsExcelData`.
+"""
+type ApplicationCcbcUsersByApplicationClaimsExcelDataApplicationIdAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsExcelData`.
+"""
+type ApplicationCcbcUsersByApplicationClaimsExcelDataApplicationIdAndUpdatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsExcelData`, and the cursor to aid in pagination.
+  """
+  edges: [ApplicationCcbcUsersByApplicationClaimsExcelDataApplicationIdAndUpdatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsExcelData`.
+"""
+type ApplicationCcbcUsersByApplicationClaimsExcelDataApplicationIdAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsExcelData`.
+"""
+type ApplicationCcbcUsersByApplicationClaimsExcelDataApplicationIdAndArchivedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsExcelData`, and the cursor to aid in pagination.
+  """
+  edges: [ApplicationCcbcUsersByApplicationClaimsExcelDataApplicationIdAndArchivedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsExcelData`.
+"""
+type ApplicationCcbcUsersByApplicationClaimsExcelDataApplicationIdAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
 }
 
 """A `Application` edge in the connection."""
@@ -48833,6 +49917,600 @@ type CcbcUserCcbcUsersByApplicationClaimsDataArchivedByAndUpdatedByManyToManyEdg
 }
 
 """
+A connection to a list of `Application` values, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserApplicationsByApplicationClaimsExcelDataCreatedByAndApplicationIdManyToManyConnection {
+  """A list of `Application` objects."""
+  nodes: [Application]!
+
+  """
+  A list of edges which contains the `Application`, info from the `ApplicationClaimsExcelData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserApplicationsByApplicationClaimsExcelDataCreatedByAndApplicationIdManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Application` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `Application` edge in the connection, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserApplicationsByApplicationClaimsExcelDataCreatedByAndApplicationIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Application` at the end of the edge."""
+  node: Application
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsExcelDataCreatedByAndUpdatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsExcelData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationClaimsExcelDataCreatedByAndUpdatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsExcelDataCreatedByAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsExcelDataCreatedByAndArchivedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsExcelData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationClaimsExcelDataCreatedByAndArchivedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsExcelDataCreatedByAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+}
+
+"""
+A connection to a list of `Application` values, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserApplicationsByApplicationClaimsExcelDataUpdatedByAndApplicationIdManyToManyConnection {
+  """A list of `Application` objects."""
+  nodes: [Application]!
+
+  """
+  A list of edges which contains the `Application`, info from the `ApplicationClaimsExcelData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserApplicationsByApplicationClaimsExcelDataUpdatedByAndApplicationIdManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Application` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `Application` edge in the connection, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserApplicationsByApplicationClaimsExcelDataUpdatedByAndApplicationIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Application` at the end of the edge."""
+  node: Application
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsExcelDataUpdatedByAndCreatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsExcelData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationClaimsExcelDataUpdatedByAndCreatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsExcelDataUpdatedByAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsExcelDataUpdatedByAndArchivedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsExcelData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationClaimsExcelDataUpdatedByAndArchivedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsExcelDataUpdatedByAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+}
+
+"""
+A connection to a list of `Application` values, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserApplicationsByApplicationClaimsExcelDataArchivedByAndApplicationIdManyToManyConnection {
+  """A list of `Application` objects."""
+  nodes: [Application]!
+
+  """
+  A list of edges which contains the `Application`, info from the `ApplicationClaimsExcelData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserApplicationsByApplicationClaimsExcelDataArchivedByAndApplicationIdManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Application` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `Application` edge in the connection, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserApplicationsByApplicationClaimsExcelDataArchivedByAndApplicationIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Application` at the end of the edge."""
+  node: Application
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsExcelDataArchivedByAndCreatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsExcelData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationClaimsExcelDataArchivedByAndCreatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsExcelDataArchivedByAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsExcelDataArchivedByAndUpdatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsExcelData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationClaimsExcelDataArchivedByAndUpdatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsExcelData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsExcelDataArchivedByAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationClaimsExcelData`.
+  """
+  applicationClaimsExcelDataByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsExcelDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsExcelDataFilter
+  ): ApplicationClaimsExcelDataConnection!
+}
+
+"""
 A connection to a list of `Application` values, with data from `ApplicationAnalystLead`.
 """
 type AnalystApplicationsByApplicationAnalystLeadAnalystIdAndApplicationIdManyToManyConnection {
@@ -49947,6 +51625,26 @@ type Mutation {
   ): UpdateApplicationClaimsDataPayload
 
   """
+  Updates a single `ApplicationClaimsExcelData` using its globally unique id and a patch.
+  """
+  updateApplicationClaimsExcelData(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateApplicationClaimsExcelDataInput!
+  ): UpdateApplicationClaimsExcelDataPayload
+
+  """
+  Updates a single `ApplicationClaimsExcelData` using a unique key and a patch.
+  """
+  updateApplicationClaimsExcelDataByRowId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateApplicationClaimsExcelDataByRowIdInput!
+  ): UpdateApplicationClaimsExcelDataPayload
+
+  """
   Updates a single `ApplicationCommunityProgressReportData` using its globally unique id and a patch.
   """
   updateApplicationCommunityProgressReportData(
@@ -51051,6 +52749,12 @@ type Mutation {
     """
     input: CreateApplicationClaimsDataInput!
   ): CreateApplicationClaimsDataPayload
+  createApplicationClaimsExcelData(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateApplicationClaimsExcelDataInput!
+  ): CreateApplicationClaimsExcelDataPayload
   createApplicationCommunityProgressReportData(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -53992,10 +55696,11 @@ input ApplicationClaimsDataPatch {
   """Id of the application the claims belongs to"""
   applicationId: Int
 
-  """
-  The due date, date received and the file information of the claims Excel file
-  """
+  """The claims form json data"""
   jsonData: JSON
+
+  """The id of the excel data that this record is associated with"""
+  excelDataId: Int
 
   """created by user id"""
   createdBy: Int
@@ -54029,7 +55734,115 @@ input UpdateApplicationClaimsDataByRowIdInput {
   """
   applicationClaimsDataPatch: ApplicationClaimsDataPatch!
 
-  """Unique ID for the claims"""
+  """Unique id for the claims"""
+  rowId: Int!
+}
+
+"""The output of our update `ApplicationClaimsExcelData` mutation."""
+type UpdateApplicationClaimsExcelDataPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `ApplicationClaimsExcelData` that was updated by this mutation."""
+  applicationClaimsExcelData: ApplicationClaimsExcelData
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Application` that is related to this `ApplicationClaimsExcelData`.
+  """
+  applicationByApplicationId: Application
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsExcelData`.
+  """
+  ccbcUserByCreatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsExcelData`.
+  """
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsExcelData`.
+  """
+  ccbcUserByArchivedBy: CcbcUser
+
+  """An edge for our `ApplicationClaimsExcelData`. May be used by Relay 1."""
+  applicationClaimsExcelDataEdge(
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ApplicationClaimsExcelDataEdge
+}
+
+"""All input for the `updateApplicationClaimsExcelData` mutation."""
+input UpdateApplicationClaimsExcelDataInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `ApplicationClaimsExcelData` to be updated.
+  """
+  id: ID!
+
+  """
+  An object where the defined keys will be set on the `ApplicationClaimsExcelData` being updated.
+  """
+  applicationClaimsExcelDataPatch: ApplicationClaimsExcelDataPatch!
+}
+
+"""
+Represents an update to a `ApplicationClaimsExcelData`. Fields that are set will be updated.
+"""
+input ApplicationClaimsExcelDataPatch {
+  """ID of the application this data belongs to"""
+  applicationId: Int
+
+  """The data imported from the excel filled by the respondent"""
+  jsonData: JSON
+
+  """created by user id"""
+  createdBy: Int
+
+  """created at timestamp"""
+  createdAt: Datetime
+
+  """updated by user id"""
+  updatedBy: Int
+
+  """updated at timestamp"""
+  updatedAt: Datetime
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """archived at timestamp"""
+  archivedAt: Datetime
+}
+
+"""All input for the `updateApplicationClaimsExcelDataByRowId` mutation."""
+input UpdateApplicationClaimsExcelDataByRowIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `ApplicationClaimsExcelData` being updated.
+  """
+  applicationClaimsExcelDataPatch: ApplicationClaimsExcelDataPatch!
+
+  """Unique ID for the claims excel data"""
   rowId: Int!
 }
 
@@ -59130,6 +60943,60 @@ input CreateApplicationClaimsDataInput {
   _applicationId: Int!
   _jsonData: JSON!
   _oldClaimsId: Int
+  _excelDataId: Int
+}
+
+"""The output of our `createApplicationClaimsExcelData` mutation."""
+type CreateApplicationClaimsExcelDataPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  applicationClaimsExcelData: ApplicationClaimsExcelData
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Application` that is related to this `ApplicationClaimsExcelData`.
+  """
+  applicationByApplicationId: Application
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsExcelData`.
+  """
+  ccbcUserByCreatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsExcelData`.
+  """
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsExcelData`.
+  """
+  ccbcUserByArchivedBy: CcbcUser
+
+  """An edge for our `ApplicationClaimsExcelData`. May be used by Relay 1."""
+  applicationClaimsExcelDataEdge(
+    """The method to use when ordering `ApplicationClaimsExcelData`."""
+    orderBy: [ApplicationClaimsExcelDataOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ApplicationClaimsExcelDataEdge
+}
+
+"""All input for the `createApplicationClaimsExcelData` mutation."""
+input CreateApplicationClaimsExcelDataInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  _applicationId: Int!
+  _jsonData: JSON!
+  _oldId: Int
 }
 
 """

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -191,6 +191,40 @@ type Query implements Node {
     filter: ApplicationAnnouncementFilter
   ): ApplicationAnnouncementsConnection
 
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  allApplicationClaimsData(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection
+
   """
   Reads and enables pagination through a set of `ApplicationCommunityProgressReportData`.
   """
@@ -1295,6 +1329,7 @@ type Query implements Node {
   applicationByRowId(rowId: Int!): Application
   applicationAnalystLeadByRowId(rowId: Int!): ApplicationAnalystLead
   applicationAnnouncementByAnnouncementIdAndApplicationId(announcementId: Int!, applicationId: Int!): ApplicationAnnouncement
+  applicationClaimsDataByRowId(rowId: Int!): ApplicationClaimsData
   applicationCommunityProgressReportDataByRowId(rowId: Int!): ApplicationCommunityProgressReportData
   applicationCommunityReportExcelDataByRowId(rowId: Int!): ApplicationCommunityReportExcelData
   applicationFormDataByFormDataIdAndApplicationId(formDataId: Int!, applicationId: Int!): ApplicationFormData
@@ -1406,6 +1441,14 @@ type Query implements Node {
     """
     id: ID!
   ): ApplicationAnnouncement
+
+  """Reads a single `ApplicationClaimsData` using its globally unique `ID`."""
+  applicationClaimsData(
+    """
+    The globally unique `ID` to be used in selecting a single `ApplicationClaimsData`.
+    """
+    id: ID!
+  ): ApplicationClaimsData
 
   """
   Reads a single `ApplicationCommunityProgressReportData` using its globally unique `ID`.
@@ -4575,6 +4618,108 @@ type CcbcUser implements Node {
     """
     filter: ApplicationCommunityReportExcelDataFilter
   ): ApplicationCommunityReportExcelDataConnection!
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
 
   """Reads and enables pagination through a set of `CcbcUser`."""
   ccbcUsersByCcbcUserCreatedByAndUpdatedBy(
@@ -12531,6 +12676,312 @@ type CcbcUser implements Node {
     """
     filter: CcbcUserFilter
   ): CcbcUserCcbcUsersByApplicationCommunityReportExcelDataArchivedByAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `Application`."""
+  applicationsByApplicationClaimsDataCreatedByAndApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Application`."""
+    orderBy: [ApplicationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationFilter
+  ): CcbcUserApplicationsByApplicationClaimsDataCreatedByAndApplicationIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsDataCreatedByAndUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationClaimsDataCreatedByAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsDataCreatedByAndArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationClaimsDataCreatedByAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `Application`."""
+  applicationsByApplicationClaimsDataUpdatedByAndApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Application`."""
+    orderBy: [ApplicationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationFilter
+  ): CcbcUserApplicationsByApplicationClaimsDataUpdatedByAndApplicationIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsDataUpdatedByAndCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationClaimsDataUpdatedByAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsDataUpdatedByAndArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationClaimsDataUpdatedByAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `Application`."""
+  applicationsByApplicationClaimsDataArchivedByAndApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Application`."""
+    orderBy: [ApplicationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationFilter
+  ): CcbcUserApplicationsByApplicationClaimsDataArchivedByAndApplicationIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsDataArchivedByAndCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationClaimsDataArchivedByAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsDataArchivedByAndUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationClaimsDataArchivedByAndUpdatedByManyToManyConnection!
 }
 
 """A connection to a list of `CcbcUser` values."""
@@ -13166,6 +13617,24 @@ input CcbcUserFilter {
   """Some related `applicationCommunityReportExcelDataByArchivedBy` exist."""
   applicationCommunityReportExcelDataByArchivedByExist: Boolean
 
+  """Filter by the object’s `applicationClaimsDataByCreatedBy` relation."""
+  applicationClaimsDataByCreatedBy: CcbcUserToManyApplicationClaimsDataFilter
+
+  """Some related `applicationClaimsDataByCreatedBy` exist."""
+  applicationClaimsDataByCreatedByExist: Boolean
+
+  """Filter by the object’s `applicationClaimsDataByUpdatedBy` relation."""
+  applicationClaimsDataByUpdatedBy: CcbcUserToManyApplicationClaimsDataFilter
+
+  """Some related `applicationClaimsDataByUpdatedBy` exist."""
+  applicationClaimsDataByUpdatedByExist: Boolean
+
+  """Filter by the object’s `applicationClaimsDataByArchivedBy` relation."""
+  applicationClaimsDataByArchivedBy: CcbcUserToManyApplicationClaimsDataFilter
+
+  """Some related `applicationClaimsDataByArchivedBy` exist."""
+  applicationClaimsDataByArchivedByExist: Boolean
+
   """Filter by the object’s `keycloakJwtsBySub` relation."""
   keycloakJwtsBySub: CcbcUserToManyKeycloakJwtFilter
 
@@ -13790,6 +14259,14 @@ input ApplicationFilter {
   Some related `applicationCommunityReportExcelDataByApplicationId` exist.
   """
   applicationCommunityReportExcelDataByApplicationIdExist: Boolean
+
+  """
+  Filter by the object’s `applicationClaimsDataByApplicationId` relation.
+  """
+  applicationClaimsDataByApplicationId: ApplicationToManyApplicationClaimsDataFilter
+
+  """Some related `applicationClaimsDataByApplicationId` exist."""
+  applicationClaimsDataByApplicationIdExist: Boolean
 
   """Filter by the object’s `intakeByIntakeId` relation."""
   intakeByIntakeId: IntakeFilter
@@ -16505,6 +16982,91 @@ input ApplicationCommunityReportExcelDataFilter {
 }
 
 """
+A filter to be used against many `ApplicationClaimsData` object types. All fields are combined with a logical ‘and.’
+"""
+input ApplicationToManyApplicationClaimsDataFilter {
+  """
+  Every related `ApplicationClaimsData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  every: ApplicationClaimsDataFilter
+
+  """
+  Some related `ApplicationClaimsData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  some: ApplicationClaimsDataFilter
+
+  """
+  No related `ApplicationClaimsData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  none: ApplicationClaimsDataFilter
+}
+
+"""
+A filter to be used against `ApplicationClaimsData` object types. All fields are combined with a logical ‘and.’
+"""
+input ApplicationClaimsDataFilter {
+  """Filter by the object’s `rowId` field."""
+  rowId: IntFilter
+
+  """Filter by the object’s `applicationId` field."""
+  applicationId: IntFilter
+
+  """Filter by the object’s `jsonData` field."""
+  jsonData: JSONFilter
+
+  """Filter by the object’s `createdBy` field."""
+  createdBy: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedBy` field."""
+  updatedBy: IntFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `archivedBy` field."""
+  archivedBy: IntFilter
+
+  """Filter by the object’s `archivedAt` field."""
+  archivedAt: DatetimeFilter
+
+  """Filter by the object’s `applicationByApplicationId` relation."""
+  applicationByApplicationId: ApplicationFilter
+
+  """A related `applicationByApplicationId` exists."""
+  applicationByApplicationIdExists: Boolean
+
+  """Filter by the object’s `ccbcUserByCreatedBy` relation."""
+  ccbcUserByCreatedBy: CcbcUserFilter
+
+  """A related `ccbcUserByCreatedBy` exists."""
+  ccbcUserByCreatedByExists: Boolean
+
+  """Filter by the object’s `ccbcUserByUpdatedBy` relation."""
+  ccbcUserByUpdatedBy: CcbcUserFilter
+
+  """A related `ccbcUserByUpdatedBy` exists."""
+  ccbcUserByUpdatedByExists: Boolean
+
+  """Filter by the object’s `ccbcUserByArchivedBy` relation."""
+  ccbcUserByArchivedBy: CcbcUserFilter
+
+  """A related `ccbcUserByArchivedBy` exists."""
+  ccbcUserByArchivedByExists: Boolean
+
+  """Checks for all expressions in this list."""
+  and: [ApplicationClaimsDataFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ApplicationClaimsDataFilter!]
+
+  """Negates the expression."""
+  not: ApplicationClaimsDataFilter
+}
+
+"""
 A filter to be used against `GaplessCounter` object types. All fields are combined with a logical ‘and.’
 """
 input GaplessCounterFilter {
@@ -17229,6 +17791,26 @@ input CcbcUserToManyApplicationCommunityReportExcelDataFilter {
   No related `ApplicationCommunityReportExcelData` matches the filter criteria. All fields are combined with a logical ‘and.’
   """
   none: ApplicationCommunityReportExcelDataFilter
+}
+
+"""
+A filter to be used against many `ApplicationClaimsData` object types. All fields are combined with a logical ‘and.’
+"""
+input CcbcUserToManyApplicationClaimsDataFilter {
+  """
+  Every related `ApplicationClaimsData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  every: ApplicationClaimsDataFilter
+
+  """
+  Some related `ApplicationClaimsData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  some: ApplicationClaimsDataFilter
+
+  """
+  No related `ApplicationClaimsData` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  none: ApplicationClaimsDataFilter
 }
 
 """
@@ -18657,6 +19239,40 @@ type Application implements Node {
     """
     filter: ApplicationCommunityReportExcelDataFilter
   ): ApplicationCommunityReportExcelDataConnection!
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
 
   """Reads and enables pagination through a set of `AssessmentData`."""
   allAssessments(
@@ -20398,6 +21014,108 @@ type Application implements Node {
     """
     filter: CcbcUserFilter
   ): ApplicationCcbcUsersByApplicationCommunityReportExcelDataApplicationIdAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsDataApplicationIdAndCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsDataApplicationIdAndUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationClaimsDataApplicationIdAndArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndArchivedByManyToManyConnection!
 }
 
 """A connection to a list of `ApplicationStatus` values."""
@@ -28561,6 +29279,149 @@ input ApplicationCommunityReportExcelDataCondition {
   archivedAt: Datetime
 }
 
+"""A connection to a list of `ApplicationClaimsData` values."""
+type ApplicationClaimsDataConnection {
+  """A list of `ApplicationClaimsData` objects."""
+  nodes: [ApplicationClaimsData]!
+
+  """
+  A list of edges which contains the `ApplicationClaimsData` and cursor to aid in pagination.
+  """
+  edges: [ApplicationClaimsDataEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ApplicationClaimsData` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""Table containing the claims data for the given application"""
+type ApplicationClaimsData implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  id: ID!
+
+  """Unique ID for the claims"""
+  rowId: Int!
+
+  """Id of the application the claims belongs to"""
+  applicationId: Int
+
+  """
+  The due date, date received and the file information of the claims Excel file
+  """
+  jsonData: JSON!
+
+  """created by user id"""
+  createdBy: Int
+
+  """created at timestamp"""
+  createdAt: Datetime!
+
+  """updated by user id"""
+  updatedBy: Int
+
+  """updated at timestamp"""
+  updatedAt: Datetime!
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """archived at timestamp"""
+  archivedAt: Datetime
+
+  """
+  Reads a single `Application` that is related to this `ApplicationClaimsData`.
+  """
+  applicationByApplicationId: Application
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsData`.
+  """
+  ccbcUserByCreatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsData`.
+  """
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsData`.
+  """
+  ccbcUserByArchivedBy: CcbcUser
+}
+
+"""A `ApplicationClaimsData` edge in the connection."""
+type ApplicationClaimsDataEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ApplicationClaimsData` at the end of the edge."""
+  node: ApplicationClaimsData
+}
+
+"""Methods to use when ordering `ApplicationClaimsData`."""
+enum ApplicationClaimsDataOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  APPLICATION_ID_ASC
+  APPLICATION_ID_DESC
+  JSON_DATA_ASC
+  JSON_DATA_DESC
+  CREATED_BY_ASC
+  CREATED_BY_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_BY_ASC
+  UPDATED_BY_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  ARCHIVED_BY_ASC
+  ARCHIVED_BY_DESC
+  ARCHIVED_AT_ASC
+  ARCHIVED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `ApplicationClaimsData` object types. All fields
+are tested for equality and combined with a logical ‘and.’
+"""
+input ApplicationClaimsDataCondition {
+  """Checks for equality with the object’s `rowId` field."""
+  rowId: Int
+
+  """Checks for equality with the object’s `applicationId` field."""
+  applicationId: Int
+
+  """Checks for equality with the object’s `jsonData` field."""
+  jsonData: JSON
+
+  """Checks for equality with the object’s `createdBy` field."""
+  createdBy: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedBy` field."""
+  updatedBy: Int
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `archivedBy` field."""
+  archivedBy: Int
+
+  """Checks for equality with the object’s `archivedAt` field."""
+  archivedAt: Datetime
+}
+
 """A connection to a list of `Announcement` values."""
 type AnnouncementsConnection {
   """A list of `Announcement` objects."""
@@ -31907,6 +32768,198 @@ type ApplicationCcbcUsersByApplicationCommunityReportExcelDataApplicationIdAndAr
     """
     filter: ApplicationCommunityReportExcelDataFilter
   ): ApplicationCommunityReportExcelDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsData`.
+"""
+type ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndCreatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsData`, and the cursor to aid in pagination.
+  """
+  edges: [ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndCreatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsData`.
+"""
+type ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsData`.
+"""
+type ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndUpdatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsData`, and the cursor to aid in pagination.
+  """
+  edges: [ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndUpdatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsData`.
+"""
+type ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsData`.
+"""
+type ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndArchivedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsData`, and the cursor to aid in pagination.
+  """
+  edges: [ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndArchivedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsData`.
+"""
+type ApplicationCcbcUsersByApplicationClaimsDataApplicationIdAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
 }
 
 """A `Application` edge in the connection."""
@@ -47204,6 +48257,582 @@ type CcbcUserCcbcUsersByApplicationCommunityReportExcelDataArchivedByAndUpdatedB
 }
 
 """
+A connection to a list of `Application` values, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserApplicationsByApplicationClaimsDataCreatedByAndApplicationIdManyToManyConnection {
+  """A list of `Application` objects."""
+  nodes: [Application]!
+
+  """
+  A list of edges which contains the `Application`, info from the `ApplicationClaimsData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserApplicationsByApplicationClaimsDataCreatedByAndApplicationIdManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Application` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `Application` edge in the connection, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserApplicationsByApplicationClaimsDataCreatedByAndApplicationIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Application` at the end of the edge."""
+  node: Application
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsDataCreatedByAndUpdatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationClaimsDataCreatedByAndUpdatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsDataCreatedByAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsDataCreatedByAndArchivedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationClaimsDataCreatedByAndArchivedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsDataCreatedByAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+}
+
+"""
+A connection to a list of `Application` values, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserApplicationsByApplicationClaimsDataUpdatedByAndApplicationIdManyToManyConnection {
+  """A list of `Application` objects."""
+  nodes: [Application]!
+
+  """
+  A list of edges which contains the `Application`, info from the `ApplicationClaimsData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserApplicationsByApplicationClaimsDataUpdatedByAndApplicationIdManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Application` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `Application` edge in the connection, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserApplicationsByApplicationClaimsDataUpdatedByAndApplicationIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Application` at the end of the edge."""
+  node: Application
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsDataUpdatedByAndCreatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationClaimsDataUpdatedByAndCreatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsDataUpdatedByAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsDataUpdatedByAndArchivedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationClaimsDataUpdatedByAndArchivedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsDataUpdatedByAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+}
+
+"""
+A connection to a list of `Application` values, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserApplicationsByApplicationClaimsDataArchivedByAndApplicationIdManyToManyConnection {
+  """A list of `Application` objects."""
+  nodes: [Application]!
+
+  """
+  A list of edges which contains the `Application`, info from the `ApplicationClaimsData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserApplicationsByApplicationClaimsDataArchivedByAndApplicationIdManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Application` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `Application` edge in the connection, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserApplicationsByApplicationClaimsDataArchivedByAndApplicationIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Application` at the end of the edge."""
+  node: Application
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsDataArchivedByAndCreatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationClaimsDataArchivedByAndCreatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsDataArchivedByAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsDataArchivedByAndUpdatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationClaimsData`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationClaimsDataArchivedByAndUpdatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationClaimsData`.
+"""
+type CcbcUserCcbcUsersByApplicationClaimsDataArchivedByAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """Reads and enables pagination through a set of `ApplicationClaimsData`."""
+  applicationClaimsDataByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationClaimsDataCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationClaimsDataFilter
+  ): ApplicationClaimsDataConnection!
+}
+
+"""
 A connection to a list of `Application` values, with data from `ApplicationAnalystLead`.
 """
 type AnalystApplicationsByApplicationAnalystLeadAnalystIdAndApplicationIdManyToManyConnection {
@@ -48296,6 +49925,26 @@ type Mutation {
     """
     input: UpdateApplicationAnnouncementByAnnouncementIdAndApplicationIdInput!
   ): UpdateApplicationAnnouncementPayload
+
+  """
+  Updates a single `ApplicationClaimsData` using its globally unique id and a patch.
+  """
+  updateApplicationClaimsData(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateApplicationClaimsDataInput!
+  ): UpdateApplicationClaimsDataPayload
+
+  """
+  Updates a single `ApplicationClaimsData` using a unique key and a patch.
+  """
+  updateApplicationClaimsDataByRowId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateApplicationClaimsDataByRowIdInput!
+  ): UpdateApplicationClaimsDataPayload
 
   """
   Updates a single `ApplicationCommunityProgressReportData` using its globally unique id and a patch.
@@ -49396,6 +51045,12 @@ type Mutation {
     """
     input: CreateApplicationInput!
   ): CreateApplicationPayload
+  createApplicationClaimsData(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateApplicationClaimsDataInput!
+  ): CreateApplicationClaimsDataPayload
   createApplicationCommunityProgressReportData(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -52266,6 +53921,116 @@ input UpdateApplicationAnnouncementByAnnouncementIdAndApplicationIdInput {
 
   """The foreign key of an application"""
   applicationId: Int!
+}
+
+"""The output of our update `ApplicationClaimsData` mutation."""
+type UpdateApplicationClaimsDataPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `ApplicationClaimsData` that was updated by this mutation."""
+  applicationClaimsData: ApplicationClaimsData
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Application` that is related to this `ApplicationClaimsData`.
+  """
+  applicationByApplicationId: Application
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsData`.
+  """
+  ccbcUserByCreatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsData`.
+  """
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsData`.
+  """
+  ccbcUserByArchivedBy: CcbcUser
+
+  """An edge for our `ApplicationClaimsData`. May be used by Relay 1."""
+  applicationClaimsDataEdge(
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ApplicationClaimsDataEdge
+}
+
+"""All input for the `updateApplicationClaimsData` mutation."""
+input UpdateApplicationClaimsDataInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `ApplicationClaimsData` to be updated.
+  """
+  id: ID!
+
+  """
+  An object where the defined keys will be set on the `ApplicationClaimsData` being updated.
+  """
+  applicationClaimsDataPatch: ApplicationClaimsDataPatch!
+}
+
+"""
+Represents an update to a `ApplicationClaimsData`. Fields that are set will be updated.
+"""
+input ApplicationClaimsDataPatch {
+  """Id of the application the claims belongs to"""
+  applicationId: Int
+
+  """
+  The due date, date received and the file information of the claims Excel file
+  """
+  jsonData: JSON
+
+  """created by user id"""
+  createdBy: Int
+
+  """created at timestamp"""
+  createdAt: Datetime
+
+  """updated by user id"""
+  updatedBy: Int
+
+  """updated at timestamp"""
+  updatedAt: Datetime
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """archived at timestamp"""
+  archivedAt: Datetime
+}
+
+"""All input for the `updateApplicationClaimsDataByRowId` mutation."""
+input UpdateApplicationClaimsDataByRowIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `ApplicationClaimsData` being updated.
+  """
+  applicationClaimsDataPatch: ApplicationClaimsDataPatch!
+
+  """Unique ID for the claims"""
+  rowId: Int!
 }
 
 """
@@ -57312,6 +59077,59 @@ input CreateApplicationInput {
   payload verbatim. May be used to track mutations by the client.
   """
   clientMutationId: String
+}
+
+"""The output of our `createApplicationClaimsData` mutation."""
+type CreateApplicationClaimsDataPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  applicationClaimsData: ApplicationClaimsData
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Application` that is related to this `ApplicationClaimsData`.
+  """
+  applicationByApplicationId: Application
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsData`.
+  """
+  ccbcUserByCreatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsData`.
+  """
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationClaimsData`.
+  """
+  ccbcUserByArchivedBy: CcbcUser
+
+  """An edge for our `ApplicationClaimsData`. May be used by Relay 1."""
+  applicationClaimsDataEdge(
+    """The method to use when ordering `ApplicationClaimsData`."""
+    orderBy: [ApplicationClaimsDataOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ApplicationClaimsDataEdge
+}
+
+"""All input for the `createApplicationClaimsData` mutation."""
+input CreateApplicationClaimsDataInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  _applicationId: Int!
+  _jsonData: JSON!
+  _oldClaimsId: Int
 }
 
 """

--- a/app/server.ts
+++ b/app/server.ts
@@ -19,6 +19,7 @@ import ssoMiddleware from './backend/lib/sso-middleware';
 import headersMiddleware from './backend/lib/headers';
 import graphQlMiddleware from './backend/lib/graphql';
 import s3download from './backend/lib/s3download';
+import claimsUpload from './backend/lib/claims-upload';
 import communityReportUpload from './backend/lib/community-report-upload';
 import gisUpload from './backend/lib/gis-upload';
 import sowUpload from './backend/lib/sow-upload';
@@ -97,7 +98,12 @@ app.prepare().then(async () => {
 
   server.use(
     unless(
-      ['/api/analyst/sow', '/api/analyst/gis', 'api/analyst/community-report'],
+      [
+        '/api/analyst/sow',
+        '/api/analyst/gis',
+        'api/analyst/community-report',
+        'api/analyst/claims',
+      ],
       graphqlUploadExpress()
     )
   );
@@ -107,6 +113,7 @@ app.prepare().then(async () => {
 
   server.use('/', s3adminArchive);
   server.use('/', s3download);
+  server.use('/', claimsUpload);
   server.use('/', communityReportUpload);
   server.use('/', gisUpload);
   server.use('/', linkPreview);

--- a/app/tests/backend/lib/claims-upload.test.ts
+++ b/app/tests/backend/lib/claims-upload.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment node
+ */
+import { mocked } from 'jest-mock';
+import request from 'supertest';
+import express from 'express';
+import session from 'express-session';
+import crypto from 'crypto';
+import claimsUpload from '../../../backend/lib/claims-upload';
+import { performQuery } from '../../../backend/lib/graphql';
+import getAuthRole from '../../../utils/getAuthRole';
+
+jest.mock('../../../backend/lib/graphql');
+jest.mock('../../../utils/getAuthRole');
+
+function FormDataMock() {
+  this.append = jest.fn();
+}
+
+global.FormData = jest.fn(() => {
+  return FormDataMock();
+}) as jest.Mock;
+
+jest.setTimeout(100000);
+
+describe('The Claims excel import api route', () => {
+  let app;
+
+  beforeEach(async () => {
+    app = express();
+    app.use(session({ secret: crypto.randomUUID(), cookie: { secure: true } }));
+    app.use('/', claimsUpload);
+  });
+
+  it('should receive the correct response for unauthorized user', async () => {
+    mocked(getAuthRole).mockImplementation(() => {
+      return {
+        pgRole: 'ccbc_guest',
+        landingRoute: '/',
+      };
+    });
+
+    const response = await request(app).post('/api/analyst/claims/1/1');
+    expect(response.status).toBe(404);
+  });
+
+  it('should process uploaded file for authorized user', async () => {
+    mocked(getAuthRole).mockImplementation(() => {
+      return {
+        pgRole: 'ccbc_admin',
+        landingRoute: '/',
+      };
+    });
+
+    mocked(performQuery).mockImplementation(async () => {
+      return {
+        data: {
+          createApplicationClaimsData: {
+            applicationClaimsData: { rowId: 1 },
+          },
+        },
+      };
+    });
+
+    const response = await request(app)
+      .post('/api/analyst/claims/10/1')
+      .set('Content-Type', 'application/json')
+      .set('Connection', 'keep-alive')
+      .field('data', JSON.stringify({ name: 'claims-data' }))
+      // replace with claims file once we receive it
+      .attach('claims-data', `${__dirname}/community_report.xlsx`)
+      .expect(200);
+
+    expect(response.status).toBe(200);
+  });
+
+  it('should return error if file does not have expected worksheets', async () => {
+    mocked(getAuthRole).mockImplementation(() => {
+      return {
+        pgRole: 'ccbc_admin',
+        landingRoute: '/',
+      };
+    });
+
+    const response = await request(app)
+      .post('/api/analyst/claims/10/1')
+      .set('Content-Type', 'application/json')
+      .set('Connection', 'keep-alive')
+      .field('data', JSON.stringify({ name: 'claims-data' }))
+      .attach('claims-data', `${__dirname}/sow_200.xlsx`)
+      .expect(400);
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual([
+      {
+        level: 'workbook',
+        error: `missing required sheet "Sheet 1". Found: ["Summary_Sommaire","1","2","3","4","5","6","7","8","Change Log","Controls","Controls_E","Controls_F","Communities","Text"]`,
+      },
+    ]);
+  });
+
+  afterEach(async () => {
+    // eslint-disable-next-line no-promise-executor-return
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 500)); // avoid jest open handle error
+  });
+  jest.resetAllMocks();
+});

--- a/app/tests/components/Analyst/Project/Claims/ClaimsForm.test.tsx
+++ b/app/tests/components/Analyst/Project/Claims/ClaimsForm.test.tsx
@@ -1,0 +1,179 @@
+import ClaimsForm from 'components/Analyst/Project/Claims/ClaimsForm';
+import { graphql } from 'react-relay';
+import compiledQuery, {
+  ApplicationFormTestQuery,
+} from '__generated__/ApplicationFormTestQuery.graphql';
+import { act, fireEvent, screen } from '@testing-library/react';
+import ComponentTestingHelper from 'tests/utils/componentTestingHelper';
+
+const testQuery = graphql`
+  query ClaimsFormTestQuery @relay_test_operation {
+    # Spread the fragment you want to test here
+    application(id: "TestApplicationId") {
+      ...ClaimsForm_application
+    }
+  }
+`;
+
+const mockQueryPayload = {
+  Application() {
+    return {
+      id: 'TestApplicationId',
+      rowId: 1,
+      ccbcNumber: '123456789',
+      applicationClaimsDataByApplicationId: {
+        edges: [
+          {
+            node: {
+              rowId: 1,
+              jsonData: {
+                dueDate: '2023-08-01',
+                dateReceived: '2023-08-02',
+                progressReportFile: [
+                  {
+                    id: 1,
+                    name: 'claims.xlsx',
+                    size: 121479,
+                    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                    uuid: '541089ee-8f80-4dd9-844f-093d7739792b',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    };
+  },
+  Query() {
+    return {
+      openIntake: {
+        closeTimestamp: '2022-08-27T12:51:26.69172-04:00',
+      },
+    };
+  },
+};
+
+const componentTestingHelper =
+  new ComponentTestingHelper<ApplicationFormTestQuery>({
+    component: ClaimsForm,
+    testQuery,
+    compiledQuery,
+    defaultQueryResolver: mockQueryPayload,
+    getPropsFromTestQuery: (data) => ({
+      application: data.application,
+    }),
+  });
+
+describe('The Claims form', () => {
+  beforeEach(() => {
+    componentTestingHelper.reinit();
+  });
+
+  it('displays the form', () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent();
+
+    expect(screen.getByRole('heading', { name: 'Claims' })).toBeVisible();
+
+    expect(screen.getByText('Add claim')).toBeInTheDocument();
+  });
+
+  it('Uploads a Claim', async () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent();
+
+    // @ts-ignore
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ status: 200, json: () => {} })
+    );
+
+    const addButton = screen.getByText('Add claim').closest('button');
+
+    await act(async () => {
+      fireEvent.click(addButton);
+    });
+
+    const file = new File([new ArrayBuffer(1)], 'file.xls', {
+      type: 'application/vnd.ms-excel',
+    });
+
+    const inputFile = screen.getByTestId('file-test');
+
+    await act(async () => {
+      fireEvent.change(inputFile, { target: { files: [file] } });
+    });
+
+    componentTestingHelper.expectMutationToBeCalled(
+      'createAttachmentMutation',
+      {
+        input: {
+          attachment: {
+            file,
+            fileName: 'file.xls',
+            fileSize: '1 Bytes',
+            fileType: 'application/vnd.ms-excel',
+            applicationId: 1,
+          },
+        },
+      }
+    );
+
+    act(() => {
+      componentTestingHelper.environment.mock.resolveMostRecentOperation({
+        data: {
+          createAttachment: {
+            attachment: {
+              rowId: 1,
+              file: 'string',
+            },
+          },
+        },
+      });
+    });
+
+    expect(screen.getByText('Replace')).toBeInTheDocument();
+    expect(screen.getByText('file.xls')).toBeInTheDocument();
+
+    const saveButton = screen.getByRole('button', {
+      name: 'Save & Import',
+    });
+
+    await act(async () => {
+      fireEvent.click(saveButton);
+    });
+
+    componentTestingHelper.expectMutationToBeCalled(
+      'createClaimsDataMutation',
+      {
+        connections: [expect.anything()],
+        input: {
+          _jsonData: {
+            claimsFile: [
+              {
+                id: 1,
+                uuid: 'string',
+                name: 'file.xls',
+                size: 1,
+                type: 'application/vnd.ms-excel',
+              },
+            ],
+          },
+          _applicationId: 1,
+        },
+      }
+    );
+
+    act(() => {
+      componentTestingHelper.environment.mock.resolveMostRecentOperation({
+        data: {
+          createClaimsData: {
+            changeRequest: {
+              rowId: 1,
+            },
+          },
+        },
+      });
+    });
+  });
+});

--- a/db/deploy/mutations/create_application_claims_data.sql
+++ b/db/deploy/mutations/create_application_claims_data.sql
@@ -1,0 +1,32 @@
+-- Deploy ccbc:mutations/create_application_claims_data to pg
+
+begin;
+
+create or replace function ccbc_public.create_application_claims_data(
+    _application_id integer,
+    _json_data jsonb,
+    _old_claims_id integer default null
+) returns ccbc_public.application_claims_data as $$
+declare
+  new_id integer;
+begin
+
+  insert into ccbc_public.application_claims_data (application_id, json_data)
+  values (_application_id, _json_data)
+  returning id into new_id;
+
+  if exists (select * from ccbc_public.application_claims_data where id = _old_claims_id)
+    then update ccbc_public.application_claims_data set archived_at = now() where id = _old_claims_id;
+  end if;
+
+  return (select row(ccbc_public.application_claims_data.*)
+    from ccbc_public.application_claims_data
+    where id = new_id);
+
+end;
+$$ language plpgsql volatile;
+
+grant execute on function ccbc_public.create_application_claims_data to ccbc_analyst;
+grant execute on function ccbc_public.create_application_claims_data to ccbc_admin;
+
+commit;

--- a/db/deploy/mutations/create_application_claims_data.sql
+++ b/db/deploy/mutations/create_application_claims_data.sql
@@ -5,19 +5,27 @@ begin;
 create or replace function ccbc_public.create_application_claims_data(
     _application_id integer,
     _json_data jsonb,
-    _old_claims_id integer default null
+    _old_claims_id integer default null,
+    _excel_data_id integer default null
 ) returns ccbc_public.application_claims_data as $$
 declare
   new_id integer;
+  old_excel_data_id integer;
 begin
 
-  insert into ccbc_public.application_claims_data (application_id, json_data)
-  values (_application_id, _json_data)
+  insert into ccbc_public.application_claims_data (application_id, json_data, excel_data_id)
+  values (_application_id, _json_data, _excel_data_id)
   returning id into new_id;
 
+  -- archive old claims data if it exists
   if exists (select * from ccbc_public.application_claims_data where id = _old_claims_id)
-    then update ccbc_public.application_claims_data set archived_at = now() where id = _old_claims_id;
+    then update ccbc_public.application_claims_data set archived_at = now() where id = _old_claims_id returning excel_data_id into old_excel_data_id;
   end if;
+
+  -- archive excel data if the form data has no claims file data
+   if(not (_json_data ? 'claimsFile') or jsonb_typeof(_json_data -> 'claimsFile') = 'null') then
+      update ccbc_public.application_claims_excel_data set archived_at = now() where id = old_excel_data_id;
+   end if;
 
   return (select row(ccbc_public.application_claims_data.*)
     from ccbc_public.application_claims_data

--- a/db/deploy/mutations/create_application_claims_excel_data.sql
+++ b/db/deploy/mutations/create_application_claims_excel_data.sql
@@ -1,0 +1,30 @@
+-- Deploy ccbc:mutations/create_application_claims_excel_data to pg
+
+begin;
+
+create or replace function ccbc_public.create_application_claims_excel_data(_application_id int, _json_data jsonb, _old_id int default null)
+returns ccbc_public.application_claims_excel_data as $$
+declare
+new_id int;
+begin
+
+  insert into ccbc_public.application_claims_excel_data (application_id, json_data)
+    values (_application_id, _json_data) returning id into new_id;
+
+  -- archive the old claims excel data
+  if exists (select * from ccbc_public.application_claims_excel_data where id = _old_id and archived_at is null)
+    then update ccbc_public.application_claims_excel_data
+    set archived_at = now() where id = _old_id;
+  end if;
+
+  return (select row(ccbc_public.application_claims_excel_data.*)
+  from ccbc_public.application_claims_excel_data
+  where id = new_id);
+
+end;
+$$ language plpgsql volatile;
+
+grant execute on function ccbc_public.create_application_claims_excel_data to ccbc_analyst;
+grant execute on function ccbc_public.create_application_claims_excel_data to ccbc_admin;
+
+commit;

--- a/db/deploy/tables/application_claims_data.sql
+++ b/db/deploy/tables/application_claims_data.sql
@@ -5,12 +5,17 @@ begin;
 create table ccbc_public.application_claims_data(
   id integer primary key generated always as identity,
   application_id integer references ccbc_public.application(id),
-  json_data jsonb not null default '{}'::jsonb
+  json_data jsonb not null default '{}'::jsonb,
+  excel_data_id integer
 );
 
 select ccbc_private.upsert_timestamp_columns('ccbc_public', 'application_claims_data');
 
 create index application_claims_data_application_id_index on ccbc_public.application_claims_data(application_id);
+
+-- enable audit/history
+select audit.enable_tracking('ccbc_public.application_claims_data'::regclass);
+
 do
 $grant$
 begin
@@ -29,7 +34,9 @@ end
 $grant$;
 
 comment on table ccbc_public.application_claims_data is 'Table containing the claims data for the given application';
-comment on column ccbc_public.application_claims_data.id is 'Unique ID for the claims';
+comment on column ccbc_public.application_claims_data.id is 'Unique id for the claims';
 comment on column ccbc_public.application_claims_data.application_id is 'Id of the application the claims belongs to';
-comment on column ccbc_public.application_claims_data.json_data is 'The due date, date received and the file information of the claims Excel file';
+comment on column ccbc_public.application_claims_data.json_data is 'The claims form json data';
+comment on column ccbc_public.application_claims_data.excel_data_id is 'The id of the excel data that this record is associated with';
+
 commit;

--- a/db/deploy/tables/application_claims_data.sql
+++ b/db/deploy/tables/application_claims_data.sql
@@ -1,0 +1,35 @@
+-- Deploy ccbc:tables/application_claims_data to pg
+
+begin;
+
+create table ccbc_public.application_claims_data(
+  id integer primary key generated always as identity,
+  application_id integer references ccbc_public.application(id),
+  json_data jsonb not null default '{}'::jsonb
+);
+
+select ccbc_private.upsert_timestamp_columns('ccbc_public', 'application_claims_data');
+
+create index application_claims_data_application_id_index on ccbc_public.application_claims_data(application_id);
+do
+$grant$
+begin
+
+-- Grant ccbc_admin permissions
+perform ccbc_private.grant_permissions('select', 'application_claims_data', 'ccbc_admin');
+perform ccbc_private.grant_permissions('insert', 'application_claims_data', 'ccbc_admin');
+perform ccbc_private.grant_permissions('update', 'application_claims_data', 'ccbc_admin');
+
+-- Grant ccbc_analyst permissions
+perform ccbc_private.grant_permissions('select', 'application_claims_data', 'ccbc_analyst');
+perform ccbc_private.grant_permissions('insert', 'application_claims_data', 'ccbc_analyst');
+perform ccbc_private.grant_permissions('update', 'application_claims_data', 'ccbc_analyst');
+
+end
+$grant$;
+
+comment on table ccbc_public.application_claims_data is 'Table containing the claims data for the given application';
+comment on column ccbc_public.application_claims_data.id is 'Unique ID for the claims';
+comment on column ccbc_public.application_claims_data.application_id is 'Id of the application the claims belongs to';
+comment on column ccbc_public.application_claims_data.json_data is 'The due date, date received and the file information of the claims Excel file';
+commit;

--- a/db/deploy/tables/application_claims_excel_data.sql
+++ b/db/deploy/tables/application_claims_excel_data.sql
@@ -1,0 +1,38 @@
+-- Deploy ccbc:tables/application_claims_excel_data to pg
+
+begin;
+
+create table ccbc_public.application_claims_excel_data(
+  id integer primary key generated always as identity,
+  application_id integer references ccbc_public.application(id),
+  json_data jsonb not null default '{}'::jsonb
+);
+
+select ccbc_private.upsert_timestamp_columns('ccbc_public', 'application_claims_excel_data');
+
+-- enable audit/history
+select audit.enable_tracking('ccbc_public.application_claims_excel_data'::regclass);
+
+do
+$grant$
+begin
+
+-- Grant ccbc_admin permissions
+perform ccbc_private.grant_permissions('select', 'application_claims_excel_data', 'ccbc_admin');
+perform ccbc_private.grant_permissions('insert', 'application_claims_excel_data', 'ccbc_admin');
+perform ccbc_private.grant_permissions('update', 'application_claims_excel_data', 'ccbc_admin');
+
+-- Grant ccbc_analyst permissions
+perform ccbc_private.grant_permissions('select', 'application_claims_excel_data', 'ccbc_analyst');
+perform ccbc_private.grant_permissions('insert', 'application_claims_excel_data', 'ccbc_analyst');
+perform ccbc_private.grant_permissions('update', 'application_claims_excel_data', 'ccbc_analyst');
+
+end
+$grant$;
+
+comment on table ccbc_public.application_claims_excel_data is 'Table containing the claims excel data for the given application';
+comment on column ccbc_public.application_claims_excel_data.id is 'Unique ID for the claims excel data';
+comment on column ccbc_public.application_claims_excel_data.application_id is 'ID of the application this data belongs to';
+comment on column ccbc_public.application_claims_excel_data.json_data is 'The data imported from the excel filled by the respondent';
+
+commit;

--- a/db/revert/mutations/create_application_claims_data.sql
+++ b/db/revert/mutations/create_application_claims_data.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:mutations/create_application_claims_data from pg
+
+begin;
+
+drop function if exists ccbc_public.application_claims_data;
+
+commit;

--- a/db/revert/mutations/create_application_claims_excel_data.sql
+++ b/db/revert/mutations/create_application_claims_excel_data.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:mutations/create_application_claims_excel_data from pg
+
+begin;
+
+drop function if exists ccbc_public.create_application_claims_excel_data cascade;
+
+commit;

--- a/db/revert/tables/application_claims_data.sql
+++ b/db/revert/tables/application_claims_data.sql
@@ -2,6 +2,6 @@
 
 begin;
 
-drop table if exists ccbc_public.application_claims_data;
+drop table if exists ccbc_public.application_claims_data cascade;
 
 commit;

--- a/db/revert/tables/application_claims_data.sql
+++ b/db/revert/tables/application_claims_data.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:tables/application_claims_data from pg
+
+begin;
+
+drop table if exists ccbc_public.application_claims_data;
+
+commit;

--- a/db/revert/tables/application_claims_excel_data.sql
+++ b/db/revert/tables/application_claims_excel_data.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:tables/application_claims_excel_data from pg
+
+begin;
+
+drop table if exists ccbc.application_claims_excel_data;
+
+commit;

--- a/db/revert/tables/application_claims_excel_data.sql
+++ b/db/revert/tables/application_claims_excel_data.sql
@@ -2,6 +2,6 @@
 
 begin;
 
-drop table if exists ccbc.application_claims_excel_data;
+drop table if exists ccbc_public.application_claims_excel_data cascade;
 
 commit;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -407,3 +407,4 @@ mutations/update_intake 2023-08-15T19:56:30Z Marcel Mueller <marcel@m2.local> # 
 @1.97.0 2023-08-18T22:52:11Z CCBC Service Account <ccbc@button.is> # release v1.97.0
 tables/application_claims_data 2023-08-18T21:23:37Z Marcel Mueller <marcel@m2> # add table to store claims form data
 mutations/create_application_claims_data 2023-08-18T21:49:29Z Marcel Mueller <marcel@m2> # mutation to create application claims data
+tables/application_claims_excel_data 2023-08-22T16:17:35Z Marcel Mueller <marcel@m2> # add table to store application claims excel data

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -408,3 +408,4 @@ mutations/update_intake 2023-08-15T19:56:30Z Marcel Mueller <marcel@m2.local> # 
 tables/application_claims_data 2023-08-18T21:23:37Z Marcel Mueller <marcel@m2> # add table to store claims form data
 mutations/create_application_claims_data 2023-08-18T21:49:29Z Marcel Mueller <marcel@m2> # mutation to create application claims data
 tables/application_claims_excel_data 2023-08-22T16:17:35Z Marcel Mueller <marcel@m2> # add table to store application claims excel data
+mutations/create_application_claims_excel_data 2023-08-22T16:49:23Z Marcel Mueller <marcel@m2> # add mutation to create application claims excel data

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -405,3 +405,4 @@ mutations/create_change_request [mutations/create_change_request@1.95.0] 2023-08
 mutations/create_application_community_progress_report_data [mutations/create_application_community_progress_report_data@1.95.0] 2023-08-18T16:22:50Z Tony Bushara <tonybushara@pop-os> # Create the community progress report data and archive old excel data if no file is present
 mutations/update_intake 2023-08-15T19:56:30Z Marcel Mueller <marcel@m2.local> # mutation to update an intake
 @1.97.0 2023-08-18T22:52:11Z CCBC Service Account <ccbc@button.is> # release v1.97.0
+tables/application_claims_data 2023-08-18T21:23:37Z Marcel Mueller <marcel@m2> # add table to store claims form data

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -406,3 +406,4 @@ mutations/create_application_community_progress_report_data [mutations/create_ap
 mutations/update_intake 2023-08-15T19:56:30Z Marcel Mueller <marcel@m2.local> # mutation to update an intake
 @1.97.0 2023-08-18T22:52:11Z CCBC Service Account <ccbc@button.is> # release v1.97.0
 tables/application_claims_data 2023-08-18T21:23:37Z Marcel Mueller <marcel@m2> # add table to store claims form data
+mutations/create_application_claims_data 2023-08-18T21:49:29Z Marcel Mueller <marcel@m2> # mutation to create application claims data

--- a/db/test/unit/mutations/create_application_claims_data_test.sql
+++ b/db/test/unit/mutations/create_application_claims_data_test.sql
@@ -1,0 +1,70 @@
+begin;
+
+select plan(4);
+
+truncate table
+  ccbc_public.application,
+  ccbc_public.application_status,
+  ccbc_public.form_data,
+  ccbc_public.application_form_data,
+  ccbc_public.intake,
+  ccbc_public.ccbc_user
+restart identity cascade;
+
+select has_function('ccbc_public', 'create_application_claims_data',
+  'has create_application_claims_data function');
+
+insert into ccbc_public.intake(open_timestamp, close_timestamp, ccbc_intake_number)
+values('2022-03-01 09:00:00-07', '2022-05-01 09:00:00-07', 1);
+
+select mocks.set_mocked_time_in_transaction('2022-04-01 09:00:00-07'::timestamptz);
+set jwt.claims.sub to 'testCcbcAuthUser';
+insert into ccbc_public.ccbc_user
+  (given_name, family_name, email_address, session_sub) values
+  ('foo1', 'bar', 'foo1@bar.com', 'testCcbcAuthUser');
+
+set role ccbc_auth_user;
+
+select ccbc_public.create_application();
+
+
+-- set role to analyst and create application claims data
+set role ccbc_analyst;
+set jwt.claims.sub to 'testCcbcAnalyst';
+
+
+select results_eq(
+  $$
+    select id, json_data from ccbc_public.create_application_claims_data(1,'{}'::jsonb);
+  $$,
+  $$
+    values (1,'{}'::jsonb)
+  $$,
+  'Should return newly created claims data'
+);
+
+-- create a claim and pass in the old claims id
+select id, json_data from ccbc_public.create_application_claims_data(1,'{}'::jsonb, 1);
+
+select results_eq(
+  $$
+    select count(*) from ccbc_public.application_claims_data where application_id = 1;
+  $$,
+  $$
+    values(2::bigint);
+  $$,
+  'Should see two entries in application_claims_data for application 1'
+);
+
+select results_eq(
+  $$
+    select count(*) from ccbc_public.application_claims_data where application_id = 1 and archived_at is null;
+  $$,
+  $$
+    values(1::bigint);
+  $$,
+  'Should see 1 entry in application_claims_data for application 1 where arechived_at is null'
+);
+
+select finish();
+rollback;

--- a/db/test/unit/mutations/create_application_claims_excel_data_test.sql
+++ b/db/test/unit/mutations/create_application_claims_excel_data_test.sql
@@ -11,8 +11,8 @@ truncate table
   ccbc_public.intake
 restart identity cascade;
 
-select has_function('ccbc_public', 'create_application_community_report_excel_data',
-  'Function create_application_community_report_excel_data should exist');
+select has_function('ccbc_public', 'create_application_claims_excel_data',
+  'Function create_application_claims_excel_data should exist');
 
 insert into ccbc_public.intake(open_timestamp, close_timestamp, ccbc_intake_number)
 values('2022-03-01 09:00:00-07', '2022-05-01 09:00:00-07', 1);
@@ -30,11 +30,11 @@ select ccbc_public.create_application();
 -- set role to analyst
 set role ccbc_analyst;
 
-select ccbc_public.create_application_community_report_excel_data(1::int , '{}'::jsonb);
+select ccbc_public.create_application_claims_excel_data(1::int , '{}'::jsonb);
 
 select results_eq (
   $$
-    select count(*) from ccbc_public.application_community_report_excel_data
+    select count(*) from ccbc_public.application_claims_excel_data
     where application_id = 1
   $$,
   $$
@@ -42,15 +42,15 @@ select results_eq (
     1::bigint
   )
   $$,
-  'Should crete community report data'
+  'Should crete claims data'
 );
 
 -- create another, pass in the previous id and make sure the previous one is archived
-select ccbc_public.create_application_community_report_excel_data(1::int , '{}'::jsonb, 1);
+select ccbc_public.create_application_claims_excel_data(1::int , '{}'::jsonb, 1);
 
 select results_eq (
   $$
-    select count(*) from ccbc_public.application_community_report_excel_data
+    select count(*) from ccbc_public.application_claims_excel_data
     where application_id = 1 and archived_at is not null
   $$,
   $$
@@ -58,7 +58,7 @@ select results_eq (
     1::bigint
   )
   $$,
-  'Original community report data should be archived'
+  'Original claims data should be archived'
 );
 
 select finish();

--- a/db/test/unit/tables/application_claims_data_test.sql
+++ b/db/test/unit/tables/application_claims_data_test.sql
@@ -1,6 +1,6 @@
 begin;
 
-select plan(8);
+select plan(9);
 
 -- Table exists
 select has_table(
@@ -12,6 +12,7 @@ select has_table(
 select has_column('ccbc_public', 'application_claims_data', 'id','The table application_claims_data has column id');
 select has_column('ccbc_public', 'application_claims_data', 'application_id','The table application_claims_data has column application_id');
 select has_column('ccbc_public', 'application_claims_data', 'json_data','The table application_claims_data has column json_data');
+select has_column('ccbc_public', 'application_claims_data', 'excel_data_id','The table application_claims_data has column excel_data_id');
 
 -- Privileges
 select table_privs_are(

--- a/db/test/unit/tables/application_claims_data_test.sql
+++ b/db/test/unit/tables/application_claims_data_test.sql
@@ -1,0 +1,38 @@
+begin;
+
+select plan(8);
+
+-- Table exists
+select has_table(
+  'ccbc_public', 'application_claims_data',
+  'ccbc_public.application_claims_data should exist and be a table'
+);
+
+-- Columns
+select has_column('ccbc_public', 'application_claims_data', 'id','The table application_claims_data has column id');
+select has_column('ccbc_public', 'application_claims_data', 'application_id','The table application_claims_data has column application_id');
+select has_column('ccbc_public', 'application_claims_data', 'json_data','The table application_claims_data has column json_data');
+
+-- Privileges
+select table_privs_are(
+  'ccbc_public', 'application_claims_data', 'ccbc_guest', ARRAY[]::text[],
+  'ccbc_guest has no privileges from application_claims_data table'
+);
+
+select table_privs_are(
+  'ccbc_public', 'application_claims_data', 'ccbc_auth_user', ARRAY[]::text[],
+  'ccbc_auth_user has no privileges from application_claims_data table'
+);
+
+select table_privs_are(
+  'ccbc_public', 'application_claims_data', 'ccbc_admin', ARRAY['SELECT', 'INSERT', 'UPDATE'],
+  'ccbc_admin can select, insert and update from application_claims_data table'
+);
+
+select table_privs_are(
+  'ccbc_public', 'application_claims_data', 'ccbc_analyst', ARRAY['SELECT', 'INSERT', 'UPDATE'],
+  'ccbc_analyst can select, insert and update from application_claims_data table'
+);
+
+select finish();
+rollback;

--- a/db/test/unit/tables/application_claims_excel_data_test.sql
+++ b/db/test/unit/tables/application_claims_excel_data_test.sql
@@ -1,0 +1,38 @@
+begin;
+
+select plan(8);
+
+-- Table exists
+select has_table(
+  'ccbc_public', 'application_claims_excel_data',
+  'ccbc_public.application_claims_excel_data should exist and be a table'
+);
+
+-- Columns
+select has_column('ccbc_public', 'application_claims_excel_data', 'id','The table application_claims_excel_data has column id');
+select has_column('ccbc_public', 'application_claims_excel_data', 'application_id','The table application_claims_excel_data has column application_id');
+select has_column('ccbc_public', 'application_claims_excel_data', 'json_data','The table application_claims_excel_data has column json_data');
+
+-- Privileges
+select table_privs_are(
+  'ccbc_public', 'application_claims_excel_data', 'ccbc_guest', ARRAY[]::text[],
+  'ccbc_guest has no privileges from application_claims_excel_data table'
+);
+
+select table_privs_are(
+  'ccbc_public', 'application_claims_excel_data', 'ccbc_auth_user', ARRAY[]::text[],
+  'ccbc_auth_user has no privileges from application_claims_excel_data table'
+);
+
+select table_privs_are(
+  'ccbc_public', 'application_claims_excel_data', 'ccbc_admin', ARRAY['SELECT', 'INSERT', 'UPDATE'],
+  'ccbc_admin can select, insert and update from application_claims_excel_data table'
+);
+
+select table_privs_are(
+  'ccbc_public', 'application_claims_excel_data', 'ccbc_analyst', ARRAY['SELECT', 'INSERT', 'UPDATE'],
+  'ccbc_analyst can select, insert and update from application_claims_excel_data table'
+);
+
+select finish();
+rollback;


### PR DESCRIPTION
To save time in upcoming claims PRs there is  a decent amount of commented code since I based this off of the `Community progress report` form which is nearly identical.

I have also added the `application_claims_excel_data` table and mutations along with a basic api route that save but has no validation or anything to do with the excel file.

Implements #2002

