### PR TITLE
fix: undefined project labels

### DIFF
--- a/app/components/Analyst/Project/fields/ProjectFieldTemplate.tsx
+++ b/app/components/Analyst/Project/fields/ProjectFieldTemplate.tsx
@@ -35,7 +35,10 @@ const ProjectFieldTemplate: React.FC<FieldTemplateProps> = ({
   children,
   uiSchema,
 }) => {
-  const uiTitle = `${uiSchema?.['ui:label'] ?? uiSchema?.['ui:title']}`;
+  const uiTitle =
+    uiSchema?.['ui:label'] || uiSchema?.['ui:title']
+      ? `${uiSchema?.['ui:label'] ?? uiSchema?.['ui:title']}`
+      : null;
   const hidden = uiSchema?.['ui:widget'] === 'HiddenWidget' || false;
   return (
     <>


### PR DESCRIPTION
adds a condition to check for the existence of the label or title before turning it into a string, otherwise null is returned so the h4 is not rendered. It was causing unintended "undefined" to be shown as labels on conditional approval

<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements [NDT-]

<!--
Add detailed description of the changes if the PR title isn't enough
 -->

- [ ] Check to trigger automatic release process
