### PR TITLE
fix: claims from year width overlap

### DIFF
--- a/app/components/Analyst/Project/Claims/ClaimsView.tsx
+++ b/app/components/Analyst/Project/Claims/ClaimsView.tsx
@@ -7,7 +7,7 @@ import DownloadLink from 'components/DownloadLink';
 
 const StyledContainer = styled.div`
   display: grid;
-  grid-template-columns: 128px 4fr 1fr;
+  grid-template-columns: 164px 4fr 1fr;
   margin-bottom: 8px;
 `;
 
@@ -41,6 +41,11 @@ const StyledFlex = styled.div`
 const StyledDate = styled.div`
   white-space: nowrap;
   font-weight: 700;
+  margin-right: 16px;
+
+  ${(props) => props.theme.breakpoint.mediumUp} {
+    margin: 0;
+  }
 `;
 
 interface Props {


### PR DESCRIPTION
Fix for dates overlapping claims excel file name due to increased width from year being added. 
<img width="1102" alt="Screenshot 2023-09-01 at 10 13 07 AM" src="https://github.com/bcgov/CONN-CCBC-portal/assets/14259474/66b46b9d-63d7-4181-ae8c-7efe09337b7b">
