### PR TITLE
fix: history for announcement to skip deleted prev records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.298.2](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.298.1...v1.298.2) (2026-05-12)
+
+### Bug Fixes
+
+- history for announcement to skip deleted prev records ([618a61e](https://github.com/bcgov/CONN-CCBC-portal/commit/618a61e7f1e41ec90f1e59342b5edc49421ffbee))
+
 ## [1.298.1](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.298.0...v1.298.1) (2026-05-06)
 
 # [1.298.0](https://github.com/bcgov/CONN-CCBC-portal/compare/v1.296.1...v1.298.0) (2026-04-29)

--- a/app/components/Analyst/History/HistoryContent.tsx
+++ b/app/components/Analyst/History/HistoryContent.tsx
@@ -201,7 +201,11 @@ const HistoryContent = ({
   }
 
   if (tableName === 'application_announcement') {
-    const operation = historyItem.record?.history_operation;
+    const rawOperation = historyItem.record?.history_operation;
+    const operation =
+      rawOperation === 'updated' && !prevHistoryItem?.record
+        ? 'added'
+        : rawOperation;
     const announcementId = historyItem.record?.announcement_id;
     const previousAnnouncementId = prevHistoryItem?.record?.announcement_id;
     const announcement = announcements?.get?.(String(announcementId));
@@ -836,7 +840,9 @@ const HistoryContent = ({
     return (
       <>
         <StyledContent data-testid="history-content-sow-data">
-          <span>{displayName} {verb} the </span>
+          <span>
+            {displayName} {verb} the{' '}
+          </span>
           <b>Sow</b>
           <span> file on {createdAtFormatted}</span>
         </StyledContent>

--- a/app/utils/historyProcessing.ts
+++ b/app/utils/historyProcessing.ts
@@ -164,16 +164,15 @@ export const processHistoryItems = (
               historyItem.record?.is_primary !== null &&
               historyItem.record?.is_primary !== undefined;
             if (isUpdated) {
-              if (hasPrimaryFlag) {
+              const nearestAnnouncement = a.find((item) => {
                 return (
-                  previousItem.tableName === historyItem.tableName &&
-                  previousItem.record?.history_operation !== 'deleted' &&
-                  previousItem.record?.is_primary ===
-                    historyItem.record?.is_primary
+                  item.tableName === historyItem.tableName &&
+                  (!hasPrimaryFlag ||
+                    item.record?.is_primary === historyItem.record?.is_primary)
                 );
-              }
+              });
               return (
-                previousItem.tableName === historyItem.tableName &&
+                previousItem === nearestAnnouncement &&
                 previousItem.record?.history_operation !== 'deleted'
               );
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CONN-CCBC-portal",
-  "version": "1.298.1",
+  "version": "1.298.2",
   "main": "index.js",
   "repository": "https://github.com/bcgov/CONN-CCBC-portal.git",
   "author": "Romer, Meherzad CITZ:EX <Meherzad.Romer@gov.bc.ca>",


### PR DESCRIPTION
<!--
PR title should follow the `<type>[(optional scope)]: <description>` format.
See docs/CONTRIBUTING.md#commit-message-guidelines
-->

Implements [[NDT-1197](https://connectivitydivision.atlassian.net/browse/NDT-1197)]

<!--
Add detailed description of the changes if the PR title isn't enough
 -->

- [ ] Check to trigger automatic release process

- [x] Check for automatic rebasing


[NDT-1197]: https://connectivitydivision.atlassian.net/browse/NDT-1197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ