### PR TITLE
chore: making a spatial data upload a multiple upload

### DIFF
--- a/app/components/Analyst/History/HistoryContent.tsx
+++ b/app/components/Analyst/History/HistoryContent.tsx
@@ -360,7 +360,7 @@ const HistoryContent = ({ historyItem, prevHistoryItem }) => {
               filesArray={
                 record.json_data?.main?.upload?.finalizedMapUpload || []
               }
-              title="Finalized map"
+              title="Finalized spatial data"
               tableTitle={false}
             />
           </>

--- a/app/components/Analyst/Project/ProjectInformation/ProjectInformationForm.tsx
+++ b/app/components/Analyst/Project/ProjectInformation/ProjectInformationForm.tsx
@@ -458,7 +458,7 @@ const ProjectInformationForm: React.FC<Props> = ({
             isChangeRequest
             isFormEditMode={isFormEditMode}
             isSowUploadError={jsonData?.isSowUploadError}
-            map={updatedMapUpload?.[0]}
+            maps={updatedMapUpload}
             sow={statementOfWorkUpload?.[0]}
           />
         );
@@ -475,7 +475,7 @@ const ProjectInformationForm: React.FC<Props> = ({
           }}
           isFormEditMode={isFormEditMode}
           isSowUploadError={projectInformationData?.isSowUploadError}
-          map={projectInformationData?.finalizedMapUpload?.[0]}
+          maps={projectInformationData?.finalizedMapUpload}
           sow={projectInformationData?.statementOfWorkUpload?.[0]}
           fundingAgreement={projectInformationData?.fundingAgreementUpload?.[0]}
           wirelessSow={projectInformationData?.sowWirelessUpload?.[0]}

--- a/app/components/Analyst/Project/ProjectInformation/ReadOnlyView.tsx
+++ b/app/components/Analyst/Project/ProjectInformation/ReadOnlyView.tsx
@@ -138,7 +138,7 @@ interface Props {
   descriptionOfChanges?: string;
   fundingAgreement?: any;
   levelOfAmendment?: string;
-  maps?: any;
+  maps?: Array<any>;
   onFormEdit?: any;
   isChangeRequest?: boolean;
   isFormEditMode?: boolean;
@@ -217,16 +217,15 @@ const ReadOnlyView: React.FC<Props> = ({
           )}
         </StyledColumn>
         <StyledColumn>
-          {maps &&
-            maps.map((mapItem) => (
-              <DownloadLink
-                key={mapItem.uuid}
-                uuid={mapItem.uuid}
-                fileName={mapItem.name}
-              >
-                <FileHeader icon={faMap} title={mapItem.name} />
-              </DownloadLink>
-            ))}
+          {maps?.map((mapItem) => (
+            <DownloadLink
+              key={mapItem.uuid}
+              uuid={mapItem.uuid}
+              fileName={mapItem.name}
+            >
+              <FileHeader icon={faMap} title={mapItem.name} />
+            </DownloadLink>
+          ))}
           {wirelessSow && (
             <DownloadLink uuid={wirelessSow.uuid} fileName={wirelessSow.name}>
               <FileHeader icon={faFileExcel} title="Wireless SoW" />

--- a/app/components/Analyst/Project/ProjectInformation/ReadOnlyView.tsx
+++ b/app/components/Analyst/Project/ProjectInformation/ReadOnlyView.tsx
@@ -138,7 +138,7 @@ interface Props {
   descriptionOfChanges?: string;
   fundingAgreement?: any;
   levelOfAmendment?: string;
-  map?: any;
+  maps?: any;
   onFormEdit?: any;
   isChangeRequest?: boolean;
   isFormEditMode?: boolean;
@@ -159,7 +159,7 @@ const ReadOnlyView: React.FC<Props> = ({
   isFormEditMode,
   isSowUploadError,
   levelOfAmendment,
-  map,
+  maps,
   onFormEdit,
   sow,
   title,
@@ -217,11 +217,16 @@ const ReadOnlyView: React.FC<Props> = ({
           )}
         </StyledColumn>
         <StyledColumn>
-          {map && (
-            <DownloadLink uuid={map.uuid} fileName={map.name}>
-              <FileHeader icon={faMap} title="Map" />
-            </DownloadLink>
-          )}
+          {maps &&
+            maps.map((mapItem) => (
+              <DownloadLink
+                key={mapItem.uuid}
+                uuid={mapItem.uuid}
+                fileName={mapItem.name}
+              >
+                <FileHeader icon={faMap} title={mapItem.name} />
+              </DownloadLink>
+            ))}
           {wirelessSow && (
             <DownloadLink uuid={wirelessSow.uuid} fileName={wirelessSow.name}>
               <FileHeader icon={faFileExcel} title="Wireless SoW" />

--- a/app/cypress/e2e/analyst/application/[applicationId]/history.cy.js
+++ b/app/cypress/e2e/analyst/application/[applicationId]/history.cy.js
@@ -34,7 +34,7 @@ describe('The analyst history page', () => {
     cy.contains('Statement of Work Excel');
     cy.contains('SOW Wireless Table');
     cy.contains('Funding agreement');
-    cy.contains('Finalized map');
+    cy.contains('Finalized spatial data');
 
     // Announcement
     cy.contains('announcement');

--- a/app/formSchema/analyst/changeRequest.ts
+++ b/app/formSchema/analyst/changeRequest.ts
@@ -55,7 +55,7 @@ const changeRequest: JSONSchema7 = {
       type: 'string',
     },
     updatedMapUpload: {
-      title: 'Upload the updated map (optional)',
+      title: 'Upload updated spatial data (kmz)',
       type: 'string',
     },
   },

--- a/app/formSchema/analyst/projectInformation.ts
+++ b/app/formSchema/analyst/projectInformation.ts
@@ -45,7 +45,7 @@ const projectInformation: JSONSchema7 = {
               type: 'string',
             },
             finalizedMapUpload: {
-              title: 'Upload the finalized map, if available',
+              title: 'Upload the finalized spatial data (kmz)',
               type: 'string',
             },
             sowValidationErrors: {

--- a/app/formSchema/uiSchema/analyst/changeRequestUiSchema.ts
+++ b/app/formSchema/uiSchema/analyst/changeRequestUiSchema.ts
@@ -67,6 +67,8 @@ const changeRequestUiSchema = {
     'ui:widget': 'FileWidget',
     'ui:options': {
       flexDirection: 'column',
+      fileTypes: '.kmz',
+      allowMultipleFiles: true,
     },
   },
 };

--- a/app/formSchema/uiSchema/analyst/projectInformationUiSchema.ts
+++ b/app/formSchema/uiSchema/analyst/projectInformationUiSchema.ts
@@ -29,6 +29,10 @@ const projectInformationUiSchema = {
   },
   finalizedMapUpload: {
     'ui:widget': 'FileWidget',
+    'ui:options': {
+      fileTypes: '.kmz',
+      allowMultipleFiles: true,
+    },
   },
   sowValidationErrors: {
     'ui:widget': 'HiddenWidget',

--- a/app/tests/components/Analyst/Project/ProjectInformation/ProjectInformationForm.test.ts
+++ b/app/tests/components/Analyst/Project/ProjectInformation/ProjectInformationForm.test.ts
@@ -86,7 +86,14 @@ const mockDataQueryPayload = {
           finalizedMapUpload: [
             {
               id: 10,
-              name: 'test.pdf',
+              name: 'test1.kmz',
+              size: 0,
+              type: 'application/pdf',
+              uuid: '4120e972-d2b3-40f0-a540-e2a57721d962',
+            },
+            {
+              id: 10,
+              name: 'test2.kmz',
               size: 0,
               type: 'application/pdf',
               uuid: '4120e972-d2b3-40f0-a540-e2a57721d962',
@@ -265,7 +272,8 @@ describe('The ProjectInformation form', () => {
 
     expect(screen.getAllByText('SoW')[0]).toBeInTheDocument();
 
-    expect(screen.getAllByText('Map')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('test1.kmz')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('test2.kmz')[0]).toBeInTheDocument();
 
     expect(screen.getByText('Wireless SoW')).toBeInTheDocument();
 


### PR DESCRIPTION
Implements [#NDT-51](https://connectivitydivision.atlassian.net/browse/NDT-51)

✅On Analyst portal, the kmz upload for signed agreement is now a multifile upload, and should operate the same way as other multifile uploads in the portal
![image](https://github.com/bcgov/CONN-CCBC-portal/assets/150947867/90d0f9da-b825-4a97-b98e-a136d2d66e41)
![image](https://github.com/bcgov/CONN-CCBC-portal/assets/150947867/b704f687-2b7a-4afa-8cd5-1a5eaab0ee2b)
![image](https://github.com/bcgov/CONN-CCBC-portal/assets/150947867/c4670b8b-eccd-4687-b853-3be01c779c49)

✅Update wording for Map upload as per screen design

✅Update wording in history to reflect wording change for the map upload
![image](https://github.com/bcgov/CONN-CCBC-portal/assets/150947867/5a12a66d-d8a0-4323-b514-9ace2072b930)

✅update map upload in change request to a multiple upload as well
![image](https://github.com/bcgov/CONN-CCBC-portal/assets/150947867/4741ba25-aaf3-4609-b565-478838663724)
