### PR TITLE
fix: announcement not updating checkbox state on navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [1.264.3](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.264.2...v1.264.3) (2025-08-05)
+
 ## [1.264.2](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.264.1...v1.264.2) (2025-08-05)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.264.2](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.264.1...v1.264.2) (2025-08-05)
+
+### Bug Fixes
+
+- announcement not updating checkbox state on navigation ([3e2478f](https://github.com/bcgov/CONN-CCBC-portal/commit/3e2478f12c2808d3315dc588d1e2413ca09027ca))
+
 ## [1.264.1](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.264.0...v1.264.1) (2025-07-29)
 
 # [1.264.0](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.263.0...v1.264.0) (2025-07-29)

--- a/app/components/Analyst/Project/Announcements/AnnouncementsForm.tsx
+++ b/app/components/Analyst/Project/Announcements/AnnouncementsForm.tsx
@@ -283,6 +283,7 @@ const AnnouncementsForm: React.FC<Props> = ({ query, isExpanded }) => {
 
   return (
     <StyledProjectForm
+      key={rowId}
       before={
         <>
           <StyledCheckbox

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CONN-CCBC-portal",
-  "version": "1.264.1",
+  "version": "1.264.2",
   "main": "index.js",
   "repository": "https://github.com/bcgov/CONN-CCBC-portal.git",
   "author": "Romer, Meherzad CITZ:EX <Meherzad.Romer@gov.bc.ca>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CONN-CCBC-portal",
-  "version": "1.264.2",
+  "version": "1.264.3",
   "main": "index.js",
   "repository": "https://github.com/bcgov/CONN-CCBC-portal.git",
   "author": "Romer, Meherzad CITZ:EX <Meherzad.Romer@gov.bc.ca>",


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/CONTRIBUTING.md#commit-message-guidelines
-->

Implements [[NDT-1018](https://connectivitydivision.atlassian.net/browse/NDT-1018)]

<!--
Add detailed description of the changes if the PR title isn't enough
 -->

- [ ] Check to trigger automatic release process

- [x] Check for automatic rebasing


[NDT-1018]: https://connectivitydivision.atlassian.net/browse/NDT-1018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ