### PR TITLE
fix: only use first name on e-mail

### DIFF
--- a/app/backend/lib/emails/templates/agreementSignedStatusChange.ts
+++ b/app/backend/lib/emails/templates/agreementSignedStatusChange.ts
@@ -16,7 +16,7 @@ const agreementSignedStatusChange: EmailTemplateProvider = (
     tag: 'agreement-signed-status-change',
     subject: `Action Required - Upload SOW for ${ccbcNumber}`,
     body: `
-      <h1>${initiator.givenName} ${initiator.familyName} has changed the status for ${ccbcNumber} to 'Agreement Signed'</h1>
+      <h1>${initiator.givenName} has changed the status for ${ccbcNumber} to 'Agreement Signed'</h1>
       <p>Please upload the SOW <a href='${url}/analyst/application/${applicationId}/project'>here</a><p>
     `,
   };

--- a/app/backend/lib/emails/templates/agreementSignedStatusChangeDataTeam.ts
+++ b/app/backend/lib/emails/templates/agreementSignedStatusChangeDataTeam.ts
@@ -16,7 +16,7 @@ const agreementSignedStatusChangeDataTeam: EmailTemplateProvider = (
     tag: 'agreement-signed-status-change-data-team',
     subject: `Action Required - Upload KMZ for ${ccbcNumber}`,
     body: `
-      <h1>${initiator.givenName} ${initiator.familyName} has changed the status for ${ccbcNumber} to 'Agreement Signed'</h1>
+      <h1>${initiator.givenName} has changed the status for ${ccbcNumber} to 'Agreement Signed'</h1>
       <p>Please upload the KMZ file <a href='${url}/analyst/application/${applicationId}/project'>here</a><p>
     `,
   };


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements [NDT-267] fix to only show first name

<!--
Add detailed description of the changes if the PR title isn't enough
 -->


[NDT-267]: https://connectivitydivision.atlassian.net/browse/NDT-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ