### PR TITLE
fix: use unique key on StyledFile and for Fragment

### DIFF
--- a/app/components/Review/widgets/FileWidget.tsx
+++ b/app/components/Review/widgets/FileWidget.tsx
@@ -66,7 +66,7 @@ const FileWidget: React.FC<WidgetProps> = ({
         const attachments = rfi?.attachments?.nodes;
 
         return (
-          <StyledFile key={rfi}>
+          <StyledFile key={rfi.id}>
             {rfiFiles[fieldName]?.map((el, index) => {
               // loop through the list of files for the current field
               const isSingleFile = !options?.allowMultipleFiles;
@@ -81,9 +81,8 @@ const FileWidget: React.FC<WidgetProps> = ({
                   DateTime.fromISO(attachmentData.createdAt).toLocaleString(
                     DateTime.DATETIME_MED
                   ));
-
               return (
-                <>
+                <React.Fragment key={el.uuid}>
                   {isDisplayIcon ? (
                     <StyledIconDiv>
                       <FontAwesomeIcon
@@ -115,7 +114,7 @@ const FileWidget: React.FC<WidgetProps> = ({
                       <span>{fileDate}</span>
                     </StyledDetails>
                   )}
-                </>
+                </React.Fragment>
               );
             })}
           </StyledFile>


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements NED-17 fix

Uses a better key for the StyledFile and adds a key on the fragment

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
