### PR TITLE
2182 change application spike

### DIFF
--- a/app/backend/lib/importJsonSchemasToDb.ts
+++ b/app/backend/lib/importJsonSchemasToDb.ts
@@ -1,5 +1,6 @@
 import { pgPool } from './setup-pg';
 import schema from '../../formSchema/schema';
+import schemaV2 from '../../formSchema/schemaV2';
 import {
   financialRisk,
   gis,
@@ -22,6 +23,13 @@ const importJsonSchemasToDb = async () => {
       'intake1schema',
       schema,
       'Schema of the first batch of applications',
+      'intake',
+    ]);
+
+    await client.query(insertQuery, [
+      'intake_schema_2',
+      schemaV2,
+      'V2 of the intake schema',
       'intake',
     ]);
 

--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -187,7 +187,6 @@ const ApplicationForm: React.FC<Props> = ({
   } = application;
   const formErrorSchema = useMemo(() => validate(jsonData), [jsonData]);
   const sectionName = getSectionNameFromPageNumber(pageNumber);
-
   const noErrors = Object.keys(formErrorSchema).length === 0;
 
   const [savingError, setSavingError] = useState(null);
@@ -207,6 +206,7 @@ const ApplicationForm: React.FC<Props> = ({
     return {
       intakeCloseTimestamp,
       fullFormData: jsonData,
+      formSchema: jsonSchema,
       formErrorSchema,
       isEditable,
       areAllAcknowledgementsChecked,

--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -6,7 +6,7 @@ import { graphql, useFragment } from 'react-relay';
 import type { JSONSchema7 } from 'json-schema';
 import styled from 'styled-components';
 import validate from 'formSchema/validate';
-import schema from 'formSchema/schema';
+// import schema from 'formSchema/schema';
 import uiSchema from 'formSchema/uiSchema/uiSchema';
 import { ApplicationForm_application$key } from '__generated__/ApplicationForm_application.graphql';
 import { UseDebouncedMutationConfig } from 'schema/mutations/useDebouncedMutation';
@@ -94,11 +94,12 @@ interface SubmissionFieldsJSON {
 }
 
 export const mergeFormSectionData = (
+  formSchema,
   formData,
   formSectionName,
   calculatedSection
 ) => {
-  const schemaSection = schema.properties[formSectionName];
+  const schemaSection = formSchema.properties[formSectionName];
 
   const handleError = (error) => {
     Sentry.captureException({
@@ -184,7 +185,6 @@ const ApplicationForm: React.FC<Props> = ({
     },
     status,
   } = application;
-
   const formErrorSchema = useMemo(() => validate(jsonData), [jsonData]);
   const sectionName = getSectionNameFromPageNumber(pageNumber);
 
@@ -248,7 +248,7 @@ const ApplicationForm: React.FC<Props> = ({
     jsonSchema as object
   );
 
-  const sectionSchema = schema.properties[sectionName] as JSONSchema7;
+  const sectionSchema = jsonSchema?.properties[sectionName] as JSONSchema7;
   const isWithdrawn = status === 'withdrawn';
   const isSubmitted = status === 'submitted';
   const isSubmitPage = sectionName === 'submission';
@@ -312,6 +312,7 @@ const ApplicationForm: React.FC<Props> = ({
     const calculatedSectionData = calculate(newFormSectionData, sectionName);
 
     const newFormData = mergeFormSectionData(
+      jsonSchema,
       jsonData,
       sectionName,
       calculatedSectionData

--- a/app/components/Review/ReviewPageField.tsx
+++ b/app/components/Review/ReviewPageField.tsx
@@ -1,5 +1,4 @@
 import { FieldProps } from '@rjsf/core';
-import fullSchema from 'formSchema/schema';
 import reviewUiSchema from 'formSchema/reviewUiSchema';
 import FormBase from 'components/Form/FormBase';
 import styled from 'styled-components';
@@ -24,7 +23,7 @@ const ReviewPageField: React.FC<FieldProps> = (props) => {
     onBlur,
     onFocus,
   } = props;
-  const { fullFormData, formErrorSchema } = formContext;
+  const { fullFormData, formSchema, formErrorSchema } = formContext;
 
   const noErrors = Object.keys(formErrorSchema).length === 0;
 
@@ -52,7 +51,7 @@ const ReviewPageField: React.FC<FieldProps> = (props) => {
       </StyledAlert>
       <FormBase
         theme={ReviewTheme}
-        schema={fullSchema}
+        schema={formSchema}
         uiSchema={reviewUiSchema as any}
         formData={fullFormData}
         liveValidate

--- a/app/components/Stepper.tsx
+++ b/app/components/Stepper.tsx
@@ -2,7 +2,6 @@ import { useRouter } from 'next/router';
 import { JSONSchema7 } from 'json-schema';
 import Link from 'next/link';
 import styled from 'styled-components';
-import schema from 'formSchema/schema';
 import uiSchema from 'formSchema/uiSchema/uiSchema';
 import getFormPage from 'utils/getFormPage';
 
@@ -48,10 +47,14 @@ const formPageList = uiSchema['ui:order'].filter((formName) => {
   return formName !== 'submission';
 });
 
-const Stepper = () => {
+interface StepperProps {
+  schema: JSONSchema7;
+}
+
+const Stepper: React.FC<StepperProps> = ({ schema }) => {
   const router = useRouter();
   const rowId = router.query.id;
-  const formPageSchema = schema.properties;
+  const formSchema = schema.properties;
 
   return (
     <StyledNav>
@@ -60,7 +63,8 @@ const Stepper = () => {
           formPageList[Number(router.query.page) - 1] === formName;
 
         const pageNumber = getFormPage(formName);
-        const formSchema = formPageSchema[formName] as JSONSchema7;
+        const formPageSchema = formSchema[formName] as JSONSchema7;
+        if (!formPageSchema) return null;
         return (
           <>
             {isCurrentPage ? (
@@ -70,7 +74,7 @@ const Stepper = () => {
                   key={formName}
                   passHref
                 >
-                  {formSchema.title}
+                  {formPageSchema.title}
                 </StyledLink>
               </StyledActive>
             ) : (
@@ -80,7 +84,7 @@ const Stepper = () => {
                   key={formName}
                   passHref
                 >
-                  {formSchema.title}
+                  {formPageSchema?.title}
                 </StyledLink>
               </StyledDiv>
             )}

--- a/app/formSchema/index.ts
+++ b/app/formSchema/index.ts
@@ -1,5 +1,6 @@
 export { default as analystUiSchema } from './analystUiSchema';
 export { default as validate } from './validate';
 export { default as schema } from './schema';
+export { default as schemaV2 } from './schemaV2';
 export { default as uiSchema } from './uiSchema/uiSchema';
 export { default as reviewUiSchema } from './reviewUiSchema';

--- a/app/formSchema/schemaV2.ts
+++ b/app/formSchema/schemaV2.ts
@@ -1,0 +1,51 @@
+import { JSONSchema7 } from 'json-schema';
+import {
+  acknowledgements,
+  alternateContact,
+  authorizedContact,
+  benefits,
+  budgetDetails,
+  contactInformation,
+  coverage,
+  existingNetworkCoverage,
+  organizationLocation,
+  organizationProfile,
+  otherFundingSources,
+  projectArea,
+  projectInformation,
+  projectFunding,
+  projectPlan,
+  submission,
+  supportingDocuments,
+  review,
+  techSolution,
+  templateUploads,
+} from './pages';
+
+const schema: JSONSchema7 = {
+  type: 'object',
+  properties: {
+    ...projectInformation,
+    ...projectArea,
+    ...existingNetworkCoverage,
+    ...budgetDetails,
+    ...projectFunding,
+    ...otherFundingSources,
+    ...techSolution,
+    ...benefits,
+    ...projectPlan,
+    ...templateUploads,
+    ...supportingDocuments,
+    ...coverage,
+    ...organizationProfile,
+    ...organizationLocation,
+    ...contactInformation,
+    ...authorizedContact,
+    ...alternateContact,
+    ...review,
+    ...acknowledgements,
+    ...submission,
+  },
+};
+
+export default schema;

--- a/app/pages/analyst/application/[applicationId]/edit/[section].tsx
+++ b/app/pages/analyst/application/[applicationId]/edit/[section].tsx
@@ -76,6 +76,7 @@ const EditApplication = ({
     const calculatedSectionData = calculate(sectionFormData, sectionName);
 
     const newFormData = mergeFormSectionData(
+      jsonSchema,
       jsonData,
       sectionName,
       calculatedSectionData

--- a/app/pages/applicantportal/form/[id]/[page].tsx
+++ b/app/pages/applicantportal/form/[id]/[page].tsx
@@ -20,6 +20,11 @@ const getPageQuery = graphql`
       id
       owner
       status
+      formData {
+        formByFormSchemaId {
+          jsonSchema
+        }
+      }
       ...ApplicationForm_application
     }
     session {
@@ -36,6 +41,11 @@ const FormPage = ({
 
   const { applicationByRowId, session } = query;
   const { status } = applicationByRowId;
+  const {
+    formData: {
+      formByFormSchemaId: { jsonSchema },
+    },
+  } = applicationByRowId;
   const router = useRouter();
 
   const applicationId = Number(router.query.id);
@@ -44,7 +54,7 @@ const FormPage = ({
 
   return (
     <Layout session={session} title="Connecting Communities BC">
-      <Stepper />
+      <Stepper schema={jsonSchema} />
 
       <FormDiv>
         {status === 'withdrawn' && (

--- a/app/tests/backend/lib/importJsonSchemasToDb.test.ts
+++ b/app/tests/backend/lib/importJsonSchemasToDb.test.ts
@@ -33,7 +33,7 @@ describe('Json  importer', () => {
     const client = await pgPool.connect();
     expect(client.query).toHaveBeenCalledWith('begin');
     expect(client.query).toHaveBeenCalledWith('commit');
-    expect(client.query).toHaveBeenCalledTimes(10);
+    expect(client.query).toHaveBeenCalledTimes(11);
     expect(client.release).toHaveBeenCalledOnce();
   });
 });

--- a/app/tests/components/Stepper.test.tsx
+++ b/app/tests/components/Stepper.test.tsx
@@ -1,11 +1,12 @@
 import Stepper from 'components/Stepper';
+import schema from 'formSchema/schema';
 import { render, screen } from '@testing-library/react';
 import GlobalTheme, { theme } from 'styles/GlobalTheme';
 
 const renderStaticLayout = () => {
   return render(
     <GlobalTheme>
-      <Stepper />
+      <Stepper schema={schema} />
     </GlobalTheme>
   );
 };


### PR DESCRIPTION
This actually went pretty well, this needs some cleanup but I just made a `schemaV2` which is imported into the database at application startup using `importJsonSchemasToDb`. From there any application created using `create_application` mutation will use the most recent `intake` schema.

I had to make a few minor changes such as passing the `jsonSchema` associated with that application to the stepper and a couple other places but it seems to be working great. Applications created before `schemaV2` were imported will display the estimated project employment page, applications after will not and it all works pretty seamlessly. There may have been a few areas I didn't think about.