### PR TITLE
fix: errorneous cases of auto enable

### DIFF
--- a/.github/workflows/release-process.yaml
+++ b/.github/workflows/release-process.yaml
@@ -112,6 +112,7 @@ jobs:
           gh pr merge --auto --merge "$PR_URL"
         env:
           GITHUB_TOKEN: ${{ secrets.RENOVATE_GITHUB_TOKEN }}
+        continue-on-error: true
       - name: Uncheck the checkbox
         if: steps.checkbox.outputs.result == 'true' && steps.up_to_date.outputs.result == 'true' && steps.pr_approval.outputs.result == 'true' && !github.event.pull_request.draft
         uses: actions/github-script@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [1.195.3](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.195.2...v1.195.3) (2024-10-03)
+
 ## [1.195.2](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.195.1...v1.195.2) (2024-10-03)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.195.2](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.195.1...v1.195.2) (2024-10-03)
+
+### Bug Fixes
+
+- errorneous cases of auto enable ([46d17a5](https://github.com/bcgov/CONN-CCBC-portal/commit/46d17a544813428a0e9ac1d8737e66ff9d989a8d))
+
 ## [1.195.1](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.195.0...v1.195.1) (2024-10-01)
 
 # [1.195.0](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.194.2...v1.195.0) (2024-10-01)

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -693,3 +693,4 @@ computed_columns/cbc_history 2024-09-03T15:16:07Z Anthony Bushara <anthony@butto
 @1.195.0 2024-10-01T18:17:16Z CCBC Service Account <ccbc@button.is> # release v1.195.0
 @1.195.1 2024-10-01T19:32:15Z CCBC Service Account <ccbc@button.is> # release v1.195.1
 @1.195.2 2024-10-03T15:39:57Z CCBC Service Account <ccbc@button.is> # release v1.195.2
+@1.195.3 2024-10-03T15:51:06Z CCBC Service Account <ccbc@button.is> # release v1.195.3

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -692,3 +692,4 @@ computed_columns/cbc_history 2024-09-03T15:16:07Z Anthony Bushara <anthony@butto
 @1.194.2 2024-10-01T17:35:28Z CCBC Service Account <ccbc@button.is> # release v1.194.2
 @1.195.0 2024-10-01T18:17:16Z CCBC Service Account <ccbc@button.is> # release v1.195.0
 @1.195.1 2024-10-01T19:32:15Z CCBC Service Account <ccbc@button.is> # release v1.195.1
+@1.195.2 2024-10-03T15:39:57Z CCBC Service Account <ccbc@button.is> # release v1.195.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CONN-CCBC-portal",
-  "version": "1.195.2",
+  "version": "1.195.3",
   "main": "index.js",
   "repository": "https://github.com/bcgov/CONN-CCBC-portal.git",
   "author": "Romer, Meherzad CITZ:EX <Meherzad.Romer@gov.bc.ca>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CONN-CCBC-portal",
-  "version": "1.195.1",
+  "version": "1.195.2",
   "main": "index.js",
   "repository": "https://github.com/bcgov/CONN-CCBC-portal.git",
   "author": "Romer, Meherzad CITZ:EX <Meherzad.Romer@gov.bc.ca>",


### PR DESCRIPTION
Implements [[NDT-545](https://connectivitydivision.atlassian.net/browse/NDT-545)]

this is for some cases which could fail the auto merge step, which could result in running make release step again. This is a quick fix for eliminating that scenario

- [ ] Check to trigger automatic release process

- [ ] Check for automatic rebasing


[NDT-545]: https://connectivitydivision.atlassian.net/browse/NDT-545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ