### PR TITLE
fix/milestones

### DIFF
--- a/app/components/Analyst/Project/Milestones/MilestonesForm.tsx
+++ b/app/components/Analyst/Project/Milestones/MilestonesForm.tsx
@@ -350,6 +350,7 @@ const MilestonesForm: React.FC<Props> = ({ application, isExpanded }) => {
           <AddButton
             isFormEditMode={isFormEditMode}
             onClick={() => {
+              setShowToast(false);
               setIsSubmitAttempted(false);
               setIsFormEditMode(true);
             }}

--- a/app/components/Analyst/Project/Milestones/MilestonesForm.tsx
+++ b/app/components/Analyst/Project/Milestones/MilestonesForm.tsx
@@ -351,6 +351,8 @@ const MilestonesForm: React.FC<Props> = ({ application, isExpanded }) => {
             isFormEditMode={isFormEditMode}
             onClick={() => {
               setShowToast(false);
+              setFormData({} as FormData);
+              setCurrentMilestoneData(null);
               setIsSubmitAttempted(false);
               setIsFormEditMode(true);
             }}

--- a/app/components/Analyst/Project/Milestones/MilestonesForm.tsx
+++ b/app/components/Analyst/Project/Milestones/MilestonesForm.tsx
@@ -275,8 +275,7 @@ const MilestonesForm: React.FC<Props> = ({ application, isExpanded }) => {
         ConnectionHandler.deleteNode(connection, milestoneConnectionId);
       },
       onCompleted: () => {
-        setShowModal(false);
-        setCurrentMilestoneData(null);
+        handleResetFormData();
       },
     });
   };

--- a/app/components/Analyst/Project/Milestones/MilestonesView.tsx
+++ b/app/components/Analyst/Project/Milestones/MilestonesView.tsx
@@ -81,7 +81,8 @@ const MilestonesView: React.FC<Props> = ({
       <span>
         {milestoneFile && (
           <DownloadLink
-            fileName="Milestone Report"
+            fileLabel="Milestone Report"
+            fileName={milestoneFile?.name}
             uuid={milestoneFile?.uuid}
           />
         )}

--- a/app/components/DownloadLink.tsx
+++ b/app/components/DownloadLink.tsx
@@ -33,15 +33,21 @@ interface Props {
   children?: any;
   uuid: string;
   fileName: string;
+  fileLabel?: string;
 }
 
-const DownloadLink: React.FC<Props> = ({ children, uuid, fileName }) => {
+const DownloadLink: React.FC<Props> = ({
+  children,
+  uuid,
+  fileName,
+  fileLabel,
+}) => {
   const [quarantinedLink, setQuarantinedLink] = useState(false);
   return quarantinedLink ? (
-    <>`${fileName}`</>
+    <>`${fileLabel || fileName}`</>
   ) : (
     <StyledLink
-      title={fileName}
+      title={fileLabel || fileName}
       data-testid="history-attachment-link"
       onClick={(e) => {
         e.preventDefault();
@@ -50,7 +56,7 @@ const DownloadLink: React.FC<Props> = ({ children, uuid, fileName }) => {
         });
       }}
     >
-      {children || fileName}
+      {children || fileLabel || fileName}
     </StyledLink>
   );
 };


### PR DESCRIPTION
- fix: milestone files in read only use label `Milestone Report` which was causing the download to have that name as well, added a prop for `fileLabel` so we could use the proper file name for the download.
- fix: set `showToast(false)` when we click `Add Milestone` so that the toast will show up more than once.
- fix: clear previous milestone data - similar issue we had on past forms due to the current milestone not being correctly cleared
