### PR TITLE
fix: intake edit and delete with time machine

### DIFF
--- a/app/components/Admin/Intake.tsx
+++ b/app/components/Admin/Intake.tsx
@@ -1,5 +1,6 @@
 import { ConnectionHandler, graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
+import cookie from 'js-cookie';
 import { DateTime } from 'luxon';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faClose, faPen } from '@fortawesome/free-solid-svg-icons';
@@ -135,7 +136,11 @@ const Intake: React.FC<IntakeProps> = ({
     DateTime.DATETIME_FULL
   );
 
-  const currentDateTime = DateTime.now();
+  const mockedDateCookie = cookie.get('mocks.mocked_date');
+  const currentDateTime = mockedDateCookie
+    ? DateTime.fromJSDate(new Date(Date.parse(mockedDateCookie)))
+    : DateTime.now();
+
   const startDateTime = DateTime.fromISO(openTimestamp);
   const endDateTime = DateTime.fromISO(closeTimestamp);
   const isAllowedDelete = currentDateTime <= startDateTime;


### PR DESCRIPTION
Implements # [NDT-41](https://connectivitydivision.atlassian.net/browse/NDT-41)

Intake edit and delete functionality fixed with time machine


[NDT-41]: https://connectivitydivision.atlassian.net/browse/NDT-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ