### PR TITLE
fix: use filteredUiSchema to give correct lastEditedPage

### DIFF
--- a/app/components/Dashboard/Row.tsx
+++ b/app/components/Dashboard/Row.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
 import styled from 'styled-components';
 import statusStyles from 'data/statusStyles';
+import { getFilteredSchemaOrderFromUiSchema } from 'utils/schemaUtils';
+import { uiSchema } from 'formSchema';
 import StatusPill from '../StatusPill';
 
 const StyledRow = styled('tr')`
@@ -39,13 +41,7 @@ const StyledWithdraw = styled.button`
   color: #d8292f;
 `;
 
-const Row = ({
-  application,
-  formPages,
-  reviewPage,
-  setCurrentApplication,
-  setArchiveId,
-}) => {
+const Row = ({ application, setCurrentApplication, setArchiveId, schema }) => {
   const {
     ccbcNumber,
     intakeByIntakeId,
@@ -56,7 +52,9 @@ const Row = ({
     id,
   } = application;
 
-  const lastEditedIndex = formPages.indexOf(formData.lastEditedPage) + 1;
+  const uiOrder = getFilteredSchemaOrderFromUiSchema(schema, uiSchema);
+  const lastEditedIndex = uiOrder.indexOf(formData.lastEditedPage) + 1;
+  const reviewPage = uiOrder.indexOf('review') + 1;
 
   const intakeClosingDate = intakeByIntakeId?.closeTimestamp;
   const isIntakeClosed = intakeClosingDate

--- a/app/components/Dashboard/Table.tsx
+++ b/app/components/Dashboard/Table.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import schema from 'formSchema/schema';
 import { dashboardQuery$data } from '__generated__/dashboardQuery.graphql';
 import Tooltip from '@mui/material/Tooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -47,9 +46,6 @@ const Table = ({ applications }: Props) => {
     .map((edge) => edge.node)
     .filter((node) => node !== null);
 
-  const formPages = Object.keys(schema.properties);
-
-  const reviewPage = formPages.indexOf('review') + 1;
   return (
     <>
       <StyledTable>
@@ -78,10 +74,9 @@ const Table = ({ applications }: Props) => {
               <Row
                 application={application}
                 key={application.owner}
-                formPages={formPages}
-                reviewPage={reviewPage}
                 setCurrentApplication={setCurrentApplication}
                 setArchiveId={setArchiveId}
+                schema={application.formData.formByFormSchemaId.jsonSchema}
               />
             ) : null;
           })}

--- a/app/components/Form/ApplicationForm.tsx
+++ b/app/components/Form/ApplicationForm.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../lib/theme/customFieldCalculations';
 import ApplicationFormStatus from './ApplicationFormStatus';
 import {
+  getFilteredSchemaOrderFromUiSchema,
   getSectionNameFromPageNumber,
   schemaToSubschemasArray,
 } from '../../utils/schemaUtils';
@@ -226,12 +227,10 @@ const ApplicationForm: React.FC<Props> = ({
     () => validate(jsonData, jsonSchema),
     [jsonData, jsonSchema]
   );
-  const filteredUiSchemaOrder = uiSchema['ui:order'].filter((formName) => {
-    return Object.prototype.hasOwnProperty.call(
-      jsonSchema.properties,
-      formName
-    );
-  });
+  const filteredUiSchemaOrder = getFilteredSchemaOrderFromUiSchema(
+    jsonSchema,
+    uiSchema
+  );
   if (ccbcIntakeNumber !== null && ccbcIntakeNumber <= 2) {
     finalUiSchema = {
       ...uiSchema,
@@ -463,7 +462,7 @@ const ApplicationForm: React.FC<Props> = ({
       : pageNumber - 1;
     const lastEditedPage =
       pageNumber < subschemaArray.length
-        ? subschemaArray[lastEditedPageNumber][0]
+        ? finalUiSchema['ui:order'][lastEditedPageNumber]
         : '';
 
     setSavingError(null);

--- a/app/pages/applicantportal/dashboard.tsx
+++ b/app/pages/applicantportal/dashboard.tsx
@@ -35,6 +35,9 @@ const getDashboardQuery = graphql`
           formData {
             lastEditedPage
             isEditable
+            formByFormSchemaId {
+              jsonSchema
+            }
           }
           intakeByIntakeId {
             ccbcIntakeNumber

--- a/app/tests/components/Dashboard/Dashboard.test.tsx
+++ b/app/tests/components/Dashboard/Dashboard.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { graphql } from 'react-relay';
+import { schema } from 'formSchema';
 import { DashboardTable } from '../../../components/Dashboard';
 import ComponentTestingHelper from '../../utils/componentTestingHelper';
 import compiledDashboardTestQuery, {
@@ -22,6 +23,9 @@ const testQuery = graphql`
           formData {
             lastEditedPage
             isEditable
+            formByFormSchemaId {
+              jsonSchema
+            }
           }
           intakeByIntakeId {
             ccbcIntakeNumber
@@ -50,6 +54,9 @@ const mockQueryPayload = {
               formData: {
                 lastEditedPage: '',
                 isEditable: false,
+                formByFormSchemaId: {
+                  jsonSchema: schema,
+                },
               },
               intakeByIntakeId: {
                 ccbcIntakeNumber: 1,
@@ -69,6 +76,9 @@ const mockQueryPayload = {
               formData: {
                 lastEditedPage: '',
                 isEditable: true,
+                formByFormSchemaId: {
+                  jsonSchema: schema,
+                },
               },
               intakeByIntakeId: {
                 ccbcIntakeNumber: 1,
@@ -88,6 +98,9 @@ const mockQueryPayload = {
               formData: {
                 lastEditedPage: '',
                 isEditable: true,
+                formByFormSchemaId: {
+                  jsonSchema: schema,
+                },
               },
               intakeByIntakeId: {
                 ccbcIntakeNumber: 1,
@@ -147,6 +160,9 @@ describe('The Dashboard', () => {
                   formData: {
                     lastEditedPage: 'templateUploads',
                     isEditable: true,
+                    formByFormSchemaId: {
+                      jsonSchema: schema,
+                    },
                   },
                   intakeByIntakeId: null,
                 },
@@ -181,6 +197,9 @@ describe('The Dashboard', () => {
                   formData: {
                     lastEditedPage: '',
                     isEditable: true,
+                    formByFormSchemaId: {
+                      jsonSchema: schema,
+                    },
                   },
                   intakeByIntakeId: {
                     ccbcIntakeNumber: 1,
@@ -220,6 +239,9 @@ describe('The Dashboard', () => {
                   formData: {
                     lastEditedPage: '',
                     isEditable: true,
+                    formByFormSchemaId: {
+                      jsonSchema: schema,
+                    },
                   },
                   intakeByIntakeId: {
                     ccbcIntakeNumber: 1,
@@ -275,6 +297,9 @@ describe('The Dashboard', () => {
                   formData: {
                     lastEditedPage: '',
                     isEditable: false,
+                    formByFormSchemaId: {
+                      jsonSchema: schema,
+                    },
                   },
                   intakeByIntakeId: {
                     ccbcIntakeNumber: 1,
@@ -312,6 +337,9 @@ describe('The Dashboard', () => {
                   formData: {
                     lastEditedPage: '',
                     isEditable: false,
+                    formByFormSchemaId: {
+                      jsonSchema: schema,
+                    },
                   },
                   intakeByIntakeId: {
                     ccbcIntakeNumber: 1,
@@ -350,6 +378,9 @@ describe('The Dashboard', () => {
                   formData: {
                     lastEditedPage: '',
                     isEditable: true,
+                    formByFormSchemaId: {
+                      jsonSchema: schema,
+                    },
                   },
                   intakeByIntakeId: {
                     ccbcIntakeNumber: 1,
@@ -397,6 +428,13 @@ describe('The Dashboard', () => {
               {
                 node: {
                   status: 'submitted',
+                  formData: {
+                    lastEditedPage: '',
+                    isEditable: true,
+                    formByFormSchemaId: {
+                      jsonSchema: schema,
+                    },
+                  },
                 },
               },
             ],
@@ -421,6 +459,13 @@ describe('The Dashboard', () => {
               {
                 node: {
                   status: 'received',
+                  formData: {
+                    lastEditedPage: '',
+                    isEditable: true,
+                    formByFormSchemaId: {
+                      jsonSchema: schema,
+                    },
+                  },
                 },
               },
             ],
@@ -445,6 +490,13 @@ describe('The Dashboard', () => {
               {
                 node: {
                   status: 'applicant_conditionally_approved',
+                  formData: {
+                    lastEditedPage: '',
+                    isEditable: true,
+                    formByFormSchemaId: {
+                      jsonSchema: schema,
+                    },
+                  },
                 },
               },
             ],
@@ -469,6 +521,13 @@ describe('The Dashboard', () => {
               {
                 node: {
                   status: 'draft',
+                  formData: {
+                    lastEditedPage: '',
+                    isEditable: true,
+                    formByFormSchemaId: {
+                      jsonSchema: schema,
+                    },
+                  },
                 },
               },
             ],

--- a/app/tests/pages/applicantportal/dashboard.test.tsx
+++ b/app/tests/pages/applicantportal/dashboard.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react';
 import * as moduleApi from '@growthbook/growthbook-react';
 import { FeatureResult, JSONValue } from '@growthbook/growthbook-react';
 import userEvent from '@testing-library/user-event';
+import { schema } from 'formSchema';
 import Dashboard, {
   withRelayOptions,
 } from '../../../pages/applicantportal/dashboard';
@@ -72,6 +73,9 @@ const mockQueryPayload = {
               formData: {
                 lastEditedPage: '',
                 isEditable: false,
+                formByFormSchemaId: {
+                  jsonSchema: schema,
+                },
               },
               intakeByIntakeId: {
                 ccbcIntakeNumber: 1,
@@ -91,6 +95,9 @@ const mockQueryPayload = {
               formData: {
                 lastEditedPage: '',
                 isEditable: false,
+                formByFormSchemaId: {
+                  jsonSchema: schema,
+                },
               },
               intakeByIntakeId: {
                 ccbcIntakeNumber: 2,
@@ -108,6 +115,9 @@ const mockQueryPayload = {
               formData: {
                 lastEditedPage: '',
                 isEditable: false,
+                formByFormSchemaId: {
+                  jsonSchema: schema,
+                },
               },
               intakeByIntakeId: {
                 ccbcIntakeNumber: 3,
@@ -151,7 +161,7 @@ const mockNoApplicationsPayload = {
 const mockClosedIntakePayload = {
   Query() {
     return {
-      allApplications: { nodes: [] },
+      allApplications: { edges: [] },
       session: {
         sub: '4e0ac88c-bf05-49ac-948f-7fd53c7a9fd6',
       },
@@ -164,7 +174,7 @@ const mockClosedIntakePayload = {
 const mockClosedIntakeOpenHiddenIntakePayload = {
   Query() {
     return {
-      allApplications: { nodes: [] },
+      allApplications: { edges: [] },
       session: {
         sub: '4e0ac88c-bf05-49ac-948f-7fd53c7a9fd6',
       },

--- a/app/utils/schemaUtils.ts
+++ b/app/utils/schemaUtils.ts
@@ -10,6 +10,20 @@ export const schemaToSubschemasArray = (
   return Object.entries(schema.properties as any);
 };
 
+/**
+ *
+ * @param schema Any json schema
+ * @param uiSchema The uiSchema that could apply to the schema, can contain more fields than the schema
+ */
+export const getFilteredSchemaOrderFromUiSchema = (
+  schema: any,
+  uiSchema: any
+) => {
+  return uiSchema['ui:order'].filter((formName) => {
+    return Object.hasOwn(schema.properties, formName);
+  });
+};
+
 export const getSectionNameFromPageNumber = (
   uiSchema,
   pageNumber: number


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements fix for NDT-89 and also NDT-91, the crux of the issue is that the current updateApplicationForm query doesn't trigger the out of sync error if the user is on the same page. The change I made here is to consistently return the correct page, thus reducing the chance of the out of sync error happening erroneously. 

I explored other options, one that I believe would solve this issue without needing to use a sync-check on the database is to use the subscription feature of graphQL and adding a subscription to the formData on this page. The work required for that though, I believe, is of far greater scope than what I believe this ticket intended so I went with this approach. 

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
