### PR TITLE
fix: use the correct keys for returned data

### DIFF
--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -363,9 +363,9 @@ const ApplicationForm: React.FC<Props> = ({
           benefits: {
             ...newFormData.benefits,
             householdsImpactedIndigenous:
-              templateData.data.result.finalEligibleHouseholds,
-            numberOfHouseholds:
               templateData.data.result.totalNumberHouseholdsImpacted,
+            numberOfHouseholds:
+              templateData.data.result.finalEligibleHouseholds,
           },
         };
       } else if (templateData.templateNumber === 2) {


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # 1379 fix for incorrect  keys associated with
<!--
Add detailed description of the changes if the PR title isn't enough
 -->
