### PR TITLE
2376 project description table

### DIFF
--- a/app/components/Analyst/EditProjectDescription.tsx
+++ b/app/components/Analyst/EditProjectDescription.tsx
@@ -18,7 +18,7 @@ const EditProjectDescription: React.FC<Props> = ({ application }) => {
     `,
     application
   );
-  const { internalDescription, rowId } = queryFragment;
+  const { id, internalDescription, rowId } = queryFragment;
 
   const [isEditing, setIsEditing] = useState(false);
   const [createDescription] = useCreateApplicationInternalDescriptionMutation();
@@ -31,6 +31,10 @@ const EditProjectDescription: React.FC<Props> = ({ application }) => {
         },
         onCompleted: () => {
           setIsEditing(false);
+        },
+        updater: (store) => {
+          const applicationRecord = store.get(id);
+          applicationRecord.setValue(value, 'internalDescription');
         },
       });
     } else {

--- a/app/components/Analyst/EditProjectDescription.tsx
+++ b/app/components/Analyst/EditProjectDescription.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { useUpdateApplicationMutation } from 'schema/mutations/application/updateApplication';
+import { useCreateApplicationInternalDescriptionMutation } from 'schema/mutations/application/createApplicationInternalDescription';
 import InlineTextArea from 'components/InlineTextArea';
 
 interface Props {
@@ -21,13 +21,13 @@ const EditProjectDescription: React.FC<Props> = ({ application }) => {
   const { internalDescription, rowId } = queryFragment;
 
   const [isEditing, setIsEditing] = useState(false);
-  const [updateApplication] = useUpdateApplicationMutation();
+  const [createDescription] = useCreateApplicationInternalDescriptionMutation();
 
   const handleSubmit = (value: string) => {
     if (value !== internalDescription) {
-      updateApplication({
+      createDescription({
         variables: {
-          input: { applicationPatch: { internalDescription: value }, rowId },
+          input: { _applicationId: rowId, _description: value },
         },
         onCompleted: () => {
           setIsEditing(false);

--- a/app/postgraphile.tags.json5
+++ b/app/postgraphile.tags.json5
@@ -72,6 +72,11 @@
           omit: ['create', 'delete'],
         },
       },
+      'ccbc_public.application_internal_description': {
+        tags: {
+          omit: ['create', 'delete'],
+        },
+      },
     },
     procedure: {
       'ccbc_public.application_analyst_lead': {

--- a/app/schema/mutations/application/createApplicationInternalDescription.ts
+++ b/app/schema/mutations/application/createApplicationInternalDescription.ts
@@ -1,0 +1,26 @@
+import type { createApplicationInternalDescriptionMutation } from '__generated__/createApplicationInternalDescriptionMutation.graphql';
+import { graphql } from 'react-relay';
+
+import useMutationWithErrorMessage from '../useMutationWithErrorMessage';
+
+const mutation = graphql`
+  mutation createApplicationInternalDescriptionMutation(
+    $input: CreateApplicationInternalDescriptionInput!
+  ) {
+    createApplicationInternalDescription(input: $input) {
+      clientMutationId
+      applicationInternalDescription {
+        description
+      }
+    }
+  }
+`;
+
+const useCreateApplicationInternalDescriptionMutation = () =>
+  useMutationWithErrorMessage<createApplicationInternalDescriptionMutation>(
+    mutation,
+    () =>
+      'An error occurred while attempting to create the application internal description.'
+  );
+
+export { mutation, useCreateApplicationInternalDescriptionMutation };

--- a/app/schema/schema.graphql
+++ b/app/schema/schema.graphql
@@ -440,6 +440,42 @@ type Query implements Node {
   ): ApplicationGisDataConnection
 
   """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  allApplicationInternalDescriptions(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection
+
+  """
   Reads and enables pagination through a set of `ApplicationMilestoneData`.
   """
   allApplicationMilestoneData(
@@ -1478,6 +1514,7 @@ type Query implements Node {
   applicationFormDataByFormDataIdAndApplicationId(formDataId: Int!, applicationId: Int!): ApplicationFormData
   applicationGisAssessmentHhByRowId(rowId: Int!): ApplicationGisAssessmentHh
   applicationGisDataByRowId(rowId: Int!): ApplicationGisData
+  applicationInternalDescriptionByRowId(rowId: Int!): ApplicationInternalDescription
   applicationMilestoneDataByRowId(rowId: Int!): ApplicationMilestoneData
   applicationMilestoneExcelDataByRowId(rowId: Int!): ApplicationMilestoneExcelData
   applicationPackageByRowId(rowId: Int!): ApplicationPackage
@@ -1651,6 +1688,16 @@ type Query implements Node {
     """
     id: ID!
   ): ApplicationGisData
+
+  """
+  Reads a single `ApplicationInternalDescription` using its globally unique `ID`.
+  """
+  applicationInternalDescription(
+    """
+    The globally unique `ID` to be used in selecting a single `ApplicationInternalDescription`.
+    """
+    id: ID!
+  ): ApplicationInternalDescription
 
   """
   Reads a single `ApplicationMilestoneData` using its globally unique `ID`.
@@ -5330,6 +5377,114 @@ type CcbcUser implements Node {
     """
     filter: CbcProjectFilter
   ): CbcProjectsConnection!
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
 
   """Reads and enables pagination through a set of `CcbcUser`."""
   ccbcUsersByCcbcUserCreatedByAndUpdatedBy(
@@ -14714,6 +14869,312 @@ type CcbcUser implements Node {
     """
     filter: CcbcUserFilter
   ): CcbcUserCcbcUsersByCbcProjectArchivedByAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `Application`."""
+  applicationsByApplicationInternalDescriptionCreatedByAndApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Application`."""
+    orderBy: [ApplicationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationFilter
+  ): CcbcUserApplicationsByApplicationInternalDescriptionCreatedByAndApplicationIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationInternalDescriptionCreatedByAndUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationInternalDescriptionCreatedByAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationInternalDescriptionCreatedByAndArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationInternalDescriptionCreatedByAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `Application`."""
+  applicationsByApplicationInternalDescriptionUpdatedByAndApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Application`."""
+    orderBy: [ApplicationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationFilter
+  ): CcbcUserApplicationsByApplicationInternalDescriptionUpdatedByAndApplicationIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationInternalDescriptionUpdatedByAndCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationInternalDescriptionUpdatedByAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationInternalDescriptionUpdatedByAndArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationInternalDescriptionUpdatedByAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `Application`."""
+  applicationsByApplicationInternalDescriptionArchivedByAndApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `Application`."""
+    orderBy: [ApplicationsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationFilter
+  ): CcbcUserApplicationsByApplicationInternalDescriptionArchivedByAndApplicationIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationInternalDescriptionArchivedByAndCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationInternalDescriptionArchivedByAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationInternalDescriptionArchivedByAndUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): CcbcUserCcbcUsersByApplicationInternalDescriptionArchivedByAndUpdatedByManyToManyConnection!
 }
 
 """A connection to a list of `CcbcUser` values."""
@@ -15453,6 +15914,30 @@ input CcbcUserFilter {
   """Some related `cbcProjectsByArchivedBy` exist."""
   cbcProjectsByArchivedByExist: Boolean
 
+  """
+  Filter by the object’s `applicationInternalDescriptionsByCreatedBy` relation.
+  """
+  applicationInternalDescriptionsByCreatedBy: CcbcUserToManyApplicationInternalDescriptionFilter
+
+  """Some related `applicationInternalDescriptionsByCreatedBy` exist."""
+  applicationInternalDescriptionsByCreatedByExist: Boolean
+
+  """
+  Filter by the object’s `applicationInternalDescriptionsByUpdatedBy` relation.
+  """
+  applicationInternalDescriptionsByUpdatedBy: CcbcUserToManyApplicationInternalDescriptionFilter
+
+  """Some related `applicationInternalDescriptionsByUpdatedBy` exist."""
+  applicationInternalDescriptionsByUpdatedByExist: Boolean
+
+  """
+  Filter by the object’s `applicationInternalDescriptionsByArchivedBy` relation.
+  """
+  applicationInternalDescriptionsByArchivedBy: CcbcUserToManyApplicationInternalDescriptionFilter
+
+  """Some related `applicationInternalDescriptionsByArchivedBy` exist."""
+  applicationInternalDescriptionsByArchivedByExist: Boolean
+
   """Filter by the object’s `keycloakJwtsBySub` relation."""
   keycloakJwtsBySub: CcbcUserToManyKeycloakJwtFilter
 
@@ -15922,9 +16407,6 @@ input ApplicationFilter {
   """Filter by the object’s `archivedAt` field."""
   archivedAt: DatetimeFilter
 
-  """Filter by the object’s `internalDescription` field."""
-  internalDescription: StringFilter
-
   """Filter by the object’s `amendmentNumbers` field."""
   amendmentNumbers: StringFilter
 
@@ -15942,6 +16424,9 @@ input ApplicationFilter {
 
   """Filter by the object’s `intakeNumber` field."""
   intakeNumber: IntFilter
+
+  """Filter by the object’s `internalDescription` field."""
+  internalDescription: StringFilter
 
   """Filter by the object’s `organizationName` field."""
   organizationName: StringFilter
@@ -16112,6 +16597,14 @@ input ApplicationFilter {
 
   """Some related `applicationMilestoneExcelDataByApplicationId` exist."""
   applicationMilestoneExcelDataByApplicationIdExist: Boolean
+
+  """
+  Filter by the object’s `applicationInternalDescriptionsByApplicationId` relation.
+  """
+  applicationInternalDescriptionsByApplicationId: ApplicationToManyApplicationInternalDescriptionFilter
+
+  """Some related `applicationInternalDescriptionsByApplicationId` exist."""
+  applicationInternalDescriptionsByApplicationIdExist: Boolean
 
   """Filter by the object’s `intakeByIntakeId` relation."""
   intakeByIntakeId: IntakeFilter
@@ -19179,6 +19672,91 @@ input ApplicationMilestoneExcelDataFilter {
 }
 
 """
+A filter to be used against many `ApplicationInternalDescription` object types. All fields are combined with a logical ‘and.’
+"""
+input ApplicationToManyApplicationInternalDescriptionFilter {
+  """
+  Every related `ApplicationInternalDescription` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  every: ApplicationInternalDescriptionFilter
+
+  """
+  Some related `ApplicationInternalDescription` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  some: ApplicationInternalDescriptionFilter
+
+  """
+  No related `ApplicationInternalDescription` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  none: ApplicationInternalDescriptionFilter
+}
+
+"""
+A filter to be used against `ApplicationInternalDescription` object types. All fields are combined with a logical ‘and.’
+"""
+input ApplicationInternalDescriptionFilter {
+  """Filter by the object’s `rowId` field."""
+  rowId: IntFilter
+
+  """Filter by the object’s `applicationId` field."""
+  applicationId: IntFilter
+
+  """Filter by the object’s `description` field."""
+  description: StringFilter
+
+  """Filter by the object’s `createdBy` field."""
+  createdBy: IntFilter
+
+  """Filter by the object’s `createdAt` field."""
+  createdAt: DatetimeFilter
+
+  """Filter by the object’s `updatedBy` field."""
+  updatedBy: IntFilter
+
+  """Filter by the object’s `updatedAt` field."""
+  updatedAt: DatetimeFilter
+
+  """Filter by the object’s `archivedBy` field."""
+  archivedBy: IntFilter
+
+  """Filter by the object’s `archivedAt` field."""
+  archivedAt: DatetimeFilter
+
+  """Filter by the object’s `applicationByApplicationId` relation."""
+  applicationByApplicationId: ApplicationFilter
+
+  """A related `applicationByApplicationId` exists."""
+  applicationByApplicationIdExists: Boolean
+
+  """Filter by the object’s `ccbcUserByCreatedBy` relation."""
+  ccbcUserByCreatedBy: CcbcUserFilter
+
+  """A related `ccbcUserByCreatedBy` exists."""
+  ccbcUserByCreatedByExists: Boolean
+
+  """Filter by the object’s `ccbcUserByUpdatedBy` relation."""
+  ccbcUserByUpdatedBy: CcbcUserFilter
+
+  """A related `ccbcUserByUpdatedBy` exists."""
+  ccbcUserByUpdatedByExists: Boolean
+
+  """Filter by the object’s `ccbcUserByArchivedBy` relation."""
+  ccbcUserByArchivedBy: CcbcUserFilter
+
+  """A related `ccbcUserByArchivedBy` exists."""
+  ccbcUserByArchivedByExists: Boolean
+
+  """Checks for all expressions in this list."""
+  and: [ApplicationInternalDescriptionFilter!]
+
+  """Checks for any expressions in this list."""
+  or: [ApplicationInternalDescriptionFilter!]
+
+  """Negates the expression."""
+  not: ApplicationInternalDescriptionFilter
+}
+
+"""
 A filter to be used against `GaplessCounter` object types. All fields are combined with a logical ‘and.’
 """
 input GaplessCounterFilter {
@@ -20065,6 +20643,26 @@ input CbcProjectFilter {
 }
 
 """
+A filter to be used against many `ApplicationInternalDescription` object types. All fields are combined with a logical ‘and.’
+"""
+input CcbcUserToManyApplicationInternalDescriptionFilter {
+  """
+  Every related `ApplicationInternalDescription` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  every: ApplicationInternalDescriptionFilter
+
+  """
+  Some related `ApplicationInternalDescription` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  some: ApplicationInternalDescriptionFilter
+
+  """
+  No related `ApplicationInternalDescription` matches the filter criteria. All fields are combined with a logical ‘and.’
+  """
+  none: ApplicationInternalDescriptionFilter
+}
+
+"""
 A filter to be used against many `KeycloakJwt` object types. All fields are combined with a logical ‘and.’
 """
 input CcbcUserToManyKeycloakJwtFilter {
@@ -20919,9 +21517,6 @@ type Application implements Node {
   """archived at timestamp"""
   archivedAt: Datetime
 
-  """Internal project description for analysts"""
-  internalDescription: String
-
   """Reads a single `Intake` that is related to this `Application`."""
   intakeByIntakeId: Intake
 
@@ -21636,6 +22231,42 @@ type Application implements Node {
     filter: ApplicationMilestoneExcelDataFilter
   ): ApplicationMilestoneExcelDataConnection!
 
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+
   """Reads and enables pagination through a set of `AssessmentData`."""
   allAssessments(
     """Only read the first `n` values of the set."""
@@ -21746,11 +22377,12 @@ type Application implements Node {
     filter: HistoryItemFilter
   ): HistoryItemsConnection!
   intakeNumber: Int
+  internalDescription: String
 
   """Computed column to display organization name from json data"""
   organizationName: String
 
-  """Computed column to return the intake number for an application"""
+  """Computed column to return the internal description for an application"""
   package: Int
 
   """Computed column to return project information data"""
@@ -23784,6 +24416,108 @@ type Application implements Node {
     """
     filter: CcbcUserFilter
   ): ApplicationCcbcUsersByApplicationMilestoneExcelDataApplicationIdAndArchivedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationInternalDescriptionApplicationIdAndCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): ApplicationCcbcUsersByApplicationInternalDescriptionApplicationIdAndCreatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationInternalDescriptionApplicationIdAndUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): ApplicationCcbcUsersByApplicationInternalDescriptionApplicationIdAndUpdatedByManyToManyConnection!
+
+  """Reads and enables pagination through a set of `CcbcUser`."""
+  ccbcUsersByApplicationInternalDescriptionApplicationIdAndArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `CcbcUser`."""
+    orderBy: [CcbcUsersOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CcbcUserCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: CcbcUserFilter
+  ): ApplicationCcbcUsersByApplicationInternalDescriptionApplicationIdAndArchivedByManyToManyConnection!
 }
 
 """A connection to a list of `ApplicationStatus` values."""
@@ -24381,8 +25115,6 @@ enum ApplicationsOrderBy {
   ARCHIVED_BY_DESC
   ARCHIVED_AT_ASC
   ARCHIVED_AT_DESC
-  INTERNAL_DESCRIPTION_ASC
-  INTERNAL_DESCRIPTION_DESC
   ANALYST_LEAD_ASC
   ANALYST_LEAD_DESC
   INTAKE_NUMBER_ASC
@@ -24439,9 +25171,6 @@ input ApplicationCondition {
 
   """Checks for equality with the object’s `archivedAt` field."""
   archivedAt: Datetime
-
-  """Checks for equality with the object’s `internalDescription` field."""
-  internalDescription: String
 }
 
 """
@@ -32548,6 +33277,147 @@ input ApplicationMilestoneExcelDataCondition {
   archivedAt: Datetime
 }
 
+"""A connection to a list of `ApplicationInternalDescription` values."""
+type ApplicationInternalDescriptionsConnection {
+  """A list of `ApplicationInternalDescription` objects."""
+  nodes: [ApplicationInternalDescription]!
+
+  """
+  A list of edges which contains the `ApplicationInternalDescription` and cursor to aid in pagination.
+  """
+  edges: [ApplicationInternalDescriptionsEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* `ApplicationInternalDescription` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""Table containing the internal description for the given application"""
+type ApplicationInternalDescription implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  id: ID!
+
+  """Unique id for the row"""
+  rowId: Int!
+
+  """Id of the application the description belongs to"""
+  applicationId: Int
+
+  """The internal description for the given application"""
+  description: String
+
+  """created by user id"""
+  createdBy: Int
+
+  """created at timestamp"""
+  createdAt: Datetime!
+
+  """updated by user id"""
+  updatedBy: Int
+
+  """updated at timestamp"""
+  updatedAt: Datetime!
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """archived at timestamp"""
+  archivedAt: Datetime
+
+  """
+  Reads a single `Application` that is related to this `ApplicationInternalDescription`.
+  """
+  applicationByApplicationId: Application
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationInternalDescription`.
+  """
+  ccbcUserByCreatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationInternalDescription`.
+  """
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationInternalDescription`.
+  """
+  ccbcUserByArchivedBy: CcbcUser
+}
+
+"""A `ApplicationInternalDescription` edge in the connection."""
+type ApplicationInternalDescriptionsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ApplicationInternalDescription` at the end of the edge."""
+  node: ApplicationInternalDescription
+}
+
+"""Methods to use when ordering `ApplicationInternalDescription`."""
+enum ApplicationInternalDescriptionsOrderBy {
+  NATURAL
+  ID_ASC
+  ID_DESC
+  APPLICATION_ID_ASC
+  APPLICATION_ID_DESC
+  DESCRIPTION_ASC
+  DESCRIPTION_DESC
+  CREATED_BY_ASC
+  CREATED_BY_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  UPDATED_BY_ASC
+  UPDATED_BY_DESC
+  UPDATED_AT_ASC
+  UPDATED_AT_DESC
+  ARCHIVED_BY_ASC
+  ARCHIVED_BY_DESC
+  ARCHIVED_AT_ASC
+  ARCHIVED_AT_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+A condition to be used against `ApplicationInternalDescription` object types.
+All fields are tested for equality and combined with a logical ‘and.’
+"""
+input ApplicationInternalDescriptionCondition {
+  """Checks for equality with the object’s `rowId` field."""
+  rowId: Int
+
+  """Checks for equality with the object’s `applicationId` field."""
+  applicationId: Int
+
+  """Checks for equality with the object’s `description` field."""
+  description: String
+
+  """Checks for equality with the object’s `createdBy` field."""
+  createdBy: Int
+
+  """Checks for equality with the object’s `createdAt` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s `updatedBy` field."""
+  updatedBy: Int
+
+  """Checks for equality with the object’s `updatedAt` field."""
+  updatedAt: Datetime
+
+  """Checks for equality with the object’s `archivedBy` field."""
+  archivedBy: Int
+
+  """Checks for equality with the object’s `archivedAt` field."""
+  archivedAt: Datetime
+}
+
 """A connection to a list of `Announcement` values."""
 type AnnouncementsConnection {
   """A list of `Announcement` objects."""
@@ -36680,6 +37550,204 @@ type ApplicationCcbcUsersByApplicationMilestoneExcelDataApplicationIdAndArchived
     """
     filter: ApplicationMilestoneExcelDataFilter
   ): ApplicationMilestoneExcelDataConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationInternalDescription`.
+"""
+type ApplicationCcbcUsersByApplicationInternalDescriptionApplicationIdAndCreatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationInternalDescription`, and the cursor to aid in pagination.
+  """
+  edges: [ApplicationCcbcUsersByApplicationInternalDescriptionApplicationIdAndCreatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationInternalDescription`.
+"""
+type ApplicationCcbcUsersByApplicationInternalDescriptionApplicationIdAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationInternalDescription`.
+"""
+type ApplicationCcbcUsersByApplicationInternalDescriptionApplicationIdAndUpdatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationInternalDescription`, and the cursor to aid in pagination.
+  """
+  edges: [ApplicationCcbcUsersByApplicationInternalDescriptionApplicationIdAndUpdatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationInternalDescription`.
+"""
+type ApplicationCcbcUsersByApplicationInternalDescriptionApplicationIdAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationInternalDescription`.
+"""
+type ApplicationCcbcUsersByApplicationInternalDescriptionApplicationIdAndArchivedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationInternalDescription`, and the cursor to aid in pagination.
+  """
+  edges: [ApplicationCcbcUsersByApplicationInternalDescriptionApplicationIdAndArchivedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationInternalDescription`.
+"""
+type ApplicationCcbcUsersByApplicationInternalDescriptionApplicationIdAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
 }
 
 """A `Application` edge in the connection."""
@@ -54835,6 +55903,600 @@ type CcbcUserCcbcUsersByCbcProjectArchivedByAndUpdatedByManyToManyEdge {
 }
 
 """
+A connection to a list of `Application` values, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserApplicationsByApplicationInternalDescriptionCreatedByAndApplicationIdManyToManyConnection {
+  """A list of `Application` objects."""
+  nodes: [Application]!
+
+  """
+  A list of edges which contains the `Application`, info from the `ApplicationInternalDescription`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserApplicationsByApplicationInternalDescriptionCreatedByAndApplicationIdManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Application` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `Application` edge in the connection, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserApplicationsByApplicationInternalDescriptionCreatedByAndApplicationIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Application` at the end of the edge."""
+  node: Application
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserCcbcUsersByApplicationInternalDescriptionCreatedByAndUpdatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationInternalDescription`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationInternalDescriptionCreatedByAndUpdatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserCcbcUsersByApplicationInternalDescriptionCreatedByAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserCcbcUsersByApplicationInternalDescriptionCreatedByAndArchivedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationInternalDescription`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationInternalDescriptionCreatedByAndArchivedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserCcbcUsersByApplicationInternalDescriptionCreatedByAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+}
+
+"""
+A connection to a list of `Application` values, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserApplicationsByApplicationInternalDescriptionUpdatedByAndApplicationIdManyToManyConnection {
+  """A list of `Application` objects."""
+  nodes: [Application]!
+
+  """
+  A list of edges which contains the `Application`, info from the `ApplicationInternalDescription`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserApplicationsByApplicationInternalDescriptionUpdatedByAndApplicationIdManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Application` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `Application` edge in the connection, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserApplicationsByApplicationInternalDescriptionUpdatedByAndApplicationIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Application` at the end of the edge."""
+  node: Application
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserCcbcUsersByApplicationInternalDescriptionUpdatedByAndCreatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationInternalDescription`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationInternalDescriptionUpdatedByAndCreatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserCcbcUsersByApplicationInternalDescriptionUpdatedByAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserCcbcUsersByApplicationInternalDescriptionUpdatedByAndArchivedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationInternalDescription`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationInternalDescriptionUpdatedByAndArchivedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserCcbcUsersByApplicationInternalDescriptionUpdatedByAndArchivedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByArchivedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+}
+
+"""
+A connection to a list of `Application` values, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserApplicationsByApplicationInternalDescriptionArchivedByAndApplicationIdManyToManyConnection {
+  """A list of `Application` objects."""
+  nodes: [Application]!
+
+  """
+  A list of edges which contains the `Application`, info from the `ApplicationInternalDescription`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserApplicationsByApplicationInternalDescriptionArchivedByAndApplicationIdManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Application` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `Application` edge in the connection, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserApplicationsByApplicationInternalDescriptionArchivedByAndApplicationIdManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Application` at the end of the edge."""
+  node: Application
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByApplicationId(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserCcbcUsersByApplicationInternalDescriptionArchivedByAndCreatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationInternalDescription`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationInternalDescriptionArchivedByAndCreatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserCcbcUsersByApplicationInternalDescriptionArchivedByAndCreatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByCreatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+}
+
+"""
+A connection to a list of `CcbcUser` values, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserCcbcUsersByApplicationInternalDescriptionArchivedByAndUpdatedByManyToManyConnection {
+  """A list of `CcbcUser` objects."""
+  nodes: [CcbcUser]!
+
+  """
+  A list of edges which contains the `CcbcUser`, info from the `ApplicationInternalDescription`, and the cursor to aid in pagination.
+  """
+  edges: [CcbcUserCcbcUsersByApplicationInternalDescriptionArchivedByAndUpdatedByManyToManyEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `CcbcUser` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A `CcbcUser` edge in the connection, with data from `ApplicationInternalDescription`.
+"""
+type CcbcUserCcbcUsersByApplicationInternalDescriptionArchivedByAndUpdatedByManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `CcbcUser` at the end of the edge."""
+  node: CcbcUser
+
+  """
+  Reads and enables pagination through a set of `ApplicationInternalDescription`.
+  """
+  applicationInternalDescriptionsByUpdatedBy(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ApplicationInternalDescriptionCondition
+
+    """
+    A filter to be used in determining which values should be returned by the collection.
+    """
+    filter: ApplicationInternalDescriptionFilter
+  ): ApplicationInternalDescriptionsConnection!
+}
+
+"""
 A connection to a list of `Application` values, with data from `ApplicationAnalystLead`.
 """
 type AnalystApplicationsByApplicationAnalystLeadAnalystIdAndApplicationIdManyToManyConnection {
@@ -56065,6 +57727,26 @@ type Mutation {
   ): UpdateApplicationGisDataPayload
 
   """
+  Updates a single `ApplicationInternalDescription` using its globally unique id and a patch.
+  """
+  updateApplicationInternalDescription(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateApplicationInternalDescriptionInput!
+  ): UpdateApplicationInternalDescriptionPayload
+
+  """
+  Updates a single `ApplicationInternalDescription` using a unique key and a patch.
+  """
+  updateApplicationInternalDescriptionByRowId(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateApplicationInternalDescriptionByRowIdInput!
+  ): UpdateApplicationInternalDescriptionPayload
+
+  """
   Updates a single `ApplicationMilestoneData` using its globally unique id and a patch.
   """
   updateApplicationMilestoneData(
@@ -57167,6 +58849,12 @@ type Mutation {
     """
     input: CreateApplicationCommunityReportExcelDataInput!
   ): CreateApplicationCommunityReportExcelDataPayload
+  createApplicationInternalDescription(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateApplicationInternalDescriptionInput!
+  ): CreateApplicationInternalDescriptionPayload
   createApplicationMilestoneData(
     """
     The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
@@ -59799,9 +61487,6 @@ input ApplicationPatch {
 
   """archived at timestamp"""
   archivedAt: Datetime
-
-  """Internal project description for analysts"""
-  internalDescription: String
 }
 
 """All input for the `updateApplicationByRowId` mutation."""
@@ -60796,6 +62481,120 @@ input UpdateApplicationGisDataByRowIdInput {
   An object where the defined keys will be set on the `ApplicationGisData` being updated.
   """
   applicationGisDataPatch: ApplicationGisDataPatch!
+  rowId: Int!
+}
+
+"""The output of our update `ApplicationInternalDescription` mutation."""
+type UpdateApplicationInternalDescriptionPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """
+  The `ApplicationInternalDescription` that was updated by this mutation.
+  """
+  applicationInternalDescription: ApplicationInternalDescription
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Application` that is related to this `ApplicationInternalDescription`.
+  """
+  applicationByApplicationId: Application
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationInternalDescription`.
+  """
+  ccbcUserByCreatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationInternalDescription`.
+  """
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationInternalDescription`.
+  """
+  ccbcUserByArchivedBy: CcbcUser
+
+  """
+  An edge for our `ApplicationInternalDescription`. May be used by Relay 1.
+  """
+  applicationInternalDescriptionEdge(
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ApplicationInternalDescriptionsEdge
+}
+
+"""All input for the `updateApplicationInternalDescription` mutation."""
+input UpdateApplicationInternalDescriptionInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `ApplicationInternalDescription` to be updated.
+  """
+  id: ID!
+
+  """
+  An object where the defined keys will be set on the `ApplicationInternalDescription` being updated.
+  """
+  applicationInternalDescriptionPatch: ApplicationInternalDescriptionPatch!
+}
+
+"""
+Represents an update to a `ApplicationInternalDescription`. Fields that are set will be updated.
+"""
+input ApplicationInternalDescriptionPatch {
+  """Id of the application the description belongs to"""
+  applicationId: Int
+
+  """The internal description for the given application"""
+  description: String
+
+  """created by user id"""
+  createdBy: Int
+
+  """created at timestamp"""
+  createdAt: Datetime
+
+  """updated by user id"""
+  updatedBy: Int
+
+  """updated at timestamp"""
+  updatedAt: Datetime
+
+  """archived by user id"""
+  archivedBy: Int
+
+  """archived at timestamp"""
+  archivedAt: Datetime
+}
+
+"""
+All input for the `updateApplicationInternalDescriptionByRowId` mutation.
+"""
+input UpdateApplicationInternalDescriptionByRowIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `ApplicationInternalDescription` being updated.
+  """
+  applicationInternalDescriptionPatch: ApplicationInternalDescriptionPatch!
+
+  """Unique id for the row"""
   rowId: Int!
 }
 
@@ -65925,6 +67724,60 @@ input CreateApplicationCommunityReportExcelDataInput {
   _applicationId: Int!
   _jsonData: JSON!
   _oldId: Int
+}
+
+"""The output of our `createApplicationInternalDescription` mutation."""
+type CreateApplicationInternalDescriptionPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  applicationInternalDescription: ApplicationInternalDescription
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """
+  Reads a single `Application` that is related to this `ApplicationInternalDescription`.
+  """
+  applicationByApplicationId: Application
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationInternalDescription`.
+  """
+  ccbcUserByCreatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationInternalDescription`.
+  """
+  ccbcUserByUpdatedBy: CcbcUser
+
+  """
+  Reads a single `CcbcUser` that is related to this `ApplicationInternalDescription`.
+  """
+  ccbcUserByArchivedBy: CcbcUser
+
+  """
+  An edge for our `ApplicationInternalDescription`. May be used by Relay 1.
+  """
+  applicationInternalDescriptionEdge(
+    """The method to use when ordering `ApplicationInternalDescription`."""
+    orderBy: [ApplicationInternalDescriptionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ApplicationInternalDescriptionsEdge
+}
+
+"""All input for the `createApplicationInternalDescription` mutation."""
+input CreateApplicationInternalDescriptionInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  _applicationId: Int!
+  _description: String!
 }
 
 """The output of our `createApplicationMilestoneData` mutation."""

--- a/app/tests/components/Analyst/EditProjectDescription.test.tsx
+++ b/app/tests/components/Analyst/EditProjectDescription.test.tsx
@@ -83,13 +83,11 @@ describe('The EditProjectDescription component', () => {
     });
 
     componentTestingHelper.expectMutationToBeCalled(
-      'updateApplicationMutation',
+      'createApplicationInternalDescriptionMutation',
       {
         input: {
-          applicationPatch: {
-            internalDescription: 'test description 2',
-          },
-          rowId: 1,
+          _applicationId: 1,
+          _description: 'test description 2',
         },
       }
     );

--- a/db/deploy/computed_columns/application_internal_description.sql
+++ b/db/deploy/computed_columns/application_internal_description.sql
@@ -1,0 +1,17 @@
+-- Deploy ccbc:computed_columns/application_internal_description to pg
+
+begin;
+
+create or replace function ccbc_public.application_internal_description(application ccbc_public.application) returns text as
+$$
+select description from ccbc_public.application_internal_description
+  where application_id = application.id and archived_at is null
+  order by id desc limit 1;
+$$ language sql stable;
+
+comment on function ccbc_public.application_package is 'Computed column to return the internal description for an application';
+
+grant execute on function ccbc_public.application_internal_description to ccbc_analyst;
+grant execute on function ccbc_public.application_internal_description to ccbc_admin;
+
+commit;

--- a/db/deploy/mutations/create_application_internal_description.sql
+++ b/db/deploy/mutations/create_application_internal_description.sql
@@ -1,0 +1,30 @@
+-- Deploy ccbc:mutations/create_application_internal_description to pg
+
+begin;
+
+create or replace function ccbc_public.create_application_internal_description(_application_id int, _description text)
+returns ccbc_public.application_internal_description as $$
+declare
+  new_id int;
+begin
+
+  insert into ccbc_public.application_internal_description (application_id, description)
+    values (_application_id, _description) returning id into new_id;
+
+  -- archive the old internal description
+  if exists (select * from ccbc_public.application_internal_description where application_id = _application_id and archived_at is null)
+    then update ccbc_public.application_internal_description
+    set archived_at = now() where application_id = _application_id and archived_at is null and id != new_id;
+  end if;
+
+  return (select row(ccbc_public.application_internal_description.*)
+  from ccbc_public.application_internal_description
+  where id = new_id);
+
+end;
+$$ language plpgsql volatile;
+
+grant execute on function ccbc_public.create_application_internal_description to ccbc_analyst;
+grant execute on function ccbc_public.create_application_internal_description to ccbc_admin;
+
+commit;

--- a/db/deploy/tables/application_internal_description.sql
+++ b/db/deploy/tables/application_internal_description.sql
@@ -1,0 +1,40 @@
+-- Deploy ccbc:tables/application_internal_description to pg
+
+begin;
+
+alter table ccbc_public.application drop column if exists internal_description;
+
+create table ccbc_public.application_internal_description(
+  id integer primary key generated always as identity,
+  application_id integer references ccbc_public.application(id),
+  description text
+);
+
+select ccbc_private.upsert_timestamp_columns('ccbc_public', 'application_internal_description');
+
+-- enable audit/history
+select audit.enable_tracking('ccbc_public.application_internal_description'::regclass);
+
+do
+$grant$
+begin
+
+-- Grant ccbc_admin permissions
+perform ccbc_private.grant_permissions('select', 'application_internal_description', 'ccbc_admin');
+perform ccbc_private.grant_permissions('insert', 'application_internal_description', 'ccbc_admin');
+perform ccbc_private.grant_permissions('update', 'application_internal_description', 'ccbc_admin');
+
+-- Grant ccbc_analyst permissions
+perform ccbc_private.grant_permissions('select', 'application_internal_description', 'ccbc_analyst');
+perform ccbc_private.grant_permissions('insert', 'application_internal_description', 'ccbc_analyst');
+perform ccbc_private.grant_permissions('update', 'application_internal_description', 'ccbc_analyst');
+
+end
+$grant$;
+
+comment on table ccbc_public.application_internal_description is 'Table containing the internal description for the given application';
+comment on column ccbc_public.application_internal_description.id is 'Unique id for the row';
+comment on column ccbc_public.application_internal_description.application_id is 'Id of the application the description belongs to';
+comment on column ccbc_public.application_internal_description.description is 'The internal description for the given application';
+
+commit;

--- a/db/revert/computed_columns/application_internal_description.sql
+++ b/db/revert/computed_columns/application_internal_description.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:computed_columns/application_internal_description from pg
+
+begin;
+
+drop function if exists ccbc_public.application_internal_description;
+
+commit;

--- a/db/revert/mutations/create_application_internal_description.sql
+++ b/db/revert/mutations/create_application_internal_description.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:mutations/create_application_internal_description from pg
+
+begin;
+
+drop function if exists ccbc_public.create_application_internal_description;
+
+commit;

--- a/db/revert/tables/application_002_add_internal_description.sql
+++ b/db/revert/tables/application_002_add_internal_description.sql
@@ -2,6 +2,6 @@
 
 begin;
 
-alter table ccbc_public.application drop column internal_description;
+alter table ccbc_public.application drop column if exists internal_description;
 
 commit;

--- a/db/revert/tables/application_internal_description.sql
+++ b/db/revert/tables/application_internal_description.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:tables/application_internal_description from pg
+
+begin;
+
+drop table if exists ccbc_public.application_internal_description;
+
+commit;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -444,3 +444,4 @@ tables/application_002_add_internal_description 2023-10-03T17:21:27Z Marcel Muel
 mutations/withdraw_application [mutations/withdraw_application@1.105.0] 2023-10-03T21:09:05Z Marcel Mueller <marcel@m2> # add status checks for withdraw
 tables/application_002_analyst_can_see_withdrawn 2023-10-04T15:10:26Z Anthony Bushara <anthony@button.is> # Change RLS to allow analysts to be able to see withdrawn applications
 @1.108.0 2023-10-06T16:42:37Z CCBC Service Account <ccbc@button.is> # release v1.108.0
+tables/application_internal_description 2023-10-06T16:21:58Z Marcel Mueller <marcel@m2> # add table for application internal description

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -446,3 +446,4 @@ tables/application_002_analyst_can_see_withdrawn 2023-10-04T15:10:26Z Anthony Bu
 @1.108.0 2023-10-06T16:42:37Z CCBC Service Account <ccbc@button.is> # release v1.108.0
 tables/application_internal_description 2023-10-06T16:21:58Z Marcel Mueller <marcel@m2> # add table for application internal description
 mutations/create_application_internal_description 2023-10-06T17:05:19Z Marcel Mueller <marcel@m2> # mutation to create application_internal_description and archive previous one
+computed_columns/application_internal_description 2023-10-06T17:46:17Z Marcel Mueller <marcel@m2> # computed column to return the internal description associated with an application

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -445,3 +445,4 @@ mutations/withdraw_application [mutations/withdraw_application@1.105.0] 2023-10-
 tables/application_002_analyst_can_see_withdrawn 2023-10-04T15:10:26Z Anthony Bushara <anthony@button.is> # Change RLS to allow analysts to be able to see withdrawn applications
 @1.108.0 2023-10-06T16:42:37Z CCBC Service Account <ccbc@button.is> # release v1.108.0
 tables/application_internal_description 2023-10-06T16:21:58Z Marcel Mueller <marcel@m2> # add table for application internal description
+mutations/create_application_internal_description 2023-10-06T17:05:19Z Marcel Mueller <marcel@m2> # mutation to create application_internal_description and archive previous one

--- a/db/test/unit/computed_columns/application_internal_description_test.sql
+++ b/db/test/unit/computed_columns/application_internal_description_test.sql
@@ -1,0 +1,74 @@
+begin;
+
+select plan(6);
+
+truncate table
+  ccbc_public.application,
+  ccbc_public.application_status,
+  ccbc_public.attachment,
+  ccbc_public.form_data,
+  ccbc_public.application_form_data,
+  ccbc_public.intake
+restart identity cascade;
+
+select has_function('ccbc_public', 'create_application_internal_description',
+  'has create_application_internal_description function');
+
+select function_privs_are(
+  'ccbc_public', 'application_internal_description', ARRAY['ccbc_public.application'], 'ccbc_admin', ARRAY['EXECUTE'],
+  'ccbc_admin can execute ccbc_public.application_internal_description(ccbc_public.application)'
+);
+
+select function_privs_are(
+  'ccbc_public', 'application_internal_description', ARRAY['ccbc_public.application'], 'ccbc_analyst', ARRAY['EXECUTE'],
+  'ccbc_analyst can execute ccbc_public.application_internal_description(ccbc_public.application)'
+);
+
+select function_privs_are(
+  'ccbc_public', 'application_internal_description', ARRAY['ccbc_public.application'], 'ccbc_guest', ARRAY[]::text[],
+  'ccbc_guest cannot execute ccbc_public.application_internal_description(ccbc_public.application)'
+);
+
+select function_privs_are(
+  'ccbc_public', 'application_internal_description', ARRAY['ccbc_public.application'], 'ccbc_auth_user', ARRAY[]::text[],
+  'ccbc_auth_user cannot execute ccbc_public.application_internal_description(ccbc_public.application)'
+);
+
+insert into
+  ccbc_public.intake(id, open_timestamp, close_timestamp, ccbc_intake_number)
+overriding system value
+values
+  (1, '2022-08-19 09:00:00 America/Vancouver','2022-11-06 09:00:00 America/Vancouver', 1);
+
+select mocks.set_mocked_time_in_transaction('2022-08-20 09:00:00 America/Vancouver'::timestamptz);
+
+set jwt.claims.sub to 'testCcbcAuthUser';
+
+insert into ccbc_public.ccbc_user
+  (given_name, family_name, email_address, session_sub) values
+  ('foo1', 'bar', 'foo1@bar.com', 'testCcbcAuthUser');
+
+set role ccbc_auth_user;
+
+select ccbc_public.create_application();
+
+set role ccbc_analyst;
+
+insert into ccbc_public.application_status (application_id, status) VALUES (1,'received');
+
+select ccbc_public.create_application_internal_description(1, 'test description'::text);
+
+select is (
+  (
+    select ccbc_public.application_internal_description(
+      (select row(application.*)::ccbc_public.application from ccbc_public.application where id = 1)
+    )
+  ),
+  'test description',
+  'application_internal_description should be test description'
+);
+
+
+select finish();
+
+rollback;

--- a/db/test/unit/mutations/create_application_internal_description_test.sql
+++ b/db/test/unit/mutations/create_application_internal_description_test.sql
@@ -1,0 +1,69 @@
+begin;
+
+select plan(4);
+
+truncate table
+  ccbc_public.application,
+  ccbc_public.application_status,
+  ccbc_public.form_data,
+  ccbc_public.application_form_data,
+  ccbc_public.intake,
+  ccbc_public.ccbc_user
+restart identity cascade;
+
+select has_function('ccbc_public', 'create_application_internal_description',
+  'has create_application_internal_description function');
+
+insert into ccbc_public.intake(open_timestamp, close_timestamp, ccbc_intake_number)
+values('2022-03-01 09:00:00-07', '2022-05-01 09:00:00-07', 1);
+
+select mocks.set_mocked_time_in_transaction('2022-04-01 09:00:00-07'::timestamptz);
+set jwt.claims.sub to 'testCcbcAuthUser';
+insert into ccbc_public.ccbc_user
+  (given_name, family_name, email_address, session_sub) values
+  ('foo1', 'bar', 'foo1@bar.com', 'testCcbcAuthUser');
+
+set role ccbc_auth_user;
+
+select ccbc_public.create_application();
+
+
+-- set role to analyst and create application community progress report data
+set role ccbc_analyst;
+set jwt.claims.sub to 'testCcbcAnalyst';
+
+select results_eq(
+  $$
+    select id, description from ccbc_public.create_application_internal_description(1, 'test description'::text);
+  $$,
+  $$
+    values (1,'test description'::text);
+  $$,
+  'Should return newly created application_internal_description'
+);
+
+-- create another and make sure the first one is archived
+select ccbc_public.create_application_internal_description(1, 'test description 2'::text);
+
+select results_eq(
+  $$
+    select count(*) from ccbc_public.application_internal_description where application_id = 1;
+  $$,
+  $$
+    values(2::bigint);
+  $$,
+  'Should see two entries in application_internal_description for application 1'
+);
+
+select results_eq(
+  $$
+    select count(*) from ccbc_public.application_internal_description where application_id = 1 and archived_at is null;
+  $$,
+  $$
+    values(1::bigint);
+  $$,
+  'Should see 1 entry in application_internal_description for application 1'
+);
+
+select finish();
+rollback;

--- a/db/test/unit/tables/application_internal_description_test.sql
+++ b/db/test/unit/tables/application_internal_description_test.sql
@@ -1,0 +1,38 @@
+begin;
+
+select plan(8);
+
+-- Table exists
+select has_table(
+  'ccbc_public', 'application_internal_description',
+  'ccbc_public.application_internal_description should exist and be a table'
+);
+
+-- Columns
+select has_column('ccbc_public', 'application_internal_description', 'id','The table application_internal_description has column id');
+select has_column('ccbc_public', 'application_internal_description', 'application_id','The table application_internal_description has column application_id');
+select has_column('ccbc_public', 'application_internal_description', 'description','The table application_internal_description has column description');
+
+-- Privileges
+select table_privs_are(
+  'ccbc_public', 'application_internal_description', 'ccbc_guest', ARRAY[]::text[],
+  'ccbc_guest has no privileges from application_internal_description table'
+);
+
+select table_privs_are(
+  'ccbc_public', 'application_internal_description', 'ccbc_auth_user', ARRAY[]::text[],
+  'ccbc_auth_user has no privileges from application_internal_description table'
+);
+
+select table_privs_are(
+  'ccbc_public', 'application_internal_description', 'ccbc_admin', ARRAY['SELECT', 'INSERT', 'UPDATE'],
+  'ccbc_admin can select, insert and update from application_internal_description table'
+);
+
+select table_privs_are(
+  'ccbc_public', 'application_internal_description', 'ccbc_analyst', ARRAY['SELECT', 'INSERT', 'UPDATE'],
+  'ccbc_analyst can select, insert and update from application_internal_description table'
+);
+
+select finish();
+rollback;

--- a/db/test/unit/tables/application_test.sql
+++ b/db/test/unit/tables/application_test.sql
@@ -3,7 +3,7 @@ create extension if not exists pgtap;
 reset client_min_messages;
 
 begin;
-SELECT plan(10);
+SELECT plan(9);
 
 truncate table
   ccbc_public.application,
@@ -27,7 +27,6 @@ select has_table(
 select has_column('ccbc_public', 'application', 'id','The table application has column id');
 select has_column('ccbc_public', 'application', 'ccbc_number','The table application has column ccbc_number');
 select has_column('ccbc_public', 'application', 'owner','The table application has column owner');
-select has_column('ccbc_public', 'application', 'internal_description','The table application has column internal_description');
 
 
 


### PR DESCRIPTION
PR to save `internal_description` in its own table instead of the `application` table so we can better track history of changes.

Implements #2376 
