### PR TITLE
fix: change withdrawal modal description

### DIFF
--- a/app/components/Dashboard/Modal.tsx
+++ b/app/components/Dashboard/Modal.tsx
@@ -79,7 +79,7 @@ const WithdrawModal = ({ application, setApplication }) => {
         <StyledContent>
           <p>
             Applications submitted are deemed as property of BC. Withdrawing
-            this application will remove it from consideration for Connection
+            this application will remove it from consideration for Connected
             Communities BC funding program. You will not be able to re-submit
             the application. If you would like to re-submit, you must start a
             new application.


### PR DESCRIPTION
Implements #2613 

Change withdrawal modal description to fix typo `Connection` to `Connected`
