### PR TITLE
chore: update applciation_history_test to use mock time

### DIFF
--- a/db/test/unit/computed_columns/application_history_test.sql
+++ b/db/test/unit/computed_columns/application_history_test.sql
@@ -22,7 +22,7 @@ select has_function(
 insert into ccbc_public.intake(open_timestamp, close_timestamp, ccbc_intake_number)
 values('2022-03-01 09:00:00-07', '2024-05-01 09:00:00-07', 1);
 
---select mocks.set_mocked_time_in_transaction('2022-04-01 09:00:00-07'::timestamptz);
+select mocks.set_mocked_time_in_transaction('2022-04-01 09:00:00-07'::timestamptz);
 
 set jwt.claims.sub to 'testCcbcAuthUser';
 insert into ccbc_public.ccbc_user


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Uncomments using the mock time which for some reason was commented out, allowing tests to pass

<!--
Add detailed description of the changes if the PR title isn't enough
 -->
