### PR TITLE
fix: cleanup unarchived application status

### DIFF
--- a/db/deploy/clean_application_status.sql
+++ b/db/deploy/clean_application_status.sql
@@ -1,0 +1,35 @@
+-- Deploy ccbc:clean_application_status to pg
+
+BEGIN;
+
+WITH latest_rows AS (
+    SELECT application_id, MAX(created_at) AS latest_created_at
+    FROM ccbc_public.application_status
+    WHERE archived_at IS NULL
+    AND status IN ('applicant_approved', 'applicant_cancelled', 'applicant_closed', 'applicant_complete', 'applicant_conditionally_approved', 'applicant_on_hold', 'applicant_received', 'draft', 'received', 'submitted', 'withdrawn')
+    GROUP BY application_id
+)
+UPDATE ccbc_public.application_status AS a
+SET archived_at = CURRENT_TIMESTAMP
+FROM latest_rows AS l
+WHERE a.application_id = l.application_id
+AND a.created_at <> l.latest_created_at
+AND a.archived_at IS NULL
+AND a.status IN ('applicant_approved', 'applicant_cancelled', 'applicant_closed', 'applicant_complete', 'applicant_conditionally_approved', 'applicant_on_hold', 'applicant_received', 'draft', 'received', 'submitted', 'withdrawn');
+
+WITH latest_rows AS (
+    SELECT application_id, MAX(created_at) AS latest_created_at
+    FROM ccbc_public.application_status
+    WHERE archived_at IS NULL
+    AND status IN ('analyst_withdrawn', 'approved', 'assessment', 'cancelled', 'closed', 'complete', 'conditionally_approved', 'on_hold', 'recommendation', 'screening')
+    GROUP BY application_id
+)
+UPDATE ccbc_public.application_status AS a
+SET archived_at = CURRENT_TIMESTAMP
+FROM latest_rows AS l
+WHERE a.application_id = l.application_id
+AND a.created_at <> l.latest_created_at
+AND a.archived_at IS NULL
+AND a.status IN ('analyst_withdrawn', 'approved', 'assessment', 'cancelled', 'closed', 'complete', 'conditionally_approved', 'on_hold', 'recommendation', 'screening');
+
+COMMIT;

--- a/db/revert/clean_application_status.sql
+++ b/db/revert/clean_application_status.sql
@@ -1,0 +1,7 @@
+-- Revert ccbc:clean_application_status from pg
+
+BEGIN;
+
+-- No real revert due to ccbc_private.archived_records_are_immutable (Deleted records cannot be modified)
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -554,3 +554,4 @@ tables/analyst_add_email 2024-04-08T17:55:49Z ,,, <ryohani89@NH504670> # add ana
 tables/email_record 2024-04-19T17:24:25Z ,,, <ryohani89@NH504670> # add email record table
 tables/notification 2024-04-18T19:54:33Z ,,, <ryohani89@NH504670> # add email notification table
 mutations/create_email_notifications 2024-04-21T02:42:44Z ,,, <ryohani89@NH504670> # add create email notifications mutation
+clean_application_status 2024-04-24T23:07:28Z Rafael Solorzano <61289255+rafasdc@users.noreply.github.com> # cleans application status table by setting archived_at to ones that are missing it


### PR DESCRIPTION
Archives lingering rows of the application status table that were not archived as they were created before the auto archiving function was created, leaves behind the two latest application status one for analyst and one for applicant.

<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements [NDT-270]

<!--
Add detailed description of the changes if the PR title isn't enough
 -->


[NDT-270]: https://connectivitydivision.atlassian.net/browse/NDT-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ