### PR TITLE
fix: project page z-index modal conflict

### DIFF
--- a/app/components/Analyst/Project/ProjectForm.tsx
+++ b/app/components/Analyst/Project/ProjectForm.tsx
@@ -82,7 +82,7 @@ const StyledAnimateForm = styled.div<AnimateFormProps>`
     isAnimated &&
     `
     position: relative;
-    z-index: ${isFormExpanded ? 100 : 1};
+    z-index: ${isFormExpanded ? 10 : 1};
     overflow: ${overflow};
     max-height: ${
       isFormExpanded


### PR DESCRIPTION
Turns out the login timeout modal z-index was also 100 so they were both conflicting.