### PR TITLE
fix: use 'full' option to include unchanged value

### DIFF
--- a/app/components/Analyst/History/HistoryFile.tsx
+++ b/app/components/Analyst/History/HistoryFile.tsx
@@ -30,6 +30,7 @@ const HistoryFile = ({
 }) => {
   const filesDiff = diff(previousFileArray || [], filesArray || [], {
     keepUnchangedValues: true,
+    full: true,
   });
   return filesDiff ? (
     <StyledTable>

--- a/app/tests/pages/analyst/application/[applicationId]/history.test.tsx
+++ b/app/tests/pages/analyst/application/[applicationId]/history.test.tsx
@@ -3138,7 +3138,7 @@ describe('The index page', () => {
 
     const claimHistoryFile = screen.getAllByTestId(
       'history-content-claims-file'
-    )[0];
+    )[1];
 
     expect(claimHistoryFile).toHaveTextContent(
       /Uploaded Claims & Progress Report Excel/
@@ -3195,7 +3195,7 @@ describe('The index page', () => {
 
     const claimHistoryFile = screen.getAllByTestId(
       'history-content-milestone-evidence-file'
-    )[0];
+    )[1];
 
     expect(claimHistoryFile).toHaveTextContent(
       'Uploaded Milestone Completion Evidence'


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements fix for history page, problem occured as the docs doesn't explicitly state that scalar values aren't included in "keepUnchangedValues"

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
