### PR TITLE
feat: disable/enable submit based on project area data

### DIFF
--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -256,6 +256,9 @@ const ApplicationForm: React.FC<Props> = ({
       jsonData?.projectArea?.geographicArea?.[0]?.toString()
     )
   );
+  const [isFnLed, setIsFnLed] = useState(
+    jsonData?.projectArea?.firstNationsLed || false
+  );
   const [areAllAcknowledgementsChecked, setAreAllacknowledgementsChecked] =
     useState(verifyAllAcknowledgementsChecked(jsonData.acknowledgements));
   const [areAllSubmissionFieldsSet, setAreAllSubmissionFieldsSet] = useState(
@@ -343,7 +346,7 @@ const ApplicationForm: React.FC<Props> = ({
         jsonData?.review?.acknowledgeIncomplete &&
         !isSubmitted &&
         isEditable &&
-        !isProjectAreaOpen
+        (!isProjectAreaOpen || isFnLed)
       );
 
     return true;
@@ -357,6 +360,7 @@ const ApplicationForm: React.FC<Props> = ({
     isSubmitted,
     isEditable,
     isProjectAreaOpen,
+    isFnLed,
   ]);
 
   if (subschemaArray.length < pageNumber) {
@@ -391,6 +395,7 @@ const ApplicationForm: React.FC<Props> = ({
       const projectAreaAccepted = acceptedProjectAreasArray.includes(
         newFormSectionData?.geographicArea?.[0]?.toString()
       );
+      setIsFnLed(newFormSectionData?.firstNationsLed || false);
       setProjectAreaOpen(!projectAreaAccepted);
       setProjectAreaModalOpen(
         !projectAreaAccepted &&


### PR DESCRIPTION
disable or enables the submit button on the form if the project area is fn led and has any zone, or if not fn led then it must be based on the zones selected on growthbook

<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements [NDT-63]
<!--
Add detailed description of the changes if the PR title isn't enough
 -->


[NDT-63]: https://connectivitydivision.atlassian.net/browse/NDT-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ