### PR TITLE
fix: submit disabled on some cases

### DIFF
--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -272,6 +272,9 @@ const ApplicationForm: React.FC<Props> = ({
   const [areAllSubmissionFieldsSet, setAreAllSubmissionFieldsSet] = useState(
     verifyAllSubmissionsFilled(jsonData.submission)
   );
+  const [isAcknowledgeIncomplete, setIsAcknowledgeIncomplete] = useState(
+    jsonData?.review?.acknowledgeIncomplete || false
+  );
   const [templateData, setTemplateData] = useState(null);
 
   const formContext = useMemo(() => {
@@ -337,6 +340,7 @@ const ApplicationForm: React.FC<Props> = ({
   const isAcknowledgementPage = sectionName === 'acknowledgements';
   const isProjectAreaPage = sectionName === 'projectArea';
   const isOtherFundingSourcesPage = sectionName === 'otherFundingSources';
+  const isReviewPage = sectionName === 'review';
 
   const isSubmitEnabled = useMemo(() => {
     if (isUpdating) return false;
@@ -354,6 +358,7 @@ const ApplicationForm: React.FC<Props> = ({
         areAllSubmissionFieldsSet &&
         areAllAcknowledgementsChecked &&
         (noErrors || jsonData?.review?.acknowledgeIncomplete) &&
+        isAcknowledgeIncomplete &&
         !isSubmitted &&
         isEditable &&
         !isProjectAreaOpen
@@ -369,6 +374,7 @@ const ApplicationForm: React.FC<Props> = ({
     jsonData,
     isSubmitted,
     isEditable,
+    isAcknowledgeIncomplete,
     isProjectAreaOpen,
     isUpdating,
   ]);
@@ -411,6 +417,11 @@ const ApplicationForm: React.FC<Props> = ({
     }
     if (isSubmitPage) {
       updateAreAllSubmissionFieldsSet(newFormSectionData);
+    }
+    if (isReviewPage) {
+      setIsAcknowledgeIncomplete(
+        newFormSectionData?.acknowledgeIncomplete || false
+      );
     }
     if (isProjectAreaPage) {
       const firstNationsLed = newFormSectionData?.firstNationsLed || false;


### PR DESCRIPTION
This turns the acknowledgeIncomplete into a state as sometimes it will have stale data at the submission page and would cause the submit button to be disabled until page refresh/reloading the application

<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Fixes [NDT-95]

<!--
Add detailed description of the changes if the PR title isn't enough
 -->


[NDT-95]: https://connectivitydivision.atlassian.net/browse/NDT-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ