### PR TITLE
feat: capture sentry exception for application form data out of sync error

### DIFF
--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -350,6 +350,10 @@ const ApplicationForm: React.FC<Props> = ({
       },
       debounceKey: formDataId,
       onError: (error) => {
+        Sentry.captureException({
+          name: 'Application form data is out of sync',
+          message: error,
+        });
         if (error.message.includes('Data is Out of Sync')) {
           window.location.hash = 'data-out-of-sync';
         }


### PR DESCRIPTION
I'm having trouble recreating this so I think it would be helpful to capture a Sentry exception. It still won't tell us when this is being triggered incorrectly (ie only 1 tab open) but could still be helpful.