### PR TITLE
test: fix assessment assignment table flaky tests

### DIFF
--- a/app/tests/components/AnalystDashboard/AssessmentAssignmentTable.test.tsx
+++ b/app/tests/components/AnalystDashboard/AssessmentAssignmentTable.test.tsx
@@ -279,6 +279,8 @@ describe('The AssessmentAssignmentTable component', () => {
     componentTestingHelper.loadQuery();
     componentTestingHelper.renderComponent();
 
+    jest.setTimeout(5000);
+
     expect(screen.getByText('CCBC-010007')).toBeVisible();
 
     const columnActions = document.querySelectorAll(

--- a/app/tests/components/AnalystDashboard/AssessmentAssignmentTable.test.tsx
+++ b/app/tests/components/AnalystDashboard/AssessmentAssignmentTable.test.tsx
@@ -327,18 +327,10 @@ describe('The AssessmentAssignmentTable component', () => {
       fireEvent.keyDown(zoneFilter, { key: 'Enter', code: 'Enter' });
     });
 
-    await new Promise((r) => {
-      setTimeout(r, 500);
-    });
-
     const filterInput = screen.getAllByRole('option')[0];
 
     await act(async () => {
       fireEvent.click(filterInput);
-    });
-
-    await new Promise((r) => {
-      setTimeout(r, 500);
     });
 
     expect(screen.getByText('CCBC-010001')).toBeInTheDocument();


### PR DESCRIPTION
Tests were being flakey due to some timeouts and the changes to the table (it looks like), removed async from zone to make it more consistent and increase timeout to 5000ms just in case.

<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements # \<issue number\>

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
