### PR TITLE
chore: set dev cronsp to once a year

### DIFF
--- a/helm/app/values-dev.yaml
+++ b/helm/app/values-dev.yaml
@@ -1,3 +1,6 @@
+cronsp:
+  schedule: '0 0 15 10 *' # dev run once a year on October 15
+
 db:
   preUpgradeCommand: |
     psql -v "ON_ERROR_STOP=1" <<EOF


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Sets dev schedule to only run once every year.

Implements # \<issue number\>

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
