### PR TITLE
fix: datacatalog url in area widget

### DIFF
--- a/app/data/externalConstants.ts
+++ b/app/data/externalConstants.ts
@@ -8,6 +8,9 @@ export const ZONE_MAP_URL_INTAKE_4 =
 export const INTAKE_3_AREAS_OF_INTEREST =
   'https://catalogue.data.gov.bc.ca/dataset/connecting-communities-bc-intake-3-areas-of-interest';
 
+export const INTAKE_4_AREAS_OF_INTEREST =
+  'https://catalogue.data.gov.bc.ca/dataset/332a5676-9171-4c50-add3-5c590fd7b985';
+
 export const CCBC_ASSESSMENT_RFI_INSTRUCTIONS =
   'https://bcgov.sharepoint.com/:w:/r/teams/00978-ConnectingCommunitiesProgram/Shared%20Documents/CCBC%20Program/0%20-%20Business%20Process%20Documentation/CCBC%20Assessment%20and%20RFI%20Instructions.docx?d=w2ef0e37b4bf6484abf9d78cdc6e4b4ec&csf=1&web=1&e=AngUhG';
 

--- a/app/lib/theme/widgets/custom/ReadOnlyProjectAreaWidgetIntakeFour.tsx
+++ b/app/lib/theme/widgets/custom/ReadOnlyProjectAreaWidgetIntakeFour.tsx
@@ -1,5 +1,7 @@
 import { WidgetProps } from '@rjsf/utils';
+import Link from '@button-inc/bcgov-theme/Link';
 import styled from 'styled-components';
+import { INTAKE_4_AREAS_OF_INTEREST } from 'data/externalConstants';
 
 const StyledError = styled('div')`
   font-weight: 700;
@@ -12,8 +14,15 @@ const ReadOnlyProjectAreaWidgetIntakeFour: React.FC<WidgetProps> = () => {
       <StyledError>
         IMPORTANT: For Intake 4, CCBC will accept applications for all eligible
         areas in the Province. In particular, in certain areas of interest that
-        have been highlighted in all zones. Refer to the BC Data catalogue for
-        maps of these areas of interest.
+        have been highlighted in all zones. Refer to the{' '}
+        <Link
+          href={INTAKE_4_AREAS_OF_INTEREST}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          BC Data catalogue
+        </Link>{' '}
+        for maps of these areas of interest.
       </StyledError>
       <StyledError>
         Projects that are First Nation-led or First Nation-supported continue to


### PR DESCRIPTION
Implements [NDT-286](https://connectivitydivision.atlassian.net/browse/NDT-286)


[NDT-286]: https://connectivitydivision.atlassian.net/browse/NDT-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ