### PR TITLE
fix: grant service account to cbc change request table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.168.1](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.168.0...v1.168.1) (2024-07-10)
+
+### Bug Fixes
+
+- grant service account to cbc change request table ([38917f7](https://github.com/bcgov/CONN-CCBC-portal/commit/38917f775498e2f41a4edb8bf72b3c6b2a49488e))
+
 # [1.168.0](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.167.2...v1.168.0) (2024-07-10)
 
 ### Bug Fixes

--- a/db/deploy/tables/cbc_application_pending_change_request_001_service_account.sql
+++ b/db/deploy/tables/cbc_application_pending_change_request_001_service_account.sql
@@ -1,0 +1,17 @@
+-- Deploy ccbc:tables/cbc_application_pending_change_request_001_service_account to pg
+
+BEGIN;
+
+do
+$grant$
+begin
+
+-- Grant ccbc_service_account permissions
+perform ccbc_private.grant_permissions('select', 'cbc_application_pending_change_request', 'ccbc_service_account');
+perform ccbc_private.grant_permissions('insert', 'cbc_application_pending_change_request', 'ccbc_service_account');
+perform ccbc_private.grant_permissions('update', 'cbc_application_pending_change_request', 'ccbc_service_account');
+
+end
+$grant$;
+
+COMMIT;

--- a/db/revert/tables/cbc_application_pending_change_request_001_service_account.sql
+++ b/db/revert/tables/cbc_application_pending_change_request_001_service_account.sql
@@ -1,0 +1,9 @@
+-- Revert ccbc:tables/cbc_application_pending_change_request_001_service_account from pg
+
+BEGIN;
+
+  revoke select on ccbc_public.cbc_application_pending_change_request from ccbc_service_account;
+  revoke update on ccbc_public.cbc_application_pending_change_request from ccbc_service_account;
+  revoke insert on ccbc_public.cbc_application_pending_change_request from ccbc_service_account;
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -595,3 +595,4 @@ mutations/create_intake [mutations/create_intake@1.165.0] 2024-06-28T14:03:53Z ,
 mutations/update_intake [mutations/update_intake@1.165.0] 2024-06-28T22:32:24Z ,,, <ryohani89@NH504670> # change update intake mutation to accept rolling flag
 @1.168.0 2024-07-10T13:35:28Z CCBC Service Account <ccbc@button.is> # release v1.168.0
 tables/cbc_application_pending_change_request_001_service_account 2024-07-09T22:28:27Z Rafael Solorzano <61289255+rafasdc@users.noreply.github.com> # grant service account access to cbc application pending change request table
+@1.168.1 2024-07-10T23:15:41Z CCBC Service Account <ccbc@button.is> # release v1.168.1

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -594,3 +594,4 @@ mutations/submit_application [mutations/submit_application@1.165.0] 2024-06-27T1
 mutations/create_intake [mutations/create_intake@1.165.0] 2024-06-28T14:03:53Z ,,, <ryohani89@NH504670> # change create intake mutation to accept rolling flag
 mutations/update_intake [mutations/update_intake@1.165.0] 2024-06-28T22:32:24Z ,,, <ryohani89@NH504670> # change update intake mutation to accept rolling flag
 @1.168.0 2024-07-10T13:35:28Z CCBC Service Account <ccbc@button.is> # release v1.168.0
+tables/cbc_application_pending_change_request_001_service_account 2024-07-09T22:28:27Z Rafael Solorzano <61289255+rafasdc@users.noreply.github.com> # grant service account access to cbc application pending change request table

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CONN-CCBC-portal",
-  "version": "1.168.0",
+  "version": "1.168.1",
   "main": "index.js",
   "repository": "https://github.com/bcgov/CONN-CCBC-portal.git",
   "author": "Romer, Meherzad CITZ:EX <Meherzad.Romer@gov.bc.ca>",


### PR DESCRIPTION
Fixes the error on the import of cbc data by the cron job by granting access to the cbc_application_pending_change_request table to the ccbc_service_account so the graphql query and mutation can succeed after initial import.

<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements [NDT-423]

<!--
Add detailed description of the changes if the PR title isn't enough
 -->

- [ ] Check to trigger automatic release process


[NDT-423]: https://connectivitydivision.atlassian.net/browse/NDT-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ