### PR TITLE
feat: metabase link is not visible while in edit mode

### DIFF
--- a/app/components/Analyst/Project/CommunityProgressReport/CommunityProgressReportForm.tsx
+++ b/app/components/Analyst/Project/CommunityProgressReport/CommunityProgressReportForm.tsx
@@ -354,7 +354,7 @@ const CommunityProgressReportForm: React.FC<Props> = ({
               title="Add community progress report"
             />
 
-            {communityProgressList?.length > 0 && (
+            {!isFormEditMode && communityProgressList?.length > 0 && (
               <MetabaseLink
                 href={`https://ccbc-metabase.apps.silver.devops.gov.bc.ca/dashboard/95-community-progress-report-prod?ccbc_number=${ccbcNumber}`}
                 text="View project data in Metabase"


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # 2328 comment for not showing metabase link while in edit mode

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
