### PR TITLE
fix: sow tab 7 total estimated project cost not importing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.202.2](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.202.1...v1.202.2) (2024-10-23)
+
+### Bug Fixes
+
+- sow tab 7 total estimated project cost not importing ([1eb0e5e](https://github.com/bcgov/CONN-CCBC-portal/commit/1eb0e5e6a50294a1fdc85d42b0072acd99a7650c))
+
 ## [1.202.1](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.202.0...v1.202.1) (2024-10-23)
 
 ### Bug Fixes

--- a/app/backend/lib/sow_import/tab_7.ts
+++ b/app/backend/lib/sow_import/tab_7.ts
@@ -265,7 +265,7 @@ const readBudget = async (sow_id, wb, sheet_name) => {
   // -- SUMMARY OF ESTIMATED PROJECT COSTS --
 
   // first pass - column B
-  for (let row = 1000; row < 1075; row++) {
+  for (let row = 1000; row < 1076; row++) {
     const suspect = budget[row]['B'];
     let value;
     if (suspect === undefined) continue;

--- a/app/tests/backend/lib/sow_tab_7.test.ts
+++ b/app/tests/backend/lib/sow_tab_7.test.ts
@@ -1787,7 +1787,7 @@ describe('sow tab 7 tests', () => {
               eligibleMobile: 0,
               totalEligibleCosts: 500000,
               totalIneligibleCosts: 250000,
-              totalProjectCost: '',
+              totalProjectCost: 750000,
             },
             totalCostsPerCostCategory: {
               directLabour: { cost: 80000, percentOfTotalEligibleCosts: 0.16 },
@@ -2015,7 +2015,7 @@ describe('sow tab 7 tests', () => {
               eligibleMobile: 0,
               totalEligibleCosts: 500000,
               totalIneligibleCosts: 250000,
-              totalProjectCost: '',
+              totalProjectCost: 750000,
             },
             totalCostsPerCostCategory: {
               directLabour: { cost: 80000, percentOfTotalEligibleCosts: 0.16 },

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -714,3 +714,4 @@ tables/application_form_template_9_data 2024-09-25T22:50:17Z Rafael Solorzano <6
 @1.201.1 2024-10-18T23:48:24Z CCBC Service Account <ccbc@button.is> # release v1.201.1
 @1.202.0 2024-10-21T21:32:01Z CCBC Service Account <ccbc@button.is> # release v1.202.0
 @1.202.1 2024-10-23T14:59:42Z CCBC Service Account <ccbc@button.is> # release v1.202.1
+@1.202.2 2024-10-23T20:54:15Z CCBC Service Account <ccbc@button.is> # release v1.202.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CONN-CCBC-portal",
-  "version": "1.202.1",
+  "version": "1.202.2",
   "main": "index.js",
   "repository": "https://github.com/bcgov/CONN-CCBC-portal.git",
   "author": "Romer, Meherzad CITZ:EX <Meherzad.Romer@gov.bc.ca>",


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/Team_Agreements.md#commit-message-guidelines
-->

Implements [NDT-583]

<!--
Add detailed description of the changes if the PR title isn't enough
 -->

- [ ] Check to trigger automatic release process

- [ ] Check for automatic rebasing


[NDT-583]: https://connectivitydivision.atlassian.net/browse/NDT-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ