### PR TITLE
chore: update submission page warning for zone selection

### DIFF
--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -256,9 +256,6 @@ const ApplicationForm: React.FC<Props> = ({
       jsonData?.projectArea?.geographicArea?.[0]?.toString()
     )
   );
-  const [isFnLed, setIsFnLed] = useState(
-    jsonData?.projectArea?.firstNationsLed || false
-  );
   const [areAllAcknowledgementsChecked, setAreAllacknowledgementsChecked] =
     useState(verifyAllAcknowledgementsChecked(jsonData.acknowledgements));
   const [areAllSubmissionFieldsSet, setAreAllSubmissionFieldsSet] = useState(
@@ -346,7 +343,7 @@ const ApplicationForm: React.FC<Props> = ({
         jsonData?.review?.acknowledgeIncomplete &&
         !isSubmitted &&
         isEditable &&
-        (!isProjectAreaOpen || isFnLed)
+        !isProjectAreaOpen
       );
 
     return true;
@@ -360,7 +357,6 @@ const ApplicationForm: React.FC<Props> = ({
     isSubmitted,
     isEditable,
     isProjectAreaOpen,
-    isFnLed,
   ]);
 
   if (subschemaArray.length < pageNumber) {
@@ -392,16 +388,25 @@ const ApplicationForm: React.FC<Props> = ({
       updateAreAllSubmissionFieldsSet(newFormSectionData);
     }
     if (isProjectAreaPage) {
-      const projectAreaAccepted = acceptedProjectAreasArray.includes(
-        newFormSectionData?.geographicArea?.[0]?.toString()
-      );
-      setIsFnLed(newFormSectionData?.firstNationsLed || false);
+      const firstNationsLed = newFormSectionData?.firstNationsLed || false;
+      const projectAreaAccepted =
+        firstNationsLed ||
+        acceptedProjectAreasArray.includes(
+          newFormSectionData?.geographicArea?.[0]?.toString()
+        );
+
       setProjectAreaOpen(!projectAreaAccepted);
+
+      const geographicAreaInputChanged =
+        typeof newFormSectionData?.geographicArea?.[0] !== 'undefined' &&
+        newFormSectionData?.geographicArea[0] !==
+          jsonData.projectArea?.geographicArea?.[0];
+      const firstNationsLedInputChanged =
+        firstNationsLed !== jsonData.projectArea?.firstNationsLed;
+
       setProjectAreaModalOpen(
         !projectAreaAccepted &&
-          typeof newFormSectionData?.geographicArea?.[0] !== 'undefined' &&
-          newFormSectionData?.geographicArea[0] !==
-            jsonData.projectArea?.geographicArea?.[0]
+          (geographicAreaInputChanged || firstNationsLedInputChanged)
       );
     }
 

--- a/app/lib/theme/widgets/custom/ReadOnlySubmissionWidget.tsx
+++ b/app/lib/theme/widgets/custom/ReadOnlySubmissionWidget.tsx
@@ -19,8 +19,15 @@ const StyledError = styled('div')`
 `;
 
 const StyledLink = styled(Link)`
-  color: ${(props) => props.theme.color.links};
-  text-decoration: none;
+  color: #e71f1f;
+`;
+
+const StyledList = styled.ul`
+  margin-bottom: 0.5rem;
+`;
+
+const StyledListItem = styled.li`
+  margin-bottom: 0;
 `;
 
 const ReadOnlySubmissionWidget: React.FC<WidgetProps> = ({
@@ -29,6 +36,8 @@ const ReadOnlySubmissionWidget: React.FC<WidgetProps> = ({
   formContext,
 }) => {
   const uiSchema = formContext.finalUiSchema['ui:order'];
+  const acceptedProjectAreas = formContext?.acceptedProjectAreasArray || null;
+
   return (
     <>
       <StyledContainer>
@@ -75,10 +84,27 @@ const ReadOnlySubmissionWidget: React.FC<WidgetProps> = ({
         {formContext.isProjectAreaOpen && (
           <>
             <br />
-            Unfortunately, we are currently not accepting applications for the
-            selected zone. However, you have the option of saving this
-            application as a draft for the next subsequent intake. Thank you for
-            your understanding.
+            For this intake CCBC is considering 2 types of projects;
+            <StyledList>
+              <StyledListItem>
+                ones that are Zones: {acceptedProjectAreas?.toString()}, or
+              </StyledListItem>
+              <StyledListItem>
+                projects that are First Nations-led or First Nations-supported
+                in any area of the province.
+              </StyledListItem>
+            </StyledList>
+            Please review your selections on the{' '}
+            <StyledLink
+              href={`/applicantportal/form/${formContext.rowId}/${getFormPage(
+                uiSchema,
+                'projectArea'
+              )}`}
+            >
+              {` Project Area `}
+            </StyledLink>{' '}
+            page to ensure your project meets these requirements to be able to
+            submit it during this intake.
           </>
         )}
       </StyledError>

--- a/app/tests/pages/applicantportal/form/[page].test.tsx
+++ b/app/tests/pages/applicantportal/form/[page].test.tsx
@@ -236,4 +236,31 @@ describe('The form page', () => {
 
     await userEvent.click(modalOkButton);
   });
+
+  it('handles modal correctly when first nation based', async () => {
+    pageTestingHelper.setMockRouterValues({
+      query: { id: '1', page: '2' },
+    });
+
+    jest.spyOn(moduleApi, 'useFeature').mockReturnValue(mockAcceptedZones);
+
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    const areas = screen.getAllByLabelText(
+      'Referring to the project zones (application guide Annex 6), which zone(s) will this project be conducted in?'
+    );
+    expect(areas).toHaveLength(14);
+
+    const fnQuestion = screen.getAllByLabelText('Yes')[0];
+
+    await userEvent.click(fnQuestion);
+    await userEvent.click(areas[5]);
+
+    expect(
+      screen.queryByText(
+        'For this intake, CCBC is considering projects that are in Zones 1, 2, 3, 4, or 5 if the project is not First Nations-led or First Nations-supported.'
+      )
+    ).not.toBeInTheDocument();
+  });
 });

--- a/app/tests/pages/applicantportal/form/[page].test.tsx
+++ b/app/tests/pages/applicantportal/form/[page].test.tsx
@@ -237,7 +237,7 @@ describe('The form page', () => {
     await userEvent.click(modalOkButton);
   });
 
-  it('handles modal correctly when first nation based', async () => {
+  it('handles modal correctly when first nation based and not an available zone', async () => {
     pageTestingHelper.setMockRouterValues({
       query: { id: '1', page: '2' },
     });
@@ -262,5 +262,36 @@ describe('The form page', () => {
         'For this intake, CCBC is considering projects that are in Zones 1, 2, 3, 4, or 5 if the project is not First Nations-led or First Nations-supported.'
       )
     ).not.toBeInTheDocument();
+  });
+
+  it('handles modal correctly when not first nation based and not an available zone', async () => {
+    pageTestingHelper.setMockRouterValues({
+      query: { id: '1', page: '2' },
+    });
+
+    jest.spyOn(moduleApi, 'useFeature').mockReturnValue(mockAcceptedZones);
+
+    pageTestingHelper.loadQuery();
+    pageTestingHelper.renderPage();
+
+    const areas = screen.getAllByLabelText(
+      'Referring to the project zones (application guide Annex 6), which zone(s) will this project be conducted in?'
+    );
+    expect(areas).toHaveLength(14);
+
+    const fnQuestion = screen.getAllByLabelText('No')[0];
+
+    await userEvent.click(fnQuestion);
+    await userEvent.click(areas[5]);
+
+    expect(
+      screen.getByText(
+        'For this intake, CCBC is considering projects that are in Zones 1, 2, 3, 4, or 5 if the project is not First Nations-led or First Nations-supported.'
+      )
+    ).toBeInTheDocument();
+
+    const modalOkButton = screen.getByTestId('project-modal-ok');
+
+    await userEvent.click(modalOkButton);
   });
 });


### PR DESCRIPTION
Implements #[NDT-55](https://connectivitydivision.atlassian.net/browse/NDT-55)

✅ If applicant has not clicked Yes to the FN question on Project area page and they have not selected one of the zones (1,2,3,6) then display text in red bold:  
![image](https://github.com/bcgov/CONN-CCBC-portal/assets/150947867/b2918404-3671-40d5-b87b-78f3ef1dac0f)

✅ Update the logic for the modal so that it operates with the FN question


[NDT-55]: https://connectivitydivision.atlassian.net/browse/NDT-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ