### PR TITLE
chore: disable immortal prs on renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,5 @@
   "onboarding": false,
   "repositories": ["bcgov/CONN-CCBC-portal"],
   "gitAuthor": "CCBC Service Account <116113628+ccbc-service-account@users.noreply.github.com>",
-  "recreateClosed": true
+  "recreateClosed": false
 }


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # \<issue number\>

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
