### PR TITLE
fix: 2nd review colour not showing on assessment dash

### DIFF
--- a/app/components/AnalystDashboard/AssessmentLead.tsx
+++ b/app/components/AnalystDashboard/AssessmentLead.tsx
@@ -68,13 +68,13 @@ const AssignLead: React.FC<Props> = ({
   } else if (jsonData?.nextStep === 'Needs RFI') {
     color = assessmentPillStyles['Needs RFI'].primary;
     backgroundColor = assessmentPillStyles['Needs RFI'].backgroundColor;
+  } else if (jsonData?.nextStep === 'Needs 2nd review') {
+    backgroundColor = assessmentPillStyles['Needs 2nd review'].backgroundColor;
+    color = assessmentPillStyles['Needs 2nd review'].primary;
     // Assigned
   } else if ((jsonData?.nextStep === 'Not started' && leadState) || leadState) {
     backgroundColor = assessmentPillStyles.Assigned.backgroundColor;
     color = assessmentPillStyles.Assigned.primary;
-  } else if (jsonData?.nextStep === 'Needs 2nd review') {
-    backgroundColor = assessmentPillStyles['Needs 2nd review'].backgroundColor;
-    color = assessmentPillStyles['Needs 2nd review'].primary;
   } else {
     backgroundColor = 'inherit';
     color = 'inherit';


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements [NDT-184]

<!--
Add detailed description of the changes if the PR title isn't enough
 -->


[NDT-184]: https://connectivitydivision.atlassian.net/browse/NDT-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ