### PR TITLE
fix: add custom sorting for assessment table analysts

### DIFF
--- a/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
+++ b/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
@@ -265,41 +265,39 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
     },
     sortingFns: {
       sortAnalysts: (rowA, rowB, columnId) => {
-        const a = (
-          rowA.getValue(columnId) as { jsonData: { assignedTo: string } }
-        )?.jsonData?.assignedTo;
-        const b = (
-          rowB.getValue(columnId) as { jsonData: { assignedTo: string } }
-        )?.jsonData?.assignedTo;
+        const valueA = rowA.getValue(columnId) as any;
+        const valueB = rowB.getValue(columnId) as any;
+        const assignedToA = valueA?.jsonData?.assignedTo;
+        const assignedToB = valueB?.jsonData?.assignedTo;
 
-        if (!a && !b) {
+        if (!assignedToA && !assignedToB) {
           return 0;
         }
 
-        if (!a) {
+        if (!assignedToA) {
           return -1;
         }
 
-        if (!b) {
+        if (!assignedToB) {
           return 1;
         }
 
-        return a.localeCompare(b);
+        return assignedToA.localeCompare(assignedToB);
       },
     },
     filterFns: {
       filterAnalysts: (row, id, filterValue) => {
-        const value = (row.getValue(id) as { jsonData: { assignedTo: string } })
-          ?.jsonData?.assignedTo;
+        const value = row.getValue(id) as any;
+        const assignedTo = value?.jsonData?.assignedTo;
 
-        if (!value) {
+        if (!assignedTo) {
           return false;
         }
 
-        return value.toLowerCase().includes(filterValue.toLowerCase());
+        return assignedTo.toLowerCase().includes(filterValue.toLowerCase());
       },
       filterCcbcId: (row, id, filterValue) => {
-        const value = row.getValue(id) as string;
+        const value = row.getValue(id) as any;
 
         if (!value) {
           return false;

--- a/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
+++ b/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
@@ -297,12 +297,12 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         return assignedTo.toLowerCase().includes(filterValue.toLowerCase());
       },
       filterCcbcId: (row, id, filterValue) => {
-        const value = row.getValue(id) as any;
+        const ccbcId = row.getValue(id) as any;
 
-        if (!value) {
+        if (!ccbcId) {
           return false;
         }
-        return value.toLowerCase().includes(filterValue.toLowerCase());
+        return ccbcId.toLowerCase().includes(filterValue.toLowerCase());
       },
     },
   });

--- a/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
+++ b/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
@@ -179,6 +179,7 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         size: 26,
         maxSize: 26,
         Cell: CcbcIdCell,
+        filterFn: 'filterCcbcId',
       },
       {
         accessorKey: 'packageNumber',
@@ -295,6 +296,14 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
           return false;
         }
 
+        return value.toLowerCase().includes(filterValue.toLowerCase());
+      },
+      filterCcbcId: (row, id, filterValue) => {
+        const value = row.getValue(id) as string;
+
+        if (!value) {
+          return false;
+        }
         return value.toLowerCase().includes(filterValue.toLowerCase());
       },
     },

--- a/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
+++ b/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
@@ -28,6 +28,47 @@ type Application = {
   organizationName: string;
 };
 
+export const filterAnalysts = (row, id, filterValue) => {
+  const value = row.getValue(id) as any;
+  const assignedTo = value?.jsonData?.assignedTo;
+
+  if (!assignedTo) {
+    return false;
+  }
+
+  return assignedTo.toLowerCase().includes(filterValue.toLowerCase());
+};
+
+export const filterCcbcId = (row, id, filterValue) => {
+  const ccbcId = row.getValue(id) as any;
+
+  if (!ccbcId) {
+    return false;
+  }
+  return ccbcId.toLowerCase().includes(filterValue.toLowerCase());
+};
+
+export const sortAnalysts = (rowA, rowB, columnId) => {
+  const valueA = rowA.getValue(columnId) as any;
+  const valueB = rowB.getValue(columnId) as any;
+  const assignedToA = valueA?.jsonData?.assignedTo;
+  const assignedToB = valueB?.jsonData?.assignedTo;
+
+  if (!assignedToA && !assignedToB) {
+    return 0;
+  }
+
+  if (!assignedToA) {
+    return -1;
+  }
+
+  if (!assignedToB) {
+    return 1;
+  }
+
+  return assignedToA.localeCompare(assignedToB);
+};
+
 const findAssessment = (assessments, assessmentType) => {
   const data = assessments.find(
     ({ node: assessment }) => assessment?.assessmentDataType === assessmentType
@@ -258,46 +299,11 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
       },
     },
     sortingFns: {
-      sortAnalysts: (rowA, rowB, columnId) => {
-        const valueA = rowA.getValue(columnId) as any;
-        const valueB = rowB.getValue(columnId) as any;
-        const assignedToA = valueA?.jsonData?.assignedTo;
-        const assignedToB = valueB?.jsonData?.assignedTo;
-
-        if (!assignedToA && !assignedToB) {
-          return 0;
-        }
-
-        if (!assignedToA) {
-          return -1;
-        }
-
-        if (!assignedToB) {
-          return 1;
-        }
-
-        return assignedToA.localeCompare(assignedToB);
-      },
+      sortAnalysts,
     },
     filterFns: {
-      filterAnalysts: (row, id, filterValue) => {
-        const value = row.getValue(id) as any;
-        const assignedTo = value?.jsonData?.assignedTo;
-
-        if (!assignedTo) {
-          return false;
-        }
-
-        return assignedTo.toLowerCase().includes(filterValue.toLowerCase());
-      },
-      filterCcbcId: (row, id, filterValue) => {
-        const ccbcId = row.getValue(id) as any;
-
-        if (!ccbcId) {
-          return false;
-        }
-        return ccbcId.toLowerCase().includes(filterValue.toLowerCase());
-      },
+      filterAnalysts,
+      filterCcbcId,
     },
   });
   return <MaterialReactTable table={table} />;

--- a/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
+++ b/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
@@ -49,7 +49,6 @@ const AssessmentCell = ({ cell }) => {
   const row = cell.row.original;
   const { applicationId, allAnalysts } = row;
   const assessment = cell.getValue();
-
   return (
     <AssessmentLead
       allAnalysts={allAnalysts.edges}
@@ -193,6 +192,7 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         size: assessmentWidth,
         maxSize: assessmentWidth,
         Cell: AssessmentCell,
+        sortingFn: 'sortAnalysts',
       },
       {
         accessorKey: 'techAssessment',
@@ -200,6 +200,7 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         size: assessmentWidth,
         maxSize: assessmentWidth,
         Cell: AssessmentCell,
+        sortingFn: 'sortAnalysts',
       },
       {
         accessorKey: 'permittingAssessment',
@@ -207,6 +208,7 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         size: assessmentWidth,
         maxSize: assessmentWidth,
         Cell: AssessmentCell,
+        sortingFn: 'sortAnalysts',
       },
       {
         accessorKey: 'gisAssessment',
@@ -214,6 +216,7 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         size: assessmentWidth,
         maxSize: assessmentWidth,
         Cell: AssessmentCell,
+        sortingFn: 'sortAnalysts',
       },
       {
         accessorKey: 'techAssessment.jsonData.targetDate',
@@ -253,6 +256,30 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         padding: '0px',
         wordBreak: 'break-word',
         texOverflow: 'wrap',
+      },
+    },
+    sortingFns: {
+      sortAnalysts: (rowA, rowB, columnId) => {
+        const a = (
+          rowA.getValue(columnId) as { jsonData: { assignedTo: string } }
+        )?.jsonData?.assignedTo;
+        const b = (
+          rowB.getValue(columnId) as { jsonData: { assignedTo: string } }
+        )?.jsonData?.assignedTo;
+
+        if (!a && !b) {
+          return 0;
+        }
+
+        if (!a) {
+          return -1;
+        }
+
+        if (!b) {
+          return 1;
+        }
+
+        return a.localeCompare(b);
       },
     },
   });

--- a/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
+++ b/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
@@ -171,6 +171,16 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
   );
 
   const assessmentWidth = 36;
+
+  // Sonarcloud duplicate lines
+  const sharedAssessmentCell = {
+    size: assessmentWidth,
+    maxSize: assessmentWidth,
+    Cell: AssessmentCell,
+    sortingFn: 'sortAnalysts',
+    filterFn: 'filterAnalysts',
+  };
+
   const columns = useMemo<MRT_ColumnDef<Application>[]>(
     () => [
       {
@@ -188,40 +198,24 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         maxSize: 24,
       },
       {
+        ...sharedAssessmentCell,
         accessorKey: 'pmAssessment',
         header: 'PM Assessment',
-        size: assessmentWidth,
-        maxSize: assessmentWidth,
-        Cell: AssessmentCell,
-        sortingFn: 'sortAnalysts',
-        filterFn: 'filterAnalysts',
       },
       {
+        ...sharedAssessmentCell,
         accessorKey: 'techAssessment',
         header: 'Tech Assessment',
-        size: assessmentWidth,
-        maxSize: assessmentWidth,
-        Cell: AssessmentCell,
-        sortingFn: 'sortAnalysts',
-        filterFn: 'filterAnalysts',
       },
       {
+        ...sharedAssessmentCell,
         accessorKey: 'permittingAssessment',
         header: 'Permitting Assessment',
-        size: assessmentWidth,
-        maxSize: assessmentWidth,
-        Cell: AssessmentCell,
-        sortingFn: 'sortAnalysts',
-        filterFn: 'filterAnalysts',
       },
       {
+        ...sharedAssessmentCell,
         accessorKey: 'gisAssessment',
         header: 'GIS Assessment',
-        size: assessmentWidth,
-        maxSize: assessmentWidth,
-        Cell: AssessmentCell,
-        sortingFn: 'sortAnalysts',
-        filterFn: 'filterAnalysts',
       },
       {
         accessorKey: 'techAssessment.jsonData.targetDate',

--- a/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
+++ b/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
@@ -193,6 +193,7 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         maxSize: assessmentWidth,
         Cell: AssessmentCell,
         sortingFn: 'sortAnalysts',
+        filterFn: 'filterAnalysts',
       },
       {
         accessorKey: 'techAssessment',
@@ -201,6 +202,7 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         maxSize: assessmentWidth,
         Cell: AssessmentCell,
         sortingFn: 'sortAnalysts',
+        filterFn: 'filterAnalysts',
       },
       {
         accessorKey: 'permittingAssessment',
@@ -209,6 +211,7 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         maxSize: assessmentWidth,
         Cell: AssessmentCell,
         sortingFn: 'sortAnalysts',
+        filterFn: 'filterAnalysts',
       },
       {
         accessorKey: 'gisAssessment',
@@ -217,6 +220,7 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         maxSize: assessmentWidth,
         Cell: AssessmentCell,
         sortingFn: 'sortAnalysts',
+        filterFn: 'filterAnalysts',
       },
       {
         accessorKey: 'techAssessment.jsonData.targetDate',
@@ -280,6 +284,18 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         }
 
         return a.localeCompare(b);
+      },
+    },
+    filterFns: {
+      filterAnalysts: (row, id, filterValue) => {
+        const value = (row.getValue(id) as { jsonData: { assignedTo: string } })
+          ?.jsonData?.assignedTo;
+
+        if (!value) {
+          return false;
+        }
+
+        return value.toLowerCase().includes(filterValue.toLowerCase());
       },
     },
   });

--- a/app/tests/components/AnalystDashboard/AssessmentAssignmentTable.test.tsx
+++ b/app/tests/components/AnalystDashboard/AssessmentAssignmentTable.test.tsx
@@ -20,7 +20,6 @@ const mockQueryPayload = {
           {
             node: {
               familyName: 'Analyst GIS',
-
               givenName: 'Test',
               active: true,
             },
@@ -230,5 +229,78 @@ describe('The AssessmentAssignmentTable component', () => {
         },
       }
     );
+  });
+
+  it('should correctly filter the CCBC ID column', async () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent();
+
+    expect(screen.getByText('CCBC-010002')).toBeVisible();
+
+    const columnActions = document.querySelectorAll(
+      '[aria-label="Column Actions"]'
+    )[0];
+
+    await act(async () => {
+      fireEvent.click(columnActions);
+    });
+
+    const ccbcIdFilter = screen.getByText('Filter by CCBC ID');
+
+    await act(async () => {
+      fireEvent.click(ccbcIdFilter);
+    });
+
+    const filterInput = screen.getByPlaceholderText('Filter by CCBC ID');
+
+    await act(async () => {
+      fireEvent.change(filterInput, { target: { value: 'CCBC-010001' } });
+    });
+
+    await new Promise((r) => {
+      setTimeout(r, 500);
+    });
+
+    expect(screen.getByText('CCBC-010001')).toBeInTheDocument();
+    expect(screen.queryByText('CCBC-010002')).not.toBeInTheDocument();
+  });
+
+  it('should correctly filter the PM Assessment column', async () => {
+    componentTestingHelper.loadQuery();
+    componentTestingHelper.renderComponent();
+
+    const analyst = screen.queryAllByText('Test Analyst Project Management')[0];
+
+    expect(analyst).toBeVisible();
+
+    const columnActions = document.querySelectorAll(
+      '[aria-label="Column Actions"]'
+    )[2];
+
+    await act(async () => {
+      fireEvent.click(columnActions);
+    });
+
+    const pmAssessmentFilter = screen.getByText('Filter by PM Assessment');
+
+    await act(async () => {
+      fireEvent.click(pmAssessmentFilter);
+    });
+
+    const filterInput = screen.getByPlaceholderText('Filter by PM Assessment');
+
+    await act(async () => {
+      fireEvent.change(filterInput, { target: { value: 'Test Analyst GIS' } });
+    });
+
+    await new Promise((r) => {
+      setTimeout(r, 500);
+    });
+
+    const analystAfterFilter = screen.queryAllByText(
+      'Test Analyst Project Management'
+    )[0];
+
+    expect(analystAfterFilter).toBeFalsy();
   });
 });

--- a/app/tests/components/AnalystDashboard/AssessmentAssignmentTable.test.tsx
+++ b/app/tests/components/AnalystDashboard/AssessmentAssignmentTable.test.tsx
@@ -1,7 +1,11 @@
 import { act, fireEvent, screen } from '@testing-library/react';
 import { graphql } from 'react-relay';
 import ComponentTestingHelper from 'tests/utils/componentTestingHelper';
-import AssessmentAssignmentTable from 'components/AnalystDashboard/AssessmentAssignmentTable';
+import AssessmentAssignmentTable, {
+  filterAnalysts,
+  filterCcbcId,
+  sortAnalysts,
+} from 'components/AnalystDashboard/AssessmentAssignmentTable';
 import compiledQuery, {
   AssessmentAssignmentTableTestQuery,
 } from '__generated__/AssessmentAssignmentTableTestQuery.graphql';
@@ -302,5 +306,93 @@ describe('The AssessmentAssignmentTable component', () => {
     )[0];
 
     expect(analystAfterFilter).toBeFalsy();
+  });
+});
+
+describe('The filterAnalysts function', () => {
+  const mockData = {
+    getValue: () => {
+      return {
+        jsonData: {
+          assignedTo: 'Test Analyst GIS',
+        },
+      };
+    },
+  };
+
+  it('should return true if the analyst name contains the filter value', () => {
+    expect(filterAnalysts(mockData, 1, 'GIS')).toBeTruthy();
+  });
+
+  it('should return false if the analyst name does not contain the filter value', () => {
+    expect(filterAnalysts(mockData, 1, 'PM')).toBeFalsy();
+  });
+});
+
+describe('The filterCcbcId function', () => {
+  const mockData = {
+    getValue: () => {
+      return 'CCBC-010001';
+    },
+  };
+
+  it('should return true if the CCBC ID contains the filter value', () => {
+    expect(filterCcbcId(mockData, 1, 'CCBC-010001')).toBeTruthy();
+  });
+
+  it('should return false if the CCBC ID does not contain the filter value', () => {
+    expect(filterCcbcId(mockData, 1, 'CCBC-010002')).toBeFalsy();
+  });
+});
+
+describe('The sortAnalysts function', () => {
+  const mockDataA = {
+    getValue: () => {
+      return {
+        jsonData: {
+          assignedTo: 'Test Analyst GIS',
+        },
+      };
+    },
+  };
+
+  const mockDataB = {
+    getValue: () => {
+      return {
+        jsonData: {
+          assignedTo: 'Test Analyst Project Management',
+        },
+      };
+    },
+  };
+
+  const mockDataC = {
+    getValue: () => {
+      return {
+        jsonData: {
+          assignedTo: null,
+        },
+      };
+    },
+  };
+
+  it('should return -1 if the first analyst is null', () => {
+    expect(sortAnalysts(mockDataC, mockDataA, 1)).toEqual(-1);
+  });
+
+  it('should return 1 if the second analyst is null', () => {
+    expect(sortAnalysts(mockDataA, mockDataC, 1)).toEqual(1);
+  });
+
+  it('should return 0 if both analysts are null', () => {
+    expect(sortAnalysts(mockDataC, mockDataC, 1)).toEqual(0);
+  });
+
+  it('should return 1 if the first analyst is null', () => {
+    expect(sortAnalysts(mockDataA, mockDataC, 1)).toEqual(1);
+  });
+
+  it('should return -1 if both analysts are not null', () => {
+    expect(sortAnalysts(mockDataA, mockDataB, 1)).toEqual(-1);
   });
 });


### PR DESCRIPTION
Fixes for a few sorting and filtering issues. 

- The `CCBC ID` column filtering will not return any value that contains an `01` anymore if you type say `ccbc-01`, it will return all values that start with `ccbc-01`.
- All four assessment columns sorting and filtering is fixed. This was due to the value being an object since it has the custom dropdown for editing so by default the sorting/filtering was broken as it didn't know which values to look for.