### PR TITLE
fix: incorrect status type criteria in assessment table

### DIFF
--- a/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
+++ b/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
@@ -143,8 +143,8 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         }
         allApplications(
           filter: {
-            status: {
-              in: ["received", "screening", "assessment", "recommendation"]
+            analystStatus: { 
+              in: ["received", "screening", "assessment"] 
             }
           }
         ) {
@@ -161,7 +161,7 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
               }
               organizationName
               package
-              status
+              analystStatus
               ccbcNumber
               rowId
               projectName

--- a/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
+++ b/app/components/AnalystDashboard/AssessmentAssignmentTable.tsx
@@ -143,9 +143,7 @@ const AssessmentAssignmentTable: React.FC<Props> = ({ query }) => {
         }
         allApplications(
           filter: {
-            analystStatus: { 
-              in: ["received", "screening", "assessment"] 
-            }
+            analystStatus: { in: ["received", "screening", "assessment"] }
           }
         ) {
           edges {


### PR DESCRIPTION
Implements #[NDT-13](https://connectivitydivision.atlassian.net/browse/NDT-13)

changed status type criteria to --> `analystStatus`
removed status `recommendation` from list

![image](https://github.com/bcgov/CONN-CCBC-portal/assets/150947867/55341feb-aa77-497f-a11b-49506e7a7da9)

010002, 0100003 and 010077 are shown now, but 010004 or 010041 are not shown since its in `recommendation`
![image](https://github.com/bcgov/CONN-CCBC-portal/assets/150947867/3ab61de6-2770-40f4-84cb-6d375dfa865f)



[NDT-13]: https://connectivitydivision.atlassian.net/browse/NDT-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ