### PR TITLE
chore: increase excel api rate limit

### DIFF
--- a/app/backend/lib/claims-upload.ts
+++ b/app/backend/lib/claims-upload.ts
@@ -1,19 +1,14 @@
 import { Router } from 'express';
 import formidable from 'formidable';
 import fs from 'fs';
-import RateLimit from 'express-rate-limit';
 import * as XLSX from 'xlsx';
+import limiter from './excel_import/excel-limiter';
 import getAuthRole from '../../utils/getAuthRole';
 import LoadClaimsData from './excel_import/claims';
 import { ExpressMiddleware, parseForm } from './express-helper';
 
 // see https://docs.sheetjs.com/docs/getting-started/installation/nodejs/#installation
 XLSX.set_fs(fs);
-
-const limiter = RateLimit({
-  windowMs: 1 * 60 * 1000, // 1 minute
-  max: 5,
-});
 
 const claimsUpload = Router();
 

--- a/app/backend/lib/community-report-upload.ts
+++ b/app/backend/lib/community-report-upload.ts
@@ -1,19 +1,14 @@
 import { Router } from 'express';
 import formidable from 'formidable';
 import fs from 'fs';
-import RateLimit from 'express-rate-limit';
 import * as XLSX from 'xlsx';
+import limiter from './excel_import/excel-limiter';
 import getAuthRole from '../../utils/getAuthRole';
 import LoadCommunityReportData from './excel_import/community_progress_report';
 import { ExpressMiddleware, parseForm } from './express-helper';
 
 // see https://docs.sheetjs.com/docs/getting-started/installation/nodejs/#installation
 XLSX.set_fs(fs);
-
-const limiter = RateLimit({
-  windowMs: 1 * 60 * 1000, // 1 minute
-  max: 5,
-});
 
 const communityReportUpload = Router();
 

--- a/app/backend/lib/excel_import/excel-limiter.ts
+++ b/app/backend/lib/excel_import/excel-limiter.ts
@@ -1,0 +1,11 @@
+import RateLimit from 'express-rate-limit';
+
+const limiter = RateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  // Max 20 connections per IP per window (1 minute)
+  // This may seem like a lot for 1 user though we hit the api twice per upload,
+  // once to validate and once to save so 10 uploads per minute is the max.
+  max: 20,
+});
+
+export default limiter;

--- a/app/backend/lib/sow-upload.ts
+++ b/app/backend/lib/sow-upload.ts
@@ -1,8 +1,8 @@
 import { Router } from 'express';
 import formidable from 'formidable';
 import fs from 'fs';
-import RateLimit from 'express-rate-limit';
 import * as XLSX from 'xlsx';
+import limiter from './excel_import/excel-limiter';
 import getAuthRole from '../../utils/getAuthRole';
 import LoadSummaryData from './sow_import/summary_tab';
 import LoadTab1Data from './sow_import/tab_1';
@@ -15,11 +15,6 @@ import { ExpressMiddleware, parseForm } from './express-helper';
 XLSX.set_fs(fs);
 
 const sheetNames = ['Summary_Sommaire', '1', '2', '7', '8'];
-
-const limiter = RateLimit({
-  windowMs: 1 * 60 * 1000, // 1 minute
-  max: 5,
-});
 
 const sowUpload = Router();
 


### PR DESCRIPTION
Increased the limit to 20 connections per IP per minute, which seems like a lot though the reason we were maxing out our 5 during testing is that we hit the API twice per upload, once to validate and the second to save. By the time we would get to saving our third excel file we would be at the limit of 5, so it would timeout and hang on save.

10 uploads per minute should be more than enough as it would be hard to hit even intentionally. 

Implements #2092


