### PR TITLE
fix: ccbc-prepare-download

### DIFF
--- a/helm/app/templates/cronJobs/prepare-download.yaml
+++ b/helm/app/templates/cronJobs/prepare-download.yaml
@@ -20,7 +20,7 @@ spec:
           containers:
             - env: {{ include "ccbc.ccbcAppUserPgEnv" . | nindent 16 }}
               name: {{ template "ccbc.fullname" . }}-receive-applications
-              image: {{ .Values.image.db.repository }}:{{ .Values.image.db.tag }}
+              image: docker.io/alpine/curl
               imagePullPolicy: {{ .Values.image.db.pullPolicy }}
               resources:
                 limits:
@@ -31,7 +31,7 @@ spec:
                   memory: 64Mi
               command:
                 - /usr/bin/env
-                - bash
+                - sh
                 - -c
                 - |
                   curl --location --request GET '{{ .Values.secureRoute.host }}/api/analyst/admin-archive/-1' --header 'x-api-key: {{ .Values.objectStorage.awsS3SecretKey }}'


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Noticed the ccbc-prepare-download was failing as it was missing curl since we are now using a sqitch only image, changing image to use alpine curl and update command to use sh instead of bash. Tested on test manually.

Implements [NDT-]

<!--
Add detailed description of the changes if the PR title isn't enough
 -->

- [ ] Check to trigger automatic release process
