### PR TITLE
fix: withdrawal modal typo

### DIFF
--- a/app/components/Dashboard/Modal.tsx
+++ b/app/components/Dashboard/Modal.tsx
@@ -79,7 +79,7 @@ const WithdrawModal = ({ application, setApplication }) => {
         <StyledContent>
           <p>
             Applications submitted are deemed as property of BC. Withdrawing
-            this application will remove it from consideration for Connected
+            this application will remove it from consideration for Connecting
             Communities BC funding program. You will not be able to re-submit
             the application. If you would like to re-submit, you must start a
             new application.


### PR DESCRIPTION
Implements #[NDT-50](https://connectivitydivision.atlassian.net/browse/NDT-50)

Changed withdrawal modal wording from `connected` to `connecting`

![image](https://github.com/bcgov/CONN-CCBC-portal/assets/150947867/3c1d1b7e-e76d-4182-9849-a026e003da41)



[NDT-50]: https://connectivitydivision.atlassian.net/browse/NDT-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ